### PR TITLE
Logic Coverage: K-map (n=3) uses columns=ab, rows=c

### DIFF
--- a/src/standalone.js
+++ b/src/standalone.js
@@ -2758,6 +2758,18 @@
   function bits(value, width) {
     return value.toString(2).padStart(width, "0");
   }
+  function composeMinterm(n, rowBits, colBits, rowClauseIdx, colClauseIdx) {
+    let minterm = 0;
+    rowClauseIdx.forEach((clauseIdx, i) => {
+      const localBit = rowBits >> rowClauseIdx.length - 1 - i & 1;
+      if (localBit) minterm |= 1 << n - 1 - clauseIdx;
+    });
+    colClauseIdx.forEach((clauseIdx, i) => {
+      const localBit = colBits >> colClauseIdx.length - 1 - i & 1;
+      if (localBit) minterm |= 1 << n - 1 - clauseIdx;
+    });
+    return minterm;
+  }
   function buildKMap(rows, clauses, target = true) {
     const n = clauses.length;
     if (n < 1 || n > 4) {
@@ -2765,39 +2777,48 @@
     }
     const map = /* @__PURE__ */ new Map();
     rows.forEach((row) => {
-      const value = row.predicate === target;
-      map.set(row.index, { value, minterm: row.index });
+      map.set(row.index, { value: row.predicate === target, minterm: row.index });
     });
     let rowOrder;
     let colOrder;
     let rowVars;
     let colVars;
+    let rowClauseIdx;
+    let colClauseIdx;
     if (n === 1) {
       rowOrder = [0];
       colOrder = GRAY2;
       rowVars = [];
       colVars = [clauses[0]];
+      rowClauseIdx = [];
+      colClauseIdx = [0];
     } else if (n === 2) {
       rowOrder = GRAY2;
       colOrder = GRAY2;
       rowVars = [clauses[0]];
       colVars = [clauses[1]];
+      rowClauseIdx = [0];
+      colClauseIdx = [1];
     } else if (n === 3) {
       rowOrder = GRAY2;
       colOrder = GRAY4;
-      rowVars = [clauses[0]];
-      colVars = [clauses[1], clauses[2]];
+      rowVars = [clauses[2]];
+      colVars = [clauses[0], clauses[1]];
+      rowClauseIdx = [2];
+      colClauseIdx = [0, 1];
     } else {
       rowOrder = GRAY4;
       colOrder = GRAY4;
       rowVars = [clauses[0], clauses[1]];
       colVars = [clauses[2], clauses[3]];
+      rowClauseIdx = [0, 1];
+      colClauseIdx = [2, 3];
     }
-    const rowWidth = rowVars.length;
-    const colWidth = colVars.length;
+    const rowWidth = rowClauseIdx.length;
+    const colWidth = colClauseIdx.length;
     const grid = rowOrder.map((rBits) => {
       const cells = colOrder.map((cBits) => {
-        const minterm = rBits << colWidth | cBits;
+        const minterm = composeMinterm(n, rBits, cBits, rowClauseIdx, colClauseIdx);
         const entry = map.get(minterm);
         return {
           minterm,

--- a/src/tests/karnaughMap.test.js
+++ b/src/tests/karnaughMap.test.js
@@ -3,20 +3,28 @@ import { parsePredicate, buildTruthTable } from '../utils/logicCoverage.js';
 import { buildKMap } from '../utils/karnaughMap.js';
 
 describe('buildKMap', () => {
-  it('returns a 2x4 grid for 3 clauses with Gray-code column order', () => {
+  it('uses columns=ab and rows=c for 3 clauses', () => {
     const parsed = parsePredicate('(a && b) || c');
     const rows = buildTruthTable(parsed);
     const map = buildKMap(rows, parsed.clauses, true);
     expect(map.unsupported).toBe(false);
-    expect(map.rowVars).toEqual(['a']);
-    expect(map.colVars).toEqual(['b', 'c']);
+    expect(map.rowVars).toEqual(['c']);
+    expect(map.colVars).toEqual(['a', 'b']);
     expect(map.colHeaders).toEqual(['00', '01', '11', '10']);
     expect(map.grid).toHaveLength(2);
     map.grid.forEach((r) => expect(r.cells).toHaveLength(4));
-    // a=1,b=1,c=1 → minterm 7 → true
-    const onCell = map.grid[1].cells[2];
-    expect(onCell.minterm).toBe(7);
-    expect(onCell.value).toBe(true);
+    // c=1 row, ab=11 col → minterm 7 → true
+    const cellAB11C1 = map.grid[1].cells[2];
+    expect(cellAB11C1.minterm).toBe(7);
+    expect(cellAB11C1.value).toBe(true);
+    // c=0 row, ab=11 col → minterm 6 → true ((a∧b))
+    const cellAB11C0 = map.grid[0].cells[2];
+    expect(cellAB11C0.minterm).toBe(6);
+    expect(cellAB11C0.value).toBe(true);
+    // c=0 row, ab=10 col → minterm 4 → false
+    const cellAB10C0 = map.grid[0].cells[3];
+    expect(cellAB10C0.minterm).toBe(4);
+    expect(cellAB10C0.value).toBe(false);
   });
 
   it('flags target=false (¬f) cells correctly', () => {

--- a/src/utils/karnaughMap.js
+++ b/src/utils/karnaughMap.js
@@ -11,52 +11,76 @@ function bits(value, width) {
   return value.toString(2).padStart(width, '0');
 }
 
+// 把 row/col 上的位元（依 rowClauseIdx / colClauseIdx 中的順序為 MSB→LSB）
+// 還原成 truth table 的 minterm 編號（clauses[0] 在 minterm 中是 MSB）。
+function composeMinterm(n, rowBits, colBits, rowClauseIdx, colClauseIdx) {
+  let minterm = 0;
+  rowClauseIdx.forEach((clauseIdx, i) => {
+    const localBit = (rowBits >> (rowClauseIdx.length - 1 - i)) & 1;
+    if (localBit) minterm |= 1 << (n - 1 - clauseIdx);
+  });
+  colClauseIdx.forEach((clauseIdx, i) => {
+    const localBit = (colBits >> (colClauseIdx.length - 1 - i)) & 1;
+    if (localBit) minterm |= 1 << (n - 1 - clauseIdx);
+  });
+  return minterm;
+}
+
 export function buildKMap(rows, clauses, target = true) {
   const n = clauses.length;
   if (n < 1 || n > 4) {
     return { unsupported: true, n };
   }
 
-  // 對每列以該列代表的 minterm index 建表（依 clauses 依序為 MSB → LSB）。
   const map = new Map();
   rows.forEach((row) => {
-    const value = row.predicate === target;
-    map.set(row.index, { value, minterm: row.index });
+    map.set(row.index, { value: row.predicate === target, minterm: row.index });
   });
 
   let rowOrder;
   let colOrder;
   let rowVars;
   let colVars;
+  let rowClauseIdx;
+  let colClauseIdx;
 
   if (n === 1) {
     rowOrder = [0];
     colOrder = GRAY2;
     rowVars = [];
     colVars = [clauses[0]];
+    rowClauseIdx = [];
+    colClauseIdx = [0];
   } else if (n === 2) {
     rowOrder = GRAY2;
     colOrder = GRAY2;
     rowVars = [clauses[0]];
     colVars = [clauses[1]];
+    rowClauseIdx = [0];
+    colClauseIdx = [1];
   } else if (n === 3) {
+    // 列：c；欄：ab（Gray code 00/01/11/10）。
     rowOrder = GRAY2;
     colOrder = GRAY4;
-    rowVars = [clauses[0]];
-    colVars = [clauses[1], clauses[2]];
+    rowVars = [clauses[2]];
+    colVars = [clauses[0], clauses[1]];
+    rowClauseIdx = [2];
+    colClauseIdx = [0, 1];
   } else {
     rowOrder = GRAY4;
     colOrder = GRAY4;
     rowVars = [clauses[0], clauses[1]];
     colVars = [clauses[2], clauses[3]];
+    rowClauseIdx = [0, 1];
+    colClauseIdx = [2, 3];
   }
 
-  const rowWidth = rowVars.length;
-  const colWidth = colVars.length;
+  const rowWidth = rowClauseIdx.length;
+  const colWidth = colClauseIdx.length;
 
   const grid = rowOrder.map((rBits) => {
     const cells = colOrder.map((cBits) => {
-      const minterm = (rBits << colWidth) | cBits;
+      const minterm = composeMinterm(n, rBits, cBits, rowClauseIdx, colClauseIdx);
       const entry = map.get(minterm);
       return {
         minterm,


### PR DESCRIPTION
## Summary
Switch the 3-variable Karnaugh map layout to the conventional form requested in #21:
- **Columns**: `ab` in Gray-code order — `00, 01, 11, 10`
- **Rows**: `c` — `0, 1`

## Implementation
- Generalized `buildKMap` in `src/utils/karnaughMap.js` to map row/col local bits back to the original clause bit positions (so the cell minterm is always computed from `clauses[0]` as MSB regardless of layout).
- For `n === 3` the layout now uses `rowVars = [c]`, `colVars = [a, b]`.
- Updated the related unit test in `src/tests/karnaughMap.test.js` to assert the new headers and minterm placement.

## Verification
- `vitest`: 120/120 passing.
- `npm run build:standalone`: succeeds.

Closes #21.
