### PR TITLE
Show path optimization metrics in graph coverage UI

### DIFF
--- a/e2e/path-optimization-metrics.spec.js
+++ b/e2e/path-optimization-metrics.spec.js
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Path Optimization Metrics', () => {
+  test('shows before and after path counts', async ({ page }) => {
+    await page.goto('/index.html');
+
+    await expect(page.getByTestId('test-path-metrics')).toBeVisible();
+
+    const baseline = Number(await page.getByTestId('baseline-path-count').textContent());
+    const optimized = Number(await page.getByTestId('optimized-path-count').textContent());
+    const saved = Number(await page.getByTestId('saved-path-count').textContent());
+
+    expect(baseline).toBeGreaterThan(0);
+    expect(optimized).toBeGreaterThan(0);
+    expect(optimized).toBeLessThanOrEqual(baseline);
+    expect(saved).toBe(baseline - optimized);
+  });
+});

--- a/src/components/GraphCoverageExplorer.css
+++ b/src/components/GraphCoverageExplorer.css
@@ -296,6 +296,31 @@
   margin-bottom: 8px;
 }
 
+.test-path-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 12px 0 14px;
+}
+
+.test-path-metric {
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  padding: 10px 12px;
+}
+
+.test-path-metric strong {
+  display: block;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.test-path-metric--accent {
+  background: linear-gradient(135deg, #fff7ed 0%, #ffffff 100%);
+  border-color: rgba(234, 88, 12, 0.25);
+}
+
 .test-path-list {
   list-style: none;
   display: grid;
@@ -412,6 +437,10 @@
 
 @media (max-width: 720px) {
   .graph-editor-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .test-path-metrics {
     grid-template-columns: 1fr;
   }
 

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -323,6 +323,20 @@ export function createGraphCoverageExplorer() {
           <div class="graph-test-path-card" data-testid="graph-test-path-card">
             <h4>Generated Test Path Set</h4>
             <p class="sidebar-text">將 requirement 自動組合成可執行測試路徑（Start 到 End）。</p>
+            <div class="test-path-metrics" data-testid="test-path-metrics">
+              <div class="test-path-metric">
+                <span class="detail-label">最佳化前</span>
+                <strong data-testid="baseline-path-count">${pathPlan.optimizationMetrics.baselinePathCount}</strong>
+              </div>
+              <div class="test-path-metric">
+                <span class="detail-label">最佳化後</span>
+                <strong data-testid="optimized-path-count">${pathPlan.optimizationMetrics.optimizedPathCount}</strong>
+              </div>
+              <div class="test-path-metric test-path-metric--accent">
+                <span class="detail-label">精簡數量</span>
+                <strong data-testid="saved-path-count">${pathPlan.optimizationMetrics.savedPathCount}</strong>
+              </div>
+            </div>
             <ul class="test-path-list" data-testid="test-path-list">
               ${pathPlan.selectedPaths.map((path, index) => `
                 <li data-testid="test-path-${index + 1}">T${index + 1}: ${path.join(' -> ')}</li>

--- a/src/tests/GraphCoverageExplorer.test.jsx
+++ b/src/tests/GraphCoverageExplorer.test.jsx
@@ -59,6 +59,10 @@ describe('GraphCoverageExplorer', () => {
     renderGraphCoverageExplorer();
     expect(document.querySelector('[data-testid="graph-test-path-card"]')).toBeInTheDocument();
     expect(document.querySelector('[data-testid="test-path-list"]')).toHaveTextContent('S -> A');
+    expect(document.querySelector('[data-testid="test-path-metrics"]')).toBeInTheDocument();
+    expect(Number(document.querySelector('[data-testid="baseline-path-count"]').textContent)).toBeGreaterThan(0);
+    expect(Number(document.querySelector('[data-testid="optimized-path-count"]').textContent)).toBeGreaterThan(0);
+    expect(Number(document.querySelector('[data-testid="saved-path-count"]').textContent)).toBeGreaterThanOrEqual(0);
   });
 
   it('編輯 graph 會即時計算 requirement', async () => {

--- a/src/tests/graphCoverage.test.js
+++ b/src/tests/graphCoverage.test.js
@@ -101,6 +101,9 @@ describe('graphCoverage utilities', () => {
 
     expect(optimized.uncoveredRequirements).toHaveLength(0);
     expect(optimized.selectedPaths.length).toBeLessThanOrEqual(naiveCount);
+    expect(optimized.optimizationMetrics.baselinePathCount).toBe(naiveCount);
+    expect(optimized.optimizationMetrics.optimizedPathCount).toBe(optimized.selectedPaths.length);
+    expect(optimized.optimizationMetrics.savedPathCount).toBeGreaterThanOrEqual(0);
   });
 
   it('set-cover 產生的路徑集合可覆蓋所有 complete-path requirements', () => {

--- a/src/utils/graphCoverage.js
+++ b/src/utils/graphCoverage.js
@@ -395,17 +395,17 @@ export function buildTestPathSetForRequirements(graph, requirements, options = {
     };
   });
 
+  const baselinePathSet = new Set(
+    requirementPaths
+      .filter((entry) => entry.covered)
+      .map((entry) => entry.path.join('->'))
+  );
+
   let selectedPaths;
   let uncoveredRequirementIds;
 
   if (optimizationMode === 'none') {
-    const uniquePathSet = new Set(
-      requirementPaths
-        .filter((entry) => entry.covered)
-        .map((entry) => entry.path.join('->'))
-    );
-
-    selectedPaths = Array.from(uniquePathSet).map((item) => item.split('->'));
+    selectedPaths = Array.from(baselinePathSet).map((item) => item.split('->'));
     uncoveredRequirementIds = new Set(
       requirementPaths
         .filter((entry) => !entry.covered)
@@ -421,6 +421,12 @@ export function buildTestPathSetForRequirements(graph, requirements, options = {
     candidatePaths,
     requirementPaths,
     selectedPaths,
+    optimizationMetrics: {
+      baselinePathCount: baselinePathSet.size,
+      optimizedPathCount: selectedPaths.length,
+      savedPathCount: Math.max(0, baselinePathSet.size - selectedPaths.length),
+      optimizationMode,
+    },
     uncoveredRequirements: requirementPaths
       .filter((entry) => !entry.covered || uncoveredRequirementIds.has(entry.requirement.id))
       .map((entry) => entry.requirement),


### PR DESCRIPTION
## Summary
- show baseline, optimized, and saved path counts in the graph coverage UI
- expose optimization metrics from the path planning utility
- add unit and browser coverage for the new optimization indicator

## Validation
- npm run test:run
- npm run test:browser

## Issue Links
Closes #7