### PR TITLE
Logic Coverage: outline each implicant on Karnaugh map

### DIFF
--- a/src/components/LogicCoverageExplorer.css
+++ b/src/components/LogicCoverageExplorer.css
@@ -263,6 +263,31 @@
   color: #b08900;
   font-weight: 700;
 }
+.logic-kmap-legend {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  font-size: 0.8rem;
+  color: #2c3e50;
+  font-family: 'JetBrains Mono', 'Menlo', 'Consolas', monospace;
+}
+.logic-kmap-legend li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.logic-kmap-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  border-width: 3px;
+  border-style: solid;
+  background: transparent;
+}
 .logic-divider {
   margin: 0 6px;
   color: #b2bec3;

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -76,12 +76,18 @@ function dnfToCompactHtml(dnf) {
     .join(' &nbsp;+&nbsp; ');
 }
 
-function renderKMap(rows, clauses, target, title) {
-  const map = buildKMap(rows, clauses, target);
+function renderKMap(rows, clauses, target, title, dnf = []) {
+  const map = buildKMap(rows, clauses, target, dnf);
   if (map.unsupported) {
     return `<div class="logic-kmap"><h4 class="logic-kmap-title">${escapeHtml(title)}</h4>
       <p class="logic-kmap-note">Karnaugh map 僅支援 1–4 個 clauses（目前為 ${map.n}）。</p></div>`;
   }
+  const palette = [
+    '#e74c3c', '#3498db', '#27ae60', '#9b59b6',
+    '#f39c12', '#16a085', '#d35400', '#2c3e50',
+  ];
+  const colorOf = (idx) => palette[idx % palette.length];
+
   const colHeaderLabel = map.colVars.length ? map.colVars.join('') : '';
   const rowHeaderLabel = map.rowVars.length ? map.rowVars.join('') : '';
   const colHeadHtml = map.colHeaders
@@ -93,7 +99,14 @@ function renderKMap(rows, clauses, target, title) {
         .map((cell) => {
           const cls = cell.value ? 'logic-kmap-cell logic-kmap-on' : 'logic-kmap-cell';
           const text = cell.value ? '1' : '0';
-          return `<td class="${cls}" title="m${cell.minterm}">${text}<sub>${cell.minterm}</sub></td>`;
+          let style = '';
+          if (cell.implicants.length) {
+            const shadows = cell.implicants
+              .map((impIdx, k) => `inset 0 0 0 ${(k + 1) * 3}px ${colorOf(impIdx)}`)
+              .join(', ');
+            style = ` style="box-shadow:${shadows}"`;
+          }
+          return `<td class="${cls}"${style} title="m${cell.minterm}">${text}<sub>${cell.minterm}</sub></td>`;
         })
         .join('');
       const rowHead = rowHeaderLabel
@@ -105,10 +118,18 @@ function renderKMap(rows, clauses, target, title) {
   const corner = rowHeaderLabel
     ? `<th class="logic-kmap-corner"><span>${escapeHtml(rowHeaderLabel)}</span><span class="logic-kmap-slash">\\</span><span>${escapeHtml(colHeaderLabel)}</span></th>`
     : `<th class="logic-kmap-corner">${escapeHtml(colHeaderLabel)}</th>`;
+  const legendHtml = dnf.length
+    ? `<ul class="logic-kmap-legend">${dnf
+        .map((term, idx) =>
+          `<li><span class="logic-kmap-swatch" style="border-color:${colorOf(idx)}"></span><code>${termToCompactHtml(term)}</code></li>`,
+        )
+        .join('')}</ul>`
+    : '';
   return `<div class="logic-kmap" data-testid="${target ? 'logic-kmap-f' : 'logic-kmap-not-f'}">
     <h4 class="logic-kmap-title">${escapeHtml(title)}</h4>
     <table class="logic-kmap-table"><thead><tr>${corner}${colHeadHtml}</tr></thead>
     <tbody>${bodyHtml}</tbody></table>
+    ${legendHtml}
   </div>`;
 }
 
@@ -395,8 +416,8 @@ export function createLogicCoverageExplorer() {
 
     const kmapMarkup = set.id === 'ic' && state.parsed
       ? `<div class="logic-kmap-row">
-          ${renderKMap(state.analysis.rows, state.parsed.clauses, true, 'f 的 Karnaugh Map')}
-          ${renderKMap(state.analysis.rows, state.parsed.clauses, false, '¬f 的 Karnaugh Map')}
+          ${renderKMap(state.analysis.rows, state.parsed.clauses, true, 'f 的 Karnaugh Map', state.analysis.dnf)}
+          ${renderKMap(state.analysis.rows, state.parsed.clauses, false, '¬f 的 Karnaugh Map', state.analysis.negDnf)}
         </div>`
       : '';
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -2770,14 +2770,14 @@
     });
     return minterm;
   }
-  function buildKMap(rows, clauses, target = true) {
+  function buildKMap(rows, clauses, target = true, dnf = []) {
     const n = clauses.length;
     if (n < 1 || n > 4) {
       return { unsupported: true, n };
     }
     const map = /* @__PURE__ */ new Map();
     rows.forEach((row) => {
-      map.set(row.index, { value: row.predicate === target, minterm: row.index });
+      map.set(row.index, { value: row.predicate === target, minterm: row.index, values: row.values });
     });
     let rowOrder;
     let colOrder;
@@ -2820,9 +2820,19 @@
       const cells = colOrder.map((cBits) => {
         const minterm = composeMinterm(n, rBits, cBits, rowClauseIdx, colClauseIdx);
         const entry = map.get(minterm);
+        const values = (entry == null ? void 0 : entry.values) || {};
+        const implicants = [];
+        if (entry == null ? void 0 : entry.value) {
+          dnf.forEach((term, idx) => {
+            if (term.every((lit) => Boolean(values[lit.name]) !== lit.negated)) {
+              implicants.push(idx);
+            }
+          });
+        }
         return {
           minterm,
-          value: entry ? entry.value : false
+          value: entry ? entry.value : false,
+          implicants
         };
       });
       return {
@@ -3118,12 +3128,23 @@ Content-Type: ${file.type || "application/octet-stream"}\r
     if (!dnf.length) return "<code>0</code>";
     return dnf.map((term) => `<code>${termToCompactHtml(term)}</code>`).join(" &nbsp;+&nbsp; ");
   }
-  function renderKMap(rows, clauses, target, title) {
-    const map = buildKMap(rows, clauses, target);
+  function renderKMap(rows, clauses, target, title, dnf = []) {
+    const map = buildKMap(rows, clauses, target, dnf);
     if (map.unsupported) {
       return `<div class="logic-kmap"><h4 class="logic-kmap-title">${escapeHtml2(title)}</h4>
       <p class="logic-kmap-note">Karnaugh map \u50C5\u652F\u63F4 1\u20134 \u500B clauses\uFF08\u76EE\u524D\u70BA ${map.n}\uFF09\u3002</p></div>`;
     }
+    const palette = [
+      "#e74c3c",
+      "#3498db",
+      "#27ae60",
+      "#9b59b6",
+      "#f39c12",
+      "#16a085",
+      "#d35400",
+      "#2c3e50"
+    ];
+    const colorOf = (idx) => palette[idx % palette.length];
     const colHeaderLabel = map.colVars.length ? map.colVars.join("") : "";
     const rowHeaderLabel = map.rowVars.length ? map.rowVars.join("") : "";
     const colHeadHtml = map.colHeaders.map((h) => `<th scope="col">${escapeHtml2(h)}</th>`).join("");
@@ -3131,16 +3152,25 @@ Content-Type: ${file.type || "application/octet-stream"}\r
       const cells = row.cells.map((cell) => {
         const cls = cell.value ? "logic-kmap-cell logic-kmap-on" : "logic-kmap-cell";
         const text = cell.value ? "1" : "0";
-        return `<td class="${cls}" title="m${cell.minterm}">${text}<sub>${cell.minterm}</sub></td>`;
+        let style = "";
+        if (cell.implicants.length) {
+          const shadows = cell.implicants.map((impIdx, k) => `inset 0 0 0 ${(k + 1) * 3}px ${colorOf(impIdx)}`).join(", ");
+          style = ` style="box-shadow:${shadows}"`;
+        }
+        return `<td class="${cls}"${style} title="m${cell.minterm}">${text}<sub>${cell.minterm}</sub></td>`;
       }).join("");
       const rowHead = rowHeaderLabel ? `<th scope="row">${escapeHtml2(row.header)}</th>` : "";
       return `<tr>${rowHead}${cells}</tr>`;
     }).join("");
     const corner = rowHeaderLabel ? `<th class="logic-kmap-corner"><span>${escapeHtml2(rowHeaderLabel)}</span><span class="logic-kmap-slash">\\</span><span>${escapeHtml2(colHeaderLabel)}</span></th>` : `<th class="logic-kmap-corner">${escapeHtml2(colHeaderLabel)}</th>`;
+    const legendHtml = dnf.length ? `<ul class="logic-kmap-legend">${dnf.map(
+      (term, idx) => `<li><span class="logic-kmap-swatch" style="border-color:${colorOf(idx)}"></span><code>${termToCompactHtml(term)}</code></li>`
+    ).join("")}</ul>` : "";
     return `<div class="logic-kmap" data-testid="${target ? "logic-kmap-f" : "logic-kmap-not-f"}">
     <h4 class="logic-kmap-title">${escapeHtml2(title)}</h4>
     <table class="logic-kmap-table"><thead><tr>${corner}${colHeadHtml}</tr></thead>
     <tbody>${bodyHtml}</tbody></table>
+    ${legendHtml}
   </div>`;
   }
   function createLogicCoverageExplorer() {
@@ -3373,8 +3403,8 @@ Content-Type: ${file.type || "application/octet-stream"}\r
                 <span class="logic-dnf-alt">\uFF08\u6559\u79D1\u66F8\u8A18\u865F\uFF1A${dnfToCompactHtml(state.analysis.negDnf)}\uFF09</span>
               </p>` : ""}` : "";
       const kmapMarkup = set.id === "ic" && state.parsed ? `<div class="logic-kmap-row">
-          ${renderKMap(state.analysis.rows, state.parsed.clauses, true, "f \u7684 Karnaugh Map")}
-          ${renderKMap(state.analysis.rows, state.parsed.clauses, false, "\xACf \u7684 Karnaugh Map")}
+          ${renderKMap(state.analysis.rows, state.parsed.clauses, true, "f \u7684 Karnaugh Map", state.analysis.dnf)}
+          ${renderKMap(state.analysis.rows, state.parsed.clauses, false, "\xACf \u7684 Karnaugh Map", state.analysis.negDnf)}
         </div>` : "";
       return `
       <h3 class="logic-summary-title">${escapeHtml2(set.name)}</h3>

--- a/src/tests/karnaughMap.test.js
+++ b/src/tests/karnaughMap.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parsePredicate, buildTruthTable } from '../utils/logicCoverage.js';
+import { parsePredicate, buildTruthTable, minimalDNF } from '../utils/logicCoverage.js';
 import { buildKMap } from '../utils/karnaughMap.js';
 
 describe('buildKMap', () => {
@@ -43,5 +43,35 @@ describe('buildKMap', () => {
     const map = buildKMap(rows, parsed.clauses, true);
     expect(map.unsupported).toBe(true);
     expect(map.n).toBe(5);
+  });
+
+  it('tags cells with covering implicant indices when DNF is provided', () => {
+    const parsed = parsePredicate('(a && b) || c');
+    const rows = buildTruthTable(parsed);
+    const dnf = minimalDNF(rows, parsed.clauses, true);
+    const map = buildKMap(rows, parsed.clauses, true, dnf);
+    // 收集每個 implicant 對應的 minterms。
+    const byImp = new Map();
+    map.grid.flatMap((r) => r.cells).forEach((cell) => {
+      cell.implicants.forEach((idx) => {
+        if (!byImp.has(idx)) byImp.set(idx, new Set());
+        byImp.get(idx).add(cell.minterm);
+      });
+    });
+    // 應該有兩個 implicants：{a∧b} → {6,7}、{c} → {1,3,5,7}。
+    const sortedSets = [...byImp.values()]
+      .map((s) => [...s].sort((a, b) => a - b).join(','))
+      .sort();
+    expect(sortedSets).toEqual(['1,3,5,7', '6,7']);
+  });
+
+  it('off-cells carry no implicants', () => {
+    const parsed = parsePredicate('a && b');
+    const rows = buildTruthTable(parsed);
+    const dnf = minimalDNF(rows, parsed.clauses, true);
+    const map = buildKMap(rows, parsed.clauses, true, dnf);
+    map.grid.flatMap((r) => r.cells).forEach((cell) => {
+      if (!cell.value) expect(cell.implicants).toEqual([]);
+    });
   });
 });

--- a/src/utils/karnaughMap.js
+++ b/src/utils/karnaughMap.js
@@ -26,7 +26,7 @@ function composeMinterm(n, rowBits, colBits, rowClauseIdx, colClauseIdx) {
   return minterm;
 }
 
-export function buildKMap(rows, clauses, target = true) {
+export function buildKMap(rows, clauses, target = true, dnf = []) {
   const n = clauses.length;
   if (n < 1 || n > 4) {
     return { unsupported: true, n };
@@ -34,7 +34,7 @@ export function buildKMap(rows, clauses, target = true) {
 
   const map = new Map();
   rows.forEach((row) => {
-    map.set(row.index, { value: row.predicate === target, minterm: row.index });
+    map.set(row.index, { value: row.predicate === target, minterm: row.index, values: row.values });
   });
 
   let rowOrder;
@@ -82,9 +82,19 @@ export function buildKMap(rows, clauses, target = true) {
     const cells = colOrder.map((cBits) => {
       const minterm = composeMinterm(n, rBits, cBits, rowClauseIdx, colClauseIdx);
       const entry = map.get(minterm);
+      const values = entry?.values || {};
+      const implicants = [];
+      if (entry?.value) {
+        dnf.forEach((term, idx) => {
+          if (term.every((lit) => Boolean(values[lit.name]) !== lit.negated)) {
+            implicants.push(idx);
+          }
+        });
+      }
       return {
         minterm,
         value: entry ? entry.value : false,
+        implicants,
       };
     });
     return {


### PR DESCRIPTION
## Summary
Outline each prime implicant on the Karnaugh map and add a small color legend per map (one for `f`, one for `¬f`).

## Implementation
- `buildKMap(rows, clauses, target, dnf?)` now tags each on-cell with `implicants: number[]` indicating which DNF terms cover that minterm.
- `LogicCoverageExplorer.renderKMap` accepts a `dnf` argument and emits per-cell inline `box-shadow` outlines (one inset ring per covering implicant, stacked when overlapping). A legend below each table maps color → term (textbook notation).
- Wrap-around groups appear as separate outlined blocks of the same color (no special drawing required).
- Added two new vitest assertions (`tags cells with covering implicant indices…`, `off-cells carry no implicants`).

## Verification
- vitest: 122/122 passing.
- Playwright (existing 6 specs): all green.
- `npm run build:standalone`: succeeds.

Closes #25.
