### PR TITLE
Add browser tests for graph coverage features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,3 +30,24 @@ jobs:
 
       - name: Run tests
         run: npm run test:run
+
+  browser-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser tests
+        run: npm run test:browser

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 site/
 .DS_Store
 coverage/
+playwright-report/
+test-results/

--- a/e2e/graph-coverage.spec.js
+++ b/e2e/graph-coverage.spec.js
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Graph Coverage Browser Tests', () => {
+  test('supports advanced criteria and generated test paths', async ({ page }) => {
+    await page.goto('/index.html');
+
+    await page.getByTestId('criterion-edge-pair').click();
+    await expect(page.getByTestId('requirement-list')).toContainText('S -> A -> B');
+
+    await page.getByTestId('criterion-complete-path').click();
+    await expect(page.getByTestId('requirement-list')).toContainText('S -> A -> B -> D -> E -> T');
+
+    await expect(page.getByTestId('graph-test-path-card')).toBeVisible();
+    await expect(page.getByTestId('test-path-list')).toContainText('T1:');
+    await expect(page.getByTestId('test-path-meta')).toContainText('Covered Requirements:');
+  });
+
+  test('recomputes requirements and test paths after graph editing', async ({ page }) => {
+    await page.goto('/index.html');
+
+    await page.getByTestId('graph-nodes-input').fill([
+      'S,Start,80,170',
+      'A,A,220,170',
+      'T,End,360,170',
+    ].join('\n'));
+
+    await page.getByTestId('graph-edges-input').fill([
+      'S-A,S,A',
+      'A-T,A,T',
+    ].join('\n'));
+
+    await page.getByTestId('graph-start-input').fill('S');
+    await page.getByTestId('graph-end-input').fill('T');
+
+    await expect(page.getByTestId('graph-editor-status')).toContainText('Graph 已同步更新');
+    await expect(page.getByTestId('requirement-list').locator('li')).toHaveCount(3);
+    await expect(page.getByTestId('test-path-list')).toContainText('S -> A -> T');
+    await expect(page.getByTestId('test-path-meta')).toContainText('Covered Requirements: 3 / 3');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -10,6 +10,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="./src/standalone.js" defer></script>
+    <script src="./src/bootstrap.js" defer></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "stvisual",
       "version": "1.0.0",
       "devDependencies": {
+        "@playwright/test": "^1.53.1",
         "@testing-library/jest-dom": "^6.4.0",
         "jsdom": "^24.1.0",
         "vitest": "^1.6.0"
@@ -568,6 +569,22 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
@@ -2087,6 +2104,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -2459,7 +2523,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "pages:prepare": "node scripts/prepare-pages.mjs",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:browser": "playwright test",
+    "test:browser:headed": "playwright test --headed"
   },
   "devDependencies": {
+    "@playwright/test": "^1.53.1",
     "@testing-library/jest-dom": "^6.4.0",
     "jsdom": "^24.1.0",
     "vitest": "^1.6.0"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  retries: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm run serve',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: true,
+    timeout: 120 * 1000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/scripts/prepare-pages.mjs
+++ b/scripts/prepare-pages.mjs
@@ -12,6 +12,7 @@ await mkdir(path.join(outputDir, 'src'), { recursive: true });
 
 await cp(path.join(projectRoot, 'index.html'), path.join(outputDir, 'index.html'));
 await cp(path.join(projectRoot, 'src', 'main.js'), path.join(outputDir, 'src', 'main.js'));
+await cp(path.join(projectRoot, 'src', 'bootstrap.js'), path.join(outputDir, 'src', 'bootstrap.js'));
 await cp(path.join(projectRoot, 'src', 'standalone.js'), path.join(outputDir, 'src', 'standalone.js'));
 await cp(path.join(projectRoot, 'src', 'app.js'), path.join(outputDir, 'src', 'app.js'));
 await cp(path.join(projectRoot, 'src', 'styles.css'), path.join(outputDir, 'src', 'styles.css'));

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,0 +1,10 @@
+const fileProtocol = window.location.protocol === 'file:';
+
+if (fileProtocol) {
+  const script = document.createElement('script');
+  script.src = './src/standalone.js';
+  script.defer = true;
+  document.head.appendChild(script);
+} else {
+  import('./main.js');
+}

--- a/src/components/GraphCoverageExplorer.css
+++ b/src/components/GraphCoverageExplorer.css
@@ -4,6 +4,92 @@
   gap: 24px;
 }
 
+.graph-editor-card {
+  background: #fff;
+  border-radius: 24px;
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.08);
+  padding: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.graph-editor-header {
+  margin-bottom: 14px;
+}
+
+.graph-editor-header h4 {
+  font-size: 1.1rem;
+  margin-bottom: 4px;
+}
+
+.graph-editor-header p {
+  color: #64748b;
+}
+
+.graph-editor-meta {
+  display: flex;
+  gap: 12px;
+  align-items: end;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.graph-editor-meta label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.graph-editor-meta input {
+  width: 120px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+}
+
+.graph-editor-reset {
+  height: 38px;
+  border: none;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #fff;
+  padding: 0 14px;
+  cursor: pointer;
+}
+
+.graph-editor-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.graph-editor-grid label {
+  display: grid;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.graph-editor-grid textarea {
+  min-height: 132px;
+  resize: vertical;
+  border-radius: 14px;
+  border: 1px solid #cbd5e1;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+  font-size: 0.78rem;
+}
+
+.graph-editor-status {
+  margin-top: 10px;
+  font-size: 0.8rem;
+  color: #15803d;
+}
+
+.graph-editor-status--error {
+  color: #b91c1c;
+}
+
 .graph-coverage-header {
   display: flex;
   justify-content: space-between;
@@ -198,6 +284,40 @@
   color: #cbd5e1;
 }
 
+.graph-test-path-card {
+  margin-top: 18px;
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  padding: 18px;
+  background: #f8fafc;
+}
+
+.graph-test-path-card h4 {
+  margin-bottom: 8px;
+}
+
+.test-path-list {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.test-path-list li {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 8px 10px;
+  color: #0f172a;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+  font-size: 0.78rem;
+}
+
+.test-path-meta {
+  font-size: 0.82rem;
+  color: #334155;
+}
+
 .graph-sidebar {
   display: flex;
   flex-direction: column;
@@ -291,6 +411,10 @@
 }
 
 @media (max-width: 720px) {
+  .graph-editor-grid {
+    grid-template-columns: 1fr;
+  }
+
   .graph-coverage-header {
     padding: 22px;
   }

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -1,5 +1,130 @@
 import { graphCoverageCriteria, graphCoverageGraph } from '../data/testingData.js';
-import { getCoverageRequirements } from '../utils/graphCoverage.js';
+import { buildTestPathSetForRequirements, getCoverageRequirements } from '../utils/graphCoverage.js';
+
+function cloneGraph(graph) {
+  return {
+    ...graph,
+    nodes: graph.nodes.map((node) => ({ ...node })),
+    edges: graph.edges.map((edge) => ({
+      ...edge,
+      control: edge.control ? { ...edge.control } : undefined,
+    })),
+  };
+}
+
+function serializeNodes(nodes) {
+  return nodes.map((node) => `${node.id},${node.label},${node.x},${node.y}`).join('\n');
+}
+
+function serializeEdges(edges) {
+  return edges
+    .map((edge) => {
+      if (edge.control?.x !== undefined && edge.control?.y !== undefined) {
+        return `${edge.id},${edge.from},${edge.to},${edge.control.x},${edge.control.y}`;
+      }
+
+      return `${edge.id},${edge.from},${edge.to}`;
+    })
+    .join('\n');
+}
+
+function parseNodesText(nodesText) {
+  const rows = nodesText.split('\n').map((item) => item.trim()).filter(Boolean);
+
+  if (!rows.length) {
+    throw new Error('節點不能為空。');
+  }
+
+  return rows.map((row, index) => {
+    const [id, label, x, y] = row.split(',').map((item) => item.trim());
+
+    if (!id || !label || x === undefined || y === undefined) {
+      throw new Error(`節點格式錯誤（第 ${index + 1} 行），請使用 id,label,x,y。`);
+    }
+
+    const parsedX = Number(x);
+    const parsedY = Number(y);
+
+    if (!Number.isFinite(parsedX) || !Number.isFinite(parsedY)) {
+      throw new Error(`節點座標格式錯誤（第 ${index + 1} 行），x,y 必須是數字。`);
+    }
+
+    return { id, label, x: parsedX, y: parsedY, kind: 'node' };
+  });
+}
+
+function parseEdgesText(edgesText, nodeIds) {
+  const rows = edgesText.split('\n').map((item) => item.trim()).filter(Boolean);
+
+  if (!rows.length) {
+    throw new Error('邊不能為空。');
+  }
+
+  return rows.map((row, index) => {
+    const cols = row.split(',').map((item) => item.trim());
+
+    let id;
+    let from;
+    let to;
+    let controlX;
+    let controlY;
+
+    if (cols.length === 2) {
+      [from, to] = cols;
+      id = `${from}-${to}`;
+    } else if (cols.length === 3) {
+      [id, from, to] = cols;
+    } else if (cols.length === 5) {
+      [id, from, to, controlX, controlY] = cols;
+    } else {
+      throw new Error(`邊格式錯誤（第 ${index + 1} 行），請使用 from,to 或 id,from,to 或 id,from,to,cx,cy。`);
+    }
+
+    if (!from || !to) {
+      throw new Error(`邊格式錯誤（第 ${index + 1} 行），缺少 from/to。`);
+    }
+
+    if (!nodeIds.has(from) || !nodeIds.has(to)) {
+      throw new Error(`邊節點不存在（第 ${index + 1} 行）：${from} -> ${to}`);
+    }
+
+    if (controlX !== undefined && controlY !== undefined) {
+      const cx = Number(controlX);
+      const cy = Number(controlY);
+
+      if (!Number.isFinite(cx) || !Number.isFinite(cy)) {
+        throw new Error(`邊控制點格式錯誤（第 ${index + 1} 行），cx,cy 必須是數字。`);
+      }
+
+      return { id, from, to, control: { x: cx, y: cy } };
+    }
+
+    return { id, from, to };
+  });
+}
+
+function parseGraphDraft({ nodesText, edgesText, startNodeId, endNodeId }) {
+  const nodes = parseNodesText(nodesText);
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const edges = parseEdgesText(edgesText, nodeIds);
+
+  if (!nodeIds.has(startNodeId)) {
+    throw new Error('Start node 不存在於節點清單。');
+  }
+
+  if (!nodeIds.has(endNodeId)) {
+    throw new Error('End node 不存在於節點清單。');
+  }
+
+  return {
+    id: 'custom-graph',
+    title: '自訂控制流程圖',
+    nodes,
+    edges,
+    startNodeId,
+    endNodeId,
+  };
+}
 
 function createGraphCanvas(graph, requirement) {
   const highlightedNodes = new Set(requirement?.nodes || []);
@@ -57,42 +182,119 @@ function createGraphCanvas(graph, requirement) {
 
 export function createGraphCoverageExplorer() {
   const root = document.createElement('div');
+  const defaultGraph = cloneGraph(graphCoverageGraph);
+
+  let graph = defaultGraph;
   let criterionId = 'node';
   let selectedRequirementId = null;
+  let parseError = '';
+  let autoApplyTimer = null;
+  let draft = {
+    nodesText: serializeNodes(defaultGraph.nodes),
+    edgesText: serializeEdges(defaultGraph.edges),
+    startNodeId: defaultGraph.startNodeId,
+    endNodeId: defaultGraph.endNodeId,
+  };
+
+  function scheduleAutoApply() {
+    if (autoApplyTimer) {
+      clearTimeout(autoApplyTimer);
+    }
+
+    autoApplyTimer = window.setTimeout(() => {
+      try {
+        graph = parseGraphDraft(draft);
+        parseError = '';
+        selectedRequirementId = null;
+        render();
+      } catch (error) {
+        parseError = error.message;
+        render();
+      }
+    }, 300);
+  }
+
+  function resetGraph() {
+    graph = cloneGraph(defaultGraph);
+    draft = {
+      nodesText: serializeNodes(graph.nodes),
+      edgesText: serializeEdges(graph.edges),
+      startNodeId: graph.startNodeId,
+      endNodeId: graph.endNodeId,
+    };
+    parseError = '';
+    selectedRequirementId = null;
+    render();
+  }
 
   function getState() {
-    const requirements = getCoverageRequirements(graphCoverageGraph, criterionId);
+    const requirements = getCoverageRequirements(graph, criterionId);
     if (!requirements.some((item) => item.id === selectedRequirementId)) {
       selectedRequirementId = requirements[0]?.id || null;
     }
+
     const selectedRequirement = requirements.find((item) => item.id === selectedRequirementId) || requirements[0] || null;
     const selectedCriterion = graphCoverageCriteria.find((item) => item.id === criterionId);
+    const pathPlan = buildTestPathSetForRequirements(graph, requirements);
 
     return {
       requirements,
       selectedRequirement,
       selectedCriterion,
+      pathPlan,
     };
   }
 
   function render() {
-    const { requirements, selectedRequirement, selectedCriterion } = getState();
+    const { requirements, selectedRequirement, selectedCriterion, pathPlan } = getState();
 
     root.className = 'graph-coverage';
     root.dataset.testid = 'graph-coverage-explorer';
     root.innerHTML = `
+      <div class="graph-editor-card" data-testid="graph-editor-card">
+        <div class="graph-editor-header">
+          <h4>Graph Editor</h4>
+          <p>編輯後會即時計算 coverage requirements 與 test paths。</p>
+        </div>
+        <div class="graph-editor-meta">
+          <label>
+            Start
+            <input type="text" value="${draft.startNodeId}" data-testid="graph-start-input" data-draft-field="startNodeId" />
+          </label>
+          <label>
+            End
+            <input type="text" value="${draft.endNodeId}" data-testid="graph-end-input" data-draft-field="endNodeId" />
+          </label>
+          <button type="button" class="graph-editor-reset" data-testid="graph-reset-btn">還原預設圖</button>
+        </div>
+        <div class="graph-editor-grid">
+          <label>
+            Nodes (id,label,x,y)
+            <textarea data-testid="graph-nodes-input" data-draft-field="nodesText">${draft.nodesText}</textarea>
+          </label>
+          <label>
+            Edges (from,to | id,from,to | id,from,to,cx,cy)
+            <textarea data-testid="graph-edges-input" data-draft-field="edgesText">${draft.edgesText}</textarea>
+          </label>
+        </div>
+        <p class="graph-editor-status${parseError ? ' graph-editor-status--error' : ''}" data-testid="graph-editor-status">
+          ${parseError || 'Graph 已同步更新'}
+        </p>
+      </div>
+
       <div class="graph-coverage-header">
         <div>
           <p class="graph-coverage-kicker">White Box Testing</p>
-          <h3>${graphCoverageGraph.title}</h3>
-          <p class="graph-coverage-desc">用同一張控制流程圖，切換不同 coverage criteria，直接看到必須涵蓋的節點、邊與 prime path。</p>
+          <h3>${graph.title}</h3>
+          <p class="graph-coverage-desc">用同一張控制流程圖，切換不同 coverage criteria，直接看到必須涵蓋的節點、邊與 path。</p>
         </div>
         <div class="graph-coverage-stats">
-          <div class="graph-stat-card"><span class="graph-stat-label">Nodes</span><strong>${graphCoverageGraph.nodes.length}</strong></div>
-          <div class="graph-stat-card"><span class="graph-stat-label">Edges</span><strong>${graphCoverageGraph.edges.length}</strong></div>
+          <div class="graph-stat-card"><span class="graph-stat-label">Nodes</span><strong>${graph.nodes.length}</strong></div>
+          <div class="graph-stat-card"><span class="graph-stat-label">Edges</span><strong>${graph.edges.length}</strong></div>
           <div class="graph-stat-card"><span class="graph-stat-label">Requirements</span><strong>${requirements.length}</strong></div>
         </div>
       </div>
+
       <div class="graph-criterion-switcher" role="tablist" aria-label="coverage criteria 切換">
         ${graphCoverageCriteria.map((criterion) => `
           <button
@@ -108,15 +310,33 @@ export function createGraphCoverageExplorer() {
           </button>
         `).join('')}
       </div>
+
       <div class="graph-coverage-layout">
         <div class="graph-main-panel">
-          ${createGraphCanvas(graphCoverageGraph, selectedRequirement)}
+          ${createGraphCanvas(graph, selectedRequirement)}
           <div class="graph-selected-summary" data-testid="selected-requirement-summary">
             <span class="summary-label">目前 requirement</span>
             <strong>${selectedRequirement?.label || '無'}</strong>
             <p>${selectedCriterion?.description || ''}</p>
           </div>
+
+          <div class="graph-test-path-card" data-testid="graph-test-path-card">
+            <h4>Generated Test Path Set</h4>
+            <p class="sidebar-text">將 requirement 自動組合成可執行測試路徑（Start 到 End）。</p>
+            <ul class="test-path-list" data-testid="test-path-list">
+              ${pathPlan.selectedPaths.map((path, index) => `
+                <li data-testid="test-path-${index + 1}">T${index + 1}: ${path.join(' -> ')}</li>
+              `).join('') || '<li>無可用路徑</li>'}
+            </ul>
+            <p class="test-path-meta" data-testid="test-path-meta">
+              Covered Requirements: ${pathPlan.requirementPaths.filter((item) => item.covered).length} / ${pathPlan.requirementPaths.length}
+            </p>
+            ${pathPlan.uncoveredRequirements.length
+              ? `<p class="graph-editor-status graph-editor-status--error">尚未覆蓋：${pathPlan.uncoveredRequirements.map((item) => item.displayText).join('、')}</p>`
+              : '<p class="graph-editor-status">全部 requirement 已對應到 test paths</p>'}
+          </div>
         </div>
+
         <aside class="graph-sidebar">
           <div class="graph-sidebar-card">
             <h4>Test Requirements</h4>
@@ -137,6 +357,7 @@ export function createGraphCoverageExplorer() {
               `).join('')}
             </ul>
           </div>
+
           <div class="graph-sidebar-card">
             <h4>Requirement Detail</h4>
             <div class="detail-grid">
@@ -157,6 +378,20 @@ export function createGraphCoverageExplorer() {
         </aside>
       </div>
     `;
+
+    root.querySelector('[data-testid="graph-reset-btn"]').addEventListener('click', () => {
+      resetGraph();
+    });
+
+    root.querySelectorAll('[data-draft-field]').forEach((input) => {
+      input.addEventListener('input', () => {
+        draft = {
+          ...draft,
+          [input.dataset.draftField]: input.value,
+        };
+        scheduleAutoApply();
+      });
+    });
 
     root.querySelectorAll('[data-criterion]').forEach((button) => {
       button.addEventListener('click', () => {

--- a/src/data/testingData.js
+++ b/src/data/testingData.js
@@ -79,6 +79,18 @@ export const graphCoverageCriteria = [
     labelZh: 'Prime Path 覆蓋',
     description: '所有 prime path 都必須被測試需求涵蓋，包含迴圈。',
   },
+  {
+    id: 'edge-pair',
+    label: 'Edge-Pair Coverage',
+    labelZh: '邊對覆蓋',
+    description: '每一組相鄰的兩條邊都要至少被一條測試路徑覆蓋。',
+  },
+  {
+    id: 'complete-path',
+    label: 'Complete Path Coverage',
+    labelZh: '完整路徑覆蓋',
+    description: '以有限深度列舉 start 到 end 的完整可行路徑集合。',
+  },
 ];
 
 export const graphCoverageGraph = {

--- a/src/tests/GraphCoverageExplorer.test.jsx
+++ b/src/tests/GraphCoverageExplorer.test.jsx
@@ -28,6 +28,18 @@ describe('GraphCoverageExplorer', () => {
     expect(document.querySelector('[data-testid="requirement-list"]')).toHaveTextContent('B -> D -> E -> B');
   });
 
+  it('切換到 edge-pair coverage 後顯示邊對 requirement', () => {
+    renderGraphCoverageExplorer();
+    document.querySelector('[data-testid="criterion-edge-pair"]').click();
+    expect(document.querySelector('[data-testid="requirement-list"]')).toHaveTextContent('S -> A -> B');
+  });
+
+  it('切換到 complete path coverage 後顯示完整路徑 requirement', () => {
+    renderGraphCoverageExplorer();
+    document.querySelector('[data-testid="criterion-complete-path"]').click();
+    expect(document.querySelector('[data-testid="requirement-list"]')).toHaveTextContent('S -> A -> B -> D -> E -> T');
+  });
+
   it('點擊 requirement 會更新 detail 區塊', () => {
     renderGraphCoverageExplorer();
     document.querySelector('[data-testid="criterion-edge"]').click();
@@ -41,5 +53,37 @@ describe('GraphCoverageExplorer', () => {
     ['S', 'A', 'B', 'C', 'D', 'E', 'F', 'T'].forEach((nodeId) => {
       expect(document.querySelector(`[data-testid="graph-node-${nodeId}"]`)).toBeInTheDocument();
     });
+  });
+
+  it('會顯示根據 requirements 產生的 test paths', () => {
+    renderGraphCoverageExplorer();
+    expect(document.querySelector('[data-testid="graph-test-path-card"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="test-path-list"]')).toHaveTextContent('S -> A');
+  });
+
+  it('編輯 graph 會即時計算 requirement', async () => {
+    renderGraphCoverageExplorer();
+
+    const nodesInput = document.querySelector('[data-testid="graph-nodes-input"]');
+    const edgesInput = document.querySelector('[data-testid="graph-edges-input"]');
+    const startInput = document.querySelector('[data-testid="graph-start-input"]');
+    const endInput = document.querySelector('[data-testid="graph-end-input"]');
+
+    nodesInput.value = 'S,Start,80,170\nA,A,220,170\nT,End,360,170';
+    nodesInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    edgesInput.value = 'S-A,S,A\nA-T,A,T';
+    edgesInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    startInput.value = 'S';
+    startInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    endInput.value = 'T';
+    endInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(document.querySelector('[data-testid="graph-editor-status"]')).toHaveTextContent('Graph 已同步更新');
+    expect(document.querySelector('[data-testid="requirement-list"]').children).toHaveLength(3);
   });
 });

--- a/src/tests/graphCoverage.test.js
+++ b/src/tests/graphCoverage.test.js
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { graphCoverageGraph } from '../data/testingData';
 import {
+  buildTestPathSetForRequirements,
   enumerateSimplePaths,
   getCoverageRequirements,
+  getCompletePathRequirements,
+  getEdgePairRequirements,
   getEdgeRequirements,
   getNodeRequirements,
   getPrimePathRequirements,
+  generateTestPaths,
   getPrimePaths,
 } from '../utils/graphCoverage';
 
@@ -48,5 +52,34 @@ describe('graphCoverage utilities', () => {
     expect(getCoverageRequirements(graphCoverageGraph, 'node')).toHaveLength(8);
     expect(getCoverageRequirements(graphCoverageGraph, 'edge')).toHaveLength(10);
     expect(getCoverageRequirements(graphCoverageGraph, 'prime-path').length).toBeGreaterThan(0);
+    expect(getCoverageRequirements(graphCoverageGraph, 'edge-pair').length).toBeGreaterThan(0);
+    expect(getCoverageRequirements(graphCoverageGraph, 'complete-path').length).toBeGreaterThan(0);
+  });
+
+  it('edge-pair requirements 包含連續兩邊', () => {
+    const requirements = getEdgePairRequirements(graphCoverageGraph);
+    expect(requirements.map((item) => item.displayText)).toContain('S -> A -> B');
+    expect(requirements.map((item) => item.displayText)).toContain('D -> E -> B');
+  });
+
+  it('complete path requirements 來自 start 到 end 的完整路徑', () => {
+    const requirements = getCompletePathRequirements(graphCoverageGraph);
+    expect(requirements.map((item) => item.displayText)).toContain('S -> A -> B -> D -> E -> T');
+    expect(requirements.map((item) => item.displayText)).toContain('S -> A -> C -> D -> F -> T');
+  });
+
+  it('generateTestPaths 會產生 start 到 end 的候選路徑', () => {
+    const paths = generateTestPaths(graphCoverageGraph).map((path) => path.join('->'));
+    expect(paths).toContain('S->A->B->D->F->T');
+    expect(paths).toContain('S->A->C->D->F->T');
+  });
+
+  it('可將 requirements 組合成測試路徑集合', () => {
+    const requirements = getCoverageRequirements(graphCoverageGraph, 'edge-pair');
+    const plan = buildTestPathSetForRequirements(graphCoverageGraph, requirements);
+
+    expect(plan.selectedPaths.length).toBeGreaterThan(0);
+    expect(plan.requirementPaths.length).toBe(requirements.length);
+    expect(plan.uncoveredRequirements).toHaveLength(0);
   });
 });

--- a/src/tests/testingData.test.js
+++ b/src/tests/testingData.test.js
@@ -154,9 +154,9 @@ describe('testingTypes', () => {
 });
 
 describe('graphCoverage data', () => {
-  it('包含三種 coverage criteria', () => {
-    expect(graphCoverageCriteria).toHaveLength(3);
-    expect(graphCoverageCriteria.map((item) => item.id)).toEqual(['node', 'edge', 'prime-path']);
+  it('包含五種 coverage criteria', () => {
+    expect(graphCoverageCriteria).toHaveLength(5);
+    expect(graphCoverageCriteria.map((item) => item.id)).toEqual(['node', 'edge', 'prime-path', 'edge-pair', 'complete-path']);
   });
 
   it('graph 包含 8 個節點與 10 條邊', () => {

--- a/src/utils/graphCoverage.js
+++ b/src/utils/graphCoverage.js
@@ -12,6 +12,17 @@ function buildAdjacency(graph) {
   return adjacency;
 }
 
+function normalizeGraph(graph) {
+  const nodes = Array.isArray(graph?.nodes) ? graph.nodes : [];
+  const edges = Array.isArray(graph?.edges) ? graph.edges : [];
+
+  return {
+    ...graph,
+    nodes,
+    edges,
+  };
+}
+
 function buildReverseAdjacency(graph) {
   const reverseAdjacency = new Map();
 
@@ -56,8 +67,39 @@ function edgeIdsFromPath(graph, path) {
   return edgeIds;
 }
 
+function containsNodePath(path, targetNodes) {
+  if (!targetNodes.length || targetNodes.length > path.length) {
+    return false;
+  }
+
+  for (let index = 0; index <= path.length - targetNodes.length; index += 1) {
+    const matched = targetNodes.every((nodeId, offset) => path[index + offset] === nodeId);
+    if (matched) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function containsEdgePath(pathEdges, targetEdges) {
+  if (!targetEdges.length || targetEdges.length > pathEdges.length) {
+    return false;
+  }
+
+  for (let index = 0; index <= pathEdges.length - targetEdges.length; index += 1) {
+    const matched = targetEdges.every((edgeId, offset) => pathEdges[index + offset] === edgeId);
+    if (matched) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function enumerateSimplePaths(graph) {
-  const adjacency = buildAdjacency(graph);
+  const normalizedGraph = normalizeGraph(graph);
+  const adjacency = buildAdjacency(normalizedGraph);
   const uniquePaths = new Map();
 
   function addPath(path) {
@@ -94,7 +136,7 @@ export function enumerateSimplePaths(graph) {
     });
   }
 
-  graph.nodes.forEach((node) => {
+  normalizedGraph.nodes.forEach((node) => {
     dfs(node.id, [node.id], new Set([node.id]));
   });
 
@@ -130,10 +172,11 @@ function canExtendBackward(path, reverseAdjacency) {
 }
 
 export function getPrimePaths(graph) {
-  const adjacency = buildAdjacency(graph);
-  const reverseAdjacency = buildReverseAdjacency(graph);
+  const normalizedGraph = normalizeGraph(graph);
+  const adjacency = buildAdjacency(normalizedGraph);
+  const reverseAdjacency = buildReverseAdjacency(normalizedGraph);
 
-  return enumerateSimplePaths(graph).filter((path) => {
+  return enumerateSimplePaths(normalizedGraph).filter((path) => {
     if (isCycle(path)) {
       return true;
     }
@@ -143,7 +186,9 @@ export function getPrimePaths(graph) {
 }
 
 export function getNodeRequirements(graph) {
-  return graph.nodes.map((node) => ({
+  const normalizedGraph = normalizeGraph(graph);
+
+  return normalizedGraph.nodes.map((node) => ({
     id: `node-${node.id}`,
     type: 'node',
     label: `Node ${node.label}`,
@@ -154,7 +199,9 @@ export function getNodeRequirements(graph) {
 }
 
 export function getEdgeRequirements(graph) {
-  return graph.edges.map((edge) => ({
+  const normalizedGraph = normalizeGraph(graph);
+
+  return normalizedGraph.edges.map((edge) => ({
     id: `edge-${edge.id}`,
     type: 'edge',
     label: `Edge ${edge.from} -> ${edge.to}`,
@@ -165,15 +212,156 @@ export function getEdgeRequirements(graph) {
 }
 
 export function getPrimePathRequirements(graph) {
-  return getPrimePaths(graph).map((path, index) => ({
+  const normalizedGraph = normalizeGraph(graph);
+
+  return getPrimePaths(normalizedGraph).map((path, index) => ({
     id: `prime-path-${index + 1}`,
     type: 'prime-path',
     label: `Path ${path.join(' -> ')}`,
     displayText: path.join(' -> '),
     nodes: [...new Set(path)],
-    edges: edgeIdsFromPath(graph, path),
+    edges: edgeIdsFromPath(normalizedGraph, path),
     path,
   }));
+}
+
+export function getEdgePairRequirements(graph) {
+  const normalizedGraph = normalizeGraph(graph);
+  const adjacency = buildAdjacency(normalizedGraph);
+  const pairMap = new Map();
+
+  normalizedGraph.edges.forEach((firstEdge) => {
+    const nextEdges = adjacency.get(firstEdge.to) || [];
+
+    nextEdges.forEach((secondEdge) => {
+      const id = `edge-pair-${firstEdge.id}__${secondEdge.id}`;
+      if (!pairMap.has(id)) {
+        pairMap.set(id, {
+          id,
+          type: 'edge-pair',
+          label: `Edge Pair ${firstEdge.from} -> ${firstEdge.to} -> ${secondEdge.to}`,
+          displayText: `${firstEdge.from} -> ${firstEdge.to} -> ${secondEdge.to}`,
+          nodes: [firstEdge.from, firstEdge.to, secondEdge.to],
+          edges: [firstEdge.id, secondEdge.id],
+        });
+      }
+    });
+  });
+
+  return Array.from(pairMap.values());
+}
+
+export function getCompletePathRequirements(graph) {
+  const normalizedGraph = normalizeGraph(graph);
+  const testPaths = generateTestPaths(normalizedGraph, { maxDepthMultiplier: 2 });
+
+  return testPaths.map((path, index) => ({
+    id: `complete-path-${index + 1}`,
+    type: 'complete-path',
+    label: `Complete Path ${path.join(' -> ')}`,
+    displayText: path.join(' -> '),
+    nodes: path,
+    edges: edgeIdsFromPath(normalizedGraph, path),
+    path,
+  }));
+}
+
+export function generateTestPaths(graph, options = {}) {
+  const normalizedGraph = normalizeGraph(graph);
+  const adjacency = buildAdjacency(normalizedGraph);
+  const nodeVisitLimit = options.nodeVisitLimit ?? 2;
+  const maxDepthMultiplier = options.maxDepthMultiplier ?? 2;
+  const maxDepth = Math.max(2, normalizedGraph.nodes.length * maxDepthMultiplier);
+  const uniquePaths = new Map();
+
+  if (!normalizedGraph.startNodeId || !normalizedGraph.endNodeId) {
+    return [];
+  }
+
+  function dfs(currentNodeId, path, visitCount) {
+    if (path.length > maxDepth) {
+      return;
+    }
+
+    if (currentNodeId === normalizedGraph.endNodeId) {
+      const key = path.join('->');
+      if (!uniquePaths.has(key)) {
+        uniquePaths.set(key, [...path]);
+      }
+      return;
+    }
+
+    const outgoingEdges = adjacency.get(currentNodeId) || [];
+    outgoingEdges.forEach((edge) => {
+      const nextNodeId = edge.to;
+      const visited = visitCount.get(nextNodeId) || 0;
+      if (visited >= nodeVisitLimit) {
+        return;
+      }
+
+      visitCount.set(nextNodeId, visited + 1);
+      path.push(nextNodeId);
+      dfs(nextNodeId, path, visitCount);
+      path.pop();
+      visitCount.set(nextNodeId, visited);
+    });
+  }
+
+  const visitCount = new Map([[normalizedGraph.startNodeId, 1]]);
+  dfs(normalizedGraph.startNodeId, [normalizedGraph.startNodeId], visitCount);
+
+  return Array.from(uniquePaths.values());
+}
+
+export function buildTestPathSetForRequirements(graph, requirements, options = {}) {
+  const normalizedGraph = normalizeGraph(graph);
+  const candidatePaths = generateTestPaths(normalizedGraph, options);
+
+  const pathRecords = candidatePaths.map((path) => ({
+    path,
+    edgeIds: edgeIdsFromPath(normalizedGraph, path),
+  }));
+
+  const requirementPaths = requirements.map((requirement) => {
+    const matchedRecord = pathRecords.find((record) => {
+      if (requirement.type === 'node') {
+        return record.path.includes(requirement.nodes[0]);
+      }
+
+      if (requirement.type === 'edge') {
+        return record.edgeIds.includes(requirement.edges[0]);
+      }
+
+      if (requirement.type === 'edge-pair') {
+        return containsEdgePath(record.edgeIds, requirement.edges);
+      }
+
+      if (requirement.type === 'prime-path' || requirement.type === 'complete-path') {
+        return containsNodePath(record.path, requirement.nodes);
+      }
+
+      return false;
+    });
+
+    return {
+      requirement,
+      path: matchedRecord ? matchedRecord.path : null,
+      covered: Boolean(matchedRecord),
+    };
+  });
+
+  const uniquePathSet = new Set(
+    requirementPaths
+      .filter((entry) => entry.covered)
+      .map((entry) => entry.path.join('->'))
+  );
+
+  return {
+    candidatePaths,
+    requirementPaths,
+    selectedPaths: Array.from(uniquePathSet).map((item) => item.split('->')),
+    uncoveredRequirements: requirementPaths.filter((entry) => !entry.covered).map((entry) => entry.requirement),
+  };
 }
 
 export function getCoverageRequirements(graph, criterion) {
@@ -187,6 +375,14 @@ export function getCoverageRequirements(graph, criterion) {
 
   if (criterion === 'prime-path') {
     return getPrimePathRequirements(graph);
+  }
+
+  if (criterion === 'edge-pair') {
+    return getEdgePairRequirements(graph);
+  }
+
+  if (criterion === 'complete-path') {
+    return getCompletePathRequirements(graph);
   }
 
   return [];

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,5 +5,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.js'],
+    exclude: ['e2e/**', 'node_modules/**'],
   },
 });


### PR DESCRIPTION
## Summary
- add Playwright browser e2e tests for graph coverage features
- cover advanced criteria, test path generation, and editable graph recomputation
- run browser tests in GitHub Actions alongside unit tests

## Validation
- npm run test:run
- npm run test:browser

## Issue Links
Closes #3
Closes #4
Closes #5