### PR TITLE
Logic Coverage: K-map (n=4) uses columns=ab, rows=cd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -158,7 +157,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -668,7 +666,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
       "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -735,7 +732,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
       "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.11",
         "@firebase/component": "0.7.2",
@@ -752,7 +748,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
       "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.0"
       }
@@ -1206,7 +1201,6 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2699,7 +2693,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -2809,10 +2809,10 @@
     } else {
       rowOrder = GRAY4;
       colOrder = GRAY4;
-      rowVars = [clauses[0], clauses[1]];
-      colVars = [clauses[2], clauses[3]];
-      rowClauseIdx = [0, 1];
-      colClauseIdx = [2, 3];
+      rowVars = [clauses[2], clauses[3]];
+      colVars = [clauses[0], clauses[1]];
+      rowClauseIdx = [2, 3];
+      colClauseIdx = [0, 1];
     }
     const rowWidth = rowClauseIdx.length;
     const colWidth = colClauseIdx.length;

--- a/src/tests/karnaughMap.test.js
+++ b/src/tests/karnaughMap.test.js
@@ -44,4 +44,24 @@ describe('buildKMap', () => {
     expect(map.unsupported).toBe(true);
     expect(map.n).toBe(5);
   });
+
+  it('uses columns=ab and rows=cd for 4 clauses', () => {
+    const parsed = parsePredicate('(a || b) && (c || d)');
+    const rows = buildTruthTable(parsed);
+    const map = buildKMap(rows, parsed.clauses, true);
+    expect(map.unsupported).toBe(false);
+    expect(map.colVars).toEqual(['a', 'b']);
+    expect(map.rowVars).toEqual(['c', 'd']);
+    expect(map.colHeaders).toEqual(['00', '01', '11', '10']);
+    expect(map.grid).toHaveLength(4);
+    map.grid.forEach((r) => expect(r.cells).toHaveLength(4));
+    // a=1,b=0,c=0,d=1 → minterm 1001 = 9 → ab=10 col, cd=01 row → row[1] col[3]
+    const cell = map.grid[1].cells[3];
+    expect(cell.minterm).toBe(9);
+    expect(cell.value).toBe(true);
+    // a=b=c=d=0 → minterm 0 → false
+    const zero = map.grid[0].cells[0];
+    expect(zero.minterm).toBe(0);
+    expect(zero.value).toBe(false);
+  });
 });

--- a/src/utils/karnaughMap.js
+++ b/src/utils/karnaughMap.js
@@ -67,12 +67,13 @@ export function buildKMap(rows, clauses, target = true) {
     rowClauseIdx = [2];
     colClauseIdx = [0, 1];
   } else {
+    // 列：cd；欄：ab，兩者皆為 Gray code 00/01/11/10。
     rowOrder = GRAY4;
     colOrder = GRAY4;
-    rowVars = [clauses[0], clauses[1]];
-    colVars = [clauses[2], clauses[3]];
-    rowClauseIdx = [0, 1];
-    colClauseIdx = [2, 3];
+    rowVars = [clauses[2], clauses[3]];
+    colVars = [clauses[0], clauses[1]];
+    rowClauseIdx = [2, 3];
+    colClauseIdx = [0, 1];
   }
 
   const rowWidth = rowClauseIdx.length;


### PR DESCRIPTION
## Summary
Match the n=3 convention (#21) for the 4-variable Karnaugh map. Columns now hold `ab` and rows hold `cd`, both Gray-coded `00, 01, 11, 10`.

## Implementation
- `src/utils/karnaughMap.js`: in the `n === 4` branch, swapped row/col variable assignment and clause indices so columns = clauses 0,1 (`ab`) and rows = clauses 2,3 (`cd`). Minterm composition is unchanged (still uses clause 0 as MSB via `composeMinterm`).
- `src/tests/karnaughMap.test.js`: added a test for the new layout against `(a || b) && (c || d)`, including a known true cell (a=1,b=0,c=0,d=1 → m9 at row[1] col[3]) and a known false cell (m0 at row[0] col[0]).

## Verification
- vitest: 121/121 passing.
- `npm run build:standalone`: succeeds.

Closes #27.
