### PR TITLE
Syntax-Based Testing: Program Mutation visualizer + cloud sync

### DIFF
--- a/e2e/logic-coverage.spec.js
+++ b/e2e/logic-coverage.spec.js
@@ -34,7 +34,11 @@ test.describe('Logic Coverage Explorer', () => {
     const titles = await onCells.evaluateAll((nodes) =>
       nodes.map((n) => n.getAttribute('title')),
     );
-    expect(titles.sort()).toEqual(['m1', 'm3', 'm5', 'm6', 'm7']);
+    // 注意：title 後面可能附帶 implicant / UTP / NFP 等註記，僅比對 m{n} 前綴。
+    const mintermTags = titles
+      .map((t) => (t || '').split(/[｜（]/)[0].trim())
+      .sort();
+    expect(mintermTags).toEqual(['m1', 'm3', 'm5', 'm6', 'm7']);
   });
 
   test('switching to a 4-clause predicate yields a 4x4 K-map', async ({ page }) => {

--- a/src/app.js
+++ b/src/app.js
@@ -4,12 +4,14 @@ import { createLogicCoverageExplorer } from './components/LogicCoverageExplorer.
 import { createTestingFlow } from './components/TestingFlow.js';
 import { createTestingTypesTable } from './components/TestingTypesTable.js';
 import { createCloudStoragePanel } from './components/CloudStoragePanel.js';
+import { createSyntaxCoverageExplorer } from './components/SyntaxCoverageExplorer.js';
 
 const sectionsConfig = [
   { id: 'all', label: '全覽' },
   { id: 'methods', label: '測試方法' },
   { id: 'graph', label: 'Graph Coverage' },
   { id: 'logic', label: 'Logic Coverage' },
+  { id: 'syntax', label: 'Syntax-Based Testing' },
   { id: 'cloud', label: '雲端整合' },
   { id: 'flow', label: '測試流程' },
   { id: 'types', label: '測試類型' },
@@ -38,6 +40,10 @@ export function renderApp(container) {
           <h2>Logic Coverage 視覺化</h2>
           <div data-slot="logic"></div>
         </section>
+        <section data-testid="section-syntax">
+          <h2>Syntax-Based Testing：Program Mutation</h2>
+          <div data-slot="syntax"></div>
+        </section>
         <section data-testid="section-cloud">
           <h2>Google 雲端整合</h2>
           <div data-slot="cloud"></div>
@@ -64,6 +70,7 @@ export function renderApp(container) {
     methods: main.querySelector('[data-testid="section-methods"]'),
     graph: main.querySelector('[data-testid="section-graph"]'),
     logic: main.querySelector('[data-testid="section-logic"]'),
+    syntax: main.querySelector('[data-testid="section-syntax"]'),
     cloud: main.querySelector('[data-testid="section-cloud"]'),
     flow: main.querySelector('[data-testid="section-flow"]'),
     types: main.querySelector('[data-testid="section-types"]'),
@@ -73,6 +80,7 @@ export function renderApp(container) {
     methods: createTestingMethodTree(),
     graph: createGraphCoverageExplorer(),
     logic: createLogicCoverageExplorer(),
+    syntax: createSyntaxCoverageExplorer(),
     cloud: createCloudStoragePanel(),
     flow: createTestingFlow(),
     types: createTestingTypesTable(),
@@ -81,6 +89,7 @@ export function renderApp(container) {
   container.querySelector('[data-slot="methods"]').appendChild(components.methods);
   container.querySelector('[data-slot="graph"]').appendChild(components.graph);
   container.querySelector('[data-slot="logic"]').appendChild(components.logic);
+  container.querySelector('[data-slot="syntax"]').appendChild(components.syntax);
   container.querySelector('[data-slot="cloud"]').appendChild(components.cloud);
   container.querySelector('[data-slot="flow"]').appendChild(components.flow);
   container.querySelector('[data-slot="types"]').appendChild(components.types);

--- a/src/components/SyntaxCoverageExplorer.css
+++ b/src/components/SyntaxCoverageExplorer.css
@@ -1,0 +1,422 @@
+.syntax-coverage {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.syntax-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.syntax-cloud-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.35rem 0.6rem;
+  background: #f1f5f9;
+  border: 1px dashed #cbd5e1;
+  border-radius: 0.4rem;
+  font-size: 0.85rem;
+  color: #475569;
+  min-height: 1.6rem;
+}
+
+.syntax-cloud-indicator:empty { display: none; }
+.syntax-cloud-indicator { font-weight: 500; }
+.syntax-cloud-indicator[data-status="syncing"] { color: #2563eb; }
+.syntax-cloud-indicator[data-status="synced"] { color: #047857; }
+.syntax-cloud-indicator[data-status="error"] { color: #b91c1c; }
+.syntax-cloud-indicator[data-status="idle"] { color: #64748b; font-style: italic; }
+.syntax-cloud-indicator[data-status="idle"]:empty::before {
+  content: '尚未登入：測試案例只會儲存在此瀏覽器';
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.syntax-reset-btn {
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #475569;
+}
+.syntax-reset-btn:hover { background: #f8fafc; border-color: #94a3b8; }
+
+.syntax-cloud-actions {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.syntax-reload-btn {
+  background: #2563eb;
+  color: #fff;
+  border: 1px solid #2563eb;
+  border-radius: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+.syntax-reload-btn:hover { background: #1d4ed8; border-color: #1d4ed8; }
+
+.syntax-examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.syntax-example-btn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  border-radius: 0.4rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.syntax-example-btn.active,
+.syntax-example-btn:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+.syntax-operators {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.syntax-op-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.65rem;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  user-select: none;
+}
+
+.syntax-op-btn input {
+  margin: 0;
+}
+
+.syntax-op-btn.active {
+  background: #ede9fe;
+  border-color: #8b5cf6;
+  color: #5b21b6;
+}
+
+.syntax-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  gap: 1rem;
+}
+
+@media (max-width: 900px) {
+  .syntax-grid { grid-template-columns: 1fr; }
+}
+
+.syntax-program,
+.syntax-tests {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.syntax-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.syntax-params,
+.syntax-body,
+.syntax-test-input {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.35rem;
+  padding: 0.4rem 0.55rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88rem;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.syntax-body {
+  resize: vertical;
+  min-height: 9rem;
+}
+
+.syntax-tests-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.syntax-tests-header h4 { margin: 0; }
+
+.syntax-test-add {
+  background: #10b981;
+  color: #fff;
+  border: 0;
+  border-radius: 0.4rem;
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+}
+
+.syntax-test-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.syntax-test-table th,
+.syntax-test-table td {
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0.35rem 0.4rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.syntax-test-table th {
+  background: #f1f5f9;
+  font-weight: 600;
+}
+
+.syntax-test-row.pass td:first-child { border-left: 3px solid #10b981; }
+.syntax-test-row.fail td:first-child { border-left: 3px solid #ef4444; }
+
+.syntax-test-mutant-head {
+  background: #ede9fe !important;
+  color: #5b21b6;
+}
+
+.syntax-test-mutant {
+  background: #f5f3ff;
+  position: relative;
+  white-space: nowrap;
+}
+
+.syntax-test-mutant.killed-by {
+  background: #fef2f2;
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.syntax-test-mutant.killed-by code {
+  background: #fee2e2;
+  color: #991b1b;
+  padding: 0.05rem 0.3rem;
+  border-radius: 0.2rem;
+}
+
+.syntax-test-mutant.survived-by {
+  color: #475569;
+}
+
+.syntax-test-mutant.survived-by code {
+  background: #e2e8f0;
+  padding: 0.05rem 0.3rem;
+  border-radius: 0.2rem;
+}
+
+.syntax-test-kill-badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.4rem;
+  background: #ef4444;
+  color: #fff;
+  border-radius: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  vertical-align: middle;
+}
+
+.syntax-test-row.killed-by td:nth-child(4) {
+  position: relative;
+}
+
+.syntax-test-remove {
+  background: transparent;
+  border: 0;
+  color: #ef4444;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.syntax-error {
+  color: #b91c1c;
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  border-radius: 0.35rem;
+  padding: 0.5rem 0.7rem;
+  margin: 0;
+}
+
+.syntax-score-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.syntax-score-bar {
+  width: 100%;
+  height: 14px;
+  background: #fee2e2;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.syntax-score-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #10b981, #2563eb);
+  transition: width 0.25s ease;
+}
+
+.syntax-score-stats {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.syntax-divider {
+  margin: 0 0.4rem;
+  color: #94a3b8;
+}
+
+.syntax-mutant-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 900px) {
+  .syntax-mutant-section { grid-template-columns: 1fr; }
+}
+
+.syntax-mutant-list {
+  max-height: 24rem;
+  overflow-y: auto;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 0.6rem;
+}
+
+.syntax-mutant-group {
+  margin-bottom: 0.75rem;
+}
+
+.syntax-mutant-group h5 {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  color: #475569;
+  letter-spacing: 0.05em;
+}
+
+.syntax-mutant-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.syntax-mutant-item {
+  display: grid;
+  grid-template-columns: 3.5rem 4rem 1fr 5rem;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.35rem 0.55rem;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.35rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.syntax-mutant-item.killed { border-left: 3px solid #10b981; }
+.syntax-mutant-item.live { border-left: 3px solid #ef4444; background: #fef2f2; }
+.syntax-mutant-item.equivalent { border-left: 3px solid #94a3b8; opacity: 0.85; }
+.syntax-mutant-item.selected { box-shadow: 0 0 0 2px #2563eb; }
+
+.syntax-mutant-id { font-weight: 600; color: #1e293b; }
+.syntax-mutant-loc { color: #64748b; font-family: ui-monospace, monospace; }
+.syntax-mutant-diff code { background: #f1f5f9; padding: 0.05rem 0.3rem; border-radius: 0.2rem; }
+.syntax-mutant-status { text-align: right; font-weight: 600; text-transform: uppercase; font-size: 0.7rem; }
+
+.syntax-mutant-detail {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.syntax-mutant-detail h4 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.syntax-mutant-op {
+  background: #ede9fe;
+  color: #5b21b6;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.3rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.syntax-mutant-meta { margin: 0; color: #475569; font-size: 0.85rem; }
+
+.syntax-mutant-source {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.4rem;
+  margin: 0;
+  font-size: 0.82rem;
+  overflow-x: auto;
+}
+
+.syntax-mutant-killed { margin: 0; font-size: 0.85rem; color: #1e293b; }
+.syntax-mutant-killed code { background: #e0e7ff; padding: 0.05rem 0.3rem; border-radius: 0.2rem; }
+
+.syntax-mutant-actions { display: flex; gap: 0.5rem; }
+
+.syntax-mutant-actions button {
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+}
+
+.syntax-mutant-empty {
+  margin: 0;
+  color: #64748b;
+  font-style: italic;
+}

--- a/src/components/SyntaxCoverageExplorer.js
+++ b/src/components/SyntaxCoverageExplorer.js
@@ -1,0 +1,633 @@
+import { mutationOperators, programExamples } from '../data/mutationData.js';
+import {
+  generateMutants,
+  evaluateMutants,
+  computeMutationScore,
+  runTestSuite,
+} from '../utils/mutation.js';
+import { createCloudIntegrationClient } from '../utils/cloudIntegration.js';
+
+const DEFAULT_OPERATORS = ['AOR', 'ROR', 'LOR', 'UOI'];
+const STORAGE_KEY = 'stvisual.syntaxTests.v1';
+const SAVE_DEBOUNCE_MS = 600;
+
+function loadLocalPrograms() {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveLocalPrograms(programs) {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(programs));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+function defaultProgramSnapshot(ex) {
+  return {
+    params: ex.params.join(', '),
+    body: ex.body,
+    tests: ex.tests.map((t) => ({
+      id: t.id,
+      argsText: t.args.map((a) => JSON.stringify(a)).join(', '),
+      expectedText: JSON.stringify(t.expected),
+    })),
+  };
+}
+
+function escapeHtml(value = '') {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function formatValue(v) {
+  if (v === undefined) return 'undefined';
+  if (typeof v === 'string') return JSON.stringify(v);
+  try { return JSON.stringify(v); } catch { return String(v); }
+}
+
+function parseTestArgs(text) {
+  // 用 JSON.parse 包成陣列，允許使用者輸入 `1, 2, "x"`。
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  try {
+    return JSON.parse(`[${trimmed}]`);
+  } catch (err) {
+    throw new Error(`參數解析失敗：${err.message}`);
+  }
+}
+
+function parseExpected(text) {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed; // 視為字串字面值
+  }
+}
+
+export function createSyntaxCoverageExplorer() {
+  const root = document.createElement('div');
+  root.className = 'syntax-coverage';
+  root.dataset.testid = 'syntax-coverage';
+
+  const initial = programExamples[0];
+  const localPrograms = loadLocalPrograms();
+  const initialSnapshot = localPrograms[initial.id] || defaultProgramSnapshot(initial);
+
+  const state = {
+    exampleId: initial.id,
+    params: initialSnapshot.params,
+    body: initialSnapshot.body,
+    operators: new Set(DEFAULT_OPERATORS),
+    tests: initialSnapshot.tests.map((t) => ({ ...t })),
+    programs: localPrograms,
+    mutants: [],
+    suiteResults: [],
+    parsedTests: [],
+    parsedParams: [],
+    score: { total: 0, killed: 0, live: 0, equivalent: 0, score: 0 },
+    error: null,
+    selectedMutantId: null,
+    cloudUser: null,
+    cloudStatus: 'idle', // 'idle' | 'syncing' | 'synced' | 'error'
+    cloudMessage: '',
+  };
+
+  let cloudClient = null;
+  try {
+    cloudClient = createCloudIntegrationClient();
+  } catch {
+    cloudClient = null;
+  }
+
+  function snapshotCurrent() {
+    return {
+      params: state.params,
+      body: state.body,
+      tests: state.tests.map((t) => ({
+        id: t.id,
+        argsText: t.argsText,
+        expectedText: t.expectedText,
+      })),
+    };
+  }
+
+  function persistCurrent() {
+    state.programs[state.exampleId] = snapshotCurrent();
+    saveLocalPrograms(state.programs);
+    pushToCloud();
+  }
+
+  let saveTimer = null;
+  let pendingSave = null;
+  function pushToCloud() {
+    if (!cloudClient || !state.cloudUser || typeof cloudClient.saveSyntaxTests !== 'function') return;
+    if (saveTimer) clearTimeout(saveTimer);
+    state.cloudStatus = 'syncing';
+    state.cloudMessage = '';
+    updateCloudIndicator();
+    pendingSave = new Promise((resolve) => {
+      saveTimer = setTimeout(async () => {
+        saveTimer = null;
+        try {
+          await cloudClient.saveSyntaxTests(state.cloudUser.uid, state.programs);
+          state.cloudStatus = 'synced';
+          state.cloudMessage = '已同步到雲端';
+        } catch (err) {
+          state.cloudStatus = 'error';
+          state.cloudMessage = `雲端儲存失敗：${err?.message || err}`;
+        }
+        updateCloudIndicator();
+        resolve();
+        pendingSave = null;
+      }, SAVE_DEBOUNCE_MS);
+    });
+  }
+
+  async function flushPendingSave() {
+    if (!pendingSave) return;
+    // 提前觸發現在正在等待的 timer。
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+      try {
+        await cloudClient.saveSyntaxTests(state.cloudUser.uid, state.programs);
+      } catch {
+        /* ignore: 下一輪 reload 會重試 */
+      }
+    } else {
+      await pendingSave;
+    }
+    pendingSave = null;
+  }
+
+  function updateCloudIndicator() {
+    const node = root.querySelector('[data-testid="syntax-cloud-indicator"]');
+    if (!node) return;
+    node.dataset.status = state.cloudStatus;
+    node.textContent = cloudIndicatorText();
+  }
+
+  function cloudIndicatorText() {
+    if (!state.cloudUser) return '';
+    switch (state.cloudStatus) {
+      case 'syncing': return '☁ 正在同步…';
+      case 'synced': return `☁ ${state.cloudMessage || '已同步到雲端'}`;
+      case 'error': return `☁ ${state.cloudMessage || '同步失敗'}`;
+      default: return `☁ 已連結 ${state.cloudUser.email || state.cloudUser.uid}`;
+    }
+  }
+
+  async function reloadFromCloud({ force = false } = {}) {
+    if (!cloudClient || !state.cloudUser) return;
+    if (typeof cloudClient.loadSyntaxTests !== 'function') return;
+    // 先 flush 任何尚未寫出的本地編輯，避免被雲端舊資料覆蓋。
+    await flushPendingSave();
+    state.cloudStatus = 'syncing';
+    state.cloudMessage = force ? '重新从雲端讀取…' : '';
+    updateCloudIndicator();
+    try {
+      const remote = await cloudClient.loadSyntaxTests(state.cloudUser.uid);
+      const remoteObj = remote && typeof remote === 'object' ? remote : {};
+      const localOnly = Object.keys(state.programs).filter((k) => !(k in remoteObj));
+      // 雲端資料為主，仅保留本地獨有的範例。
+      const merged = { ...remoteObj };
+      localOnly.forEach((k) => { merged[k] = state.programs[k]; });
+      state.programs = merged;
+      saveLocalPrograms(state.programs);
+      const current = state.programs[state.exampleId];
+      if (current) {
+        state.params = current.params ?? state.params;
+        state.body = current.body ?? state.body;
+        state.tests = Array.isArray(current.tests)
+          ? current.tests.map((t) => ({ ...t }))
+          : state.tests;
+        state.selectedMutantId = null;
+      }
+      state.cloudStatus = 'synced';
+      state.cloudMessage = '已從雲端載入';
+      render();
+      // 只有本地有雲端缺少的範例才回寫，避免覆蓋他端更新。
+      if (localOnly.length > 0) pushToCloud();
+    } catch (err) {
+      state.cloudStatus = 'error';
+      state.cloudMessage = `雲端讀取失敗：${err?.message || err}`;
+      updateCloudIndicator();
+    }
+  }
+
+  function recompute() {
+    state.error = null;
+    let params;
+    try {
+      params = state.params.split(',').map((s) => s.trim()).filter(Boolean);
+    } catch (err) {
+      state.error = `參數解析失敗：${err.message}`;
+      return;
+    }
+
+    let parsedTests;
+    try {
+      parsedTests = state.tests.map((t) => ({
+        id: t.id,
+        args: parseTestArgs(t.argsText),
+        expected: parseExpected(t.expectedText),
+      }));
+    } catch (err) {
+      state.error = err.message;
+      return;
+    }
+
+    let suiteResults;
+    try {
+      suiteResults = runTestSuite(params, state.body, parsedTests);
+    } catch (err) {
+      state.error = `原程式編譯/執行失敗：${err.message}`;
+      return;
+    }
+
+    const operators = [...state.operators];
+    const generated = generateMutants(state.body, operators);
+    const evaluated = evaluateMutants(params, state.body, parsedTests, generated);
+
+    // 保留使用者標為 equivalent 的設定（依 id 對應；id 重生時不保留）。
+    const prevEquivalent = new Set(
+      state.mutants.filter((m) => m.status === 'equivalent').map((m) => m.id),
+    );
+    const finalMutants = evaluated.map((m) =>
+      prevEquivalent.has(m.id) ? { ...m, status: 'equivalent', killedBy: [] } : m,
+    );
+
+    state.suiteResults = suiteResults;
+    state.parsedTests = parsedTests;
+    state.parsedParams = params;
+    state.mutants = finalMutants;
+    state.score = computeMutationScore(finalMutants);
+    if (!state.mutants.find((m) => m.id === state.selectedMutantId)) {
+      state.selectedMutantId = finalMutants[0]?.id || null;
+    }
+  }
+
+  function loadExample(id) {
+    const ex = programExamples.find((e) => e.id === id);
+    if (!ex) return;
+    state.exampleId = id;
+    const snap = state.programs[id] || defaultProgramSnapshot(ex);
+    state.params = snap.params;
+    state.body = snap.body;
+    state.tests = snap.tests.map((t) => ({ ...t }));
+    state.selectedMutantId = null;
+  }
+
+  function render() {
+    recompute();
+
+    const exampleButtons = programExamples.map((ex) => `
+      <button
+        type="button"
+        class="syntax-example-btn${state.exampleId === ex.id ? ' active' : ''}"
+        data-example="${ex.id}"
+        title="${escapeHtml(ex.description)}"
+        data-testid="syntax-example-${ex.id}"
+      >${escapeHtml(ex.name)}</button>
+    `).join('');
+
+    const operatorButtons = mutationOperators.map((op) => `
+      <label class="syntax-op-btn${state.operators.has(op.id) ? ' active' : ''}" title="${escapeHtml(op.desc)}">
+        <input type="checkbox" data-operator="${op.id}" ${state.operators.has(op.id) ? 'checked' : ''} />
+        <span>${escapeHtml(op.id)}</span>
+      </label>
+    `).join('');
+
+    const selectedMutant = state.mutants.find((m) => m.id === state.selectedMutantId) || null;
+    let mutantSuiteResults = null;
+    if (selectedMutant) {
+      try {
+        mutantSuiteResults = runTestSuite(
+          state.parsedParams,
+          selectedMutant.source,
+          state.parsedTests,
+        );
+      } catch {
+        mutantSuiteResults = state.parsedTests.map(() => ({
+          outcome: { ok: false, error: 'compile error' },
+        }));
+      }
+    }
+
+    const showMutantCol = !!selectedMutant;
+    const killedByIds = selectedMutant ? new Set(selectedMutant.killedBy) : new Set();
+
+    const testRows = state.tests.map((t, i) => {
+      const result = state.suiteResults[i];
+      const passClass = result?.passed ? 'pass' : (result ? 'fail' : '');
+      const actual = result?.outcome.ok ? formatValue(result.outcome.value) : `⚠ ${result?.outcome.error || ''}`;
+
+      let mutantCell = '';
+      let killClass = '';
+      if (showMutantCol) {
+        const mr = mutantSuiteResults?.[i];
+        const mutantActual = mr?.outcome.ok
+          ? formatValue(mr.outcome.value)
+          : `⚠ ${mr?.outcome.error || ''}`;
+        const isKilled = killedByIds.has(t.id);
+        killClass = isKilled ? 'killed-by' : 'survived-by';
+        mutantCell = `<td class="syntax-test-mutant ${killClass}"><code>${escapeHtml(mutantActual)}</code>${isKilled ? '<span class="syntax-test-kill-badge">killed</span>' : ''}</td>`;
+      }
+
+      return `
+        <tr class="syntax-test-row ${passClass} ${killClass}" data-testid="syntax-test-row-${t.id}">
+          <td><code>${escapeHtml(t.id)}</code></td>
+          <td><input type="text" class="syntax-test-input" data-test-args="${t.id}" value="${escapeHtml(t.argsText)}" /></td>
+          <td><input type="text" class="syntax-test-input" data-test-expected="${t.id}" value="${escapeHtml(t.expectedText)}" /></td>
+          <td><code>${escapeHtml(actual)}</code></td>
+          ${mutantCell}
+          <td>
+            <button type="button" class="syntax-test-remove" data-remove-test="${t.id}" aria-label="移除">×</button>
+          </td>
+        </tr>
+      `;
+    }).join('');
+
+    const mutantHeaderCol = showMutantCol
+      ? `<th class="syntax-test-mutant-head">mutant actual${selectedMutant ? `<br><small>(${escapeHtml(selectedMutant.id)})</small>` : ''}</th>`
+      : '';
+
+    // 群組顯示 mutants
+    const grouped = new Map();
+    state.mutants.forEach((m) => {
+      if (!grouped.has(m.operator)) grouped.set(m.operator, []);
+      grouped.get(m.operator).push(m);
+    });
+
+    const mutantList = [...grouped.entries()].map(([op, list]) => {
+      const items = list.map((m) => `
+        <li class="syntax-mutant-item ${m.status}${state.selectedMutantId === m.id ? ' selected' : ''}" data-mutant-id="${m.id}" data-testid="syntax-mutant-${m.id}">
+          <span class="syntax-mutant-id">${escapeHtml(m.id)}</span>
+          <span class="syntax-mutant-loc">L${m.line}:${m.col}</span>
+          <span class="syntax-mutant-diff"><code>${escapeHtml(m.original)}</code> → <code>${escapeHtml(m.mutated)}</code></span>
+          <span class="syntax-mutant-status">${escapeHtml(m.status)}</span>
+        </li>
+      `).join('');
+      return `
+        <div class="syntax-mutant-group" data-testid="syntax-mutant-group-${op}">
+          <h5>${escapeHtml(op)}（${list.length}）</h5>
+          <ul>${items}</ul>
+        </div>
+      `;
+    }).join('');
+
+    const selected = selectedMutant;
+    const selectedDetail = selected ? `
+      <div class="syntax-mutant-detail" data-testid="syntax-mutant-detail">
+        <h4>${escapeHtml(selected.id)} <span class="syntax-mutant-op">${escapeHtml(selected.operator)}</span></h4>
+        <p class="syntax-mutant-meta">L${selected.line}:${selected.col} · 狀態：<strong>${escapeHtml(selected.status)}</strong></p>
+        <pre class="syntax-mutant-source"><code>${escapeHtml(selected.source)}</code></pre>
+        <p class="syntax-mutant-killed">
+          ${selected.killedBy.length
+            ? `被以下 test killed：${selected.killedBy.map((id) => `<code>${escapeHtml(id)}</code>`).join(', ')}`
+            : '此 mutant 仍 live；可手動標為 equivalent。'}
+        </p>
+        <div class="syntax-mutant-actions">
+          <button type="button" data-toggle-equivalent="${selected.id}">
+            ${selected.status === 'equivalent' ? '取消標記為 equivalent' : '標記為 equivalent'}
+          </button>
+        </div>
+      </div>
+    ` : '<p class="syntax-mutant-empty">點選左側 mutant 查看細節。</p>';
+
+    const scorePct = Math.round(state.score.score * 100);
+
+    root.innerHTML = `
+      <div class="syntax-toolbar">
+        <div class="syntax-examples" role="tablist">${exampleButtons}</div>
+        <div class="syntax-operators" data-testid="syntax-operators">${operatorButtons}</div>
+      </div>
+      <div class="syntax-cloud-bar">
+        <span
+          class="syntax-cloud-indicator"
+          data-testid="syntax-cloud-indicator"
+          data-status="${state.cloudStatus}"
+        >${escapeHtml(cloudIndicatorText())}</span>
+        <span class="syntax-cloud-actions">
+          ${state.cloudUser ? '<button type="button" class="syntax-reload-btn" data-testid="syntax-cloud-reload">↻ 從雲端重新載入</button>' : ''}
+          <button type="button" class="syntax-reset-btn" data-testid="syntax-reset-program">↺ 還原此範例預設</button>
+        </span>
+      </div>
+
+      <div class="syntax-grid">
+        <section class="syntax-program">
+          <label class="syntax-label">參數（逗號分隔）</label>
+          <input type="text" class="syntax-params" data-testid="syntax-params" value="${escapeHtml(state.params)}" />
+          <label class="syntax-label">函式內容</label>
+          <textarea class="syntax-body" rows="8" data-testid="syntax-body">${escapeHtml(state.body)}</textarea>
+        </section>
+
+        <section class="syntax-tests">
+          <header class="syntax-tests-header">
+            <h4>測試案例</h4>
+            <button type="button" class="syntax-test-add" data-testid="syntax-test-add">＋ 新增 test</button>
+          </header>
+          <table class="syntax-test-table" data-testid="syntax-test-table">
+            <thead>
+              <tr>
+                <th>id</th>
+                <th>args（JSON 元素，逗號分隔）</th>
+                <th>expected（JSON）</th>
+                <th>actual</th>
+                ${mutantHeaderCol}
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>${testRows}</tbody>
+          </table>
+        </section>
+      </div>
+
+      ${state.error ? `<p class="syntax-error" data-testid="syntax-error">${escapeHtml(state.error)}</p>` : ''}
+
+      <section class="syntax-score-section">
+        <div class="syntax-score-bar">
+          <div class="syntax-score-fill" style="width:${scorePct}%" data-testid="syntax-score-fill"></div>
+        </div>
+        <p class="syntax-score-stats" data-testid="syntax-score-stats">
+          Mutation Score：<strong>${scorePct}%</strong>
+          <span class="syntax-divider">·</span>
+          總數 ${state.score.total}
+          <span class="syntax-divider">·</span>
+          killed <strong>${state.score.killed}</strong>
+          <span class="syntax-divider">·</span>
+          live <strong>${state.score.live}</strong>
+          <span class="syntax-divider">·</span>
+          equivalent <strong>${state.score.equivalent}</strong>
+        </p>
+      </section>
+
+      <section class="syntax-mutant-section">
+        <div class="syntax-mutant-list" data-testid="syntax-mutant-list">${mutantList || '<p class="syntax-mutant-empty">無 mutants（請選擇至少一個 operator）。</p>'}</div>
+        ${selectedDetail}
+      </section>
+    `;
+
+    bindEvents();
+  }
+
+  function bindEvents() {
+    root.querySelectorAll('[data-example]').forEach((btn) => {
+      btn.addEventListener('click', () => { loadExample(btn.dataset.example); render(); });
+    });
+
+    const resetBtn = root.querySelector('[data-testid="syntax-reset-program"]');
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        const ex = programExamples.find((e) => e.id === state.exampleId);
+        if (!ex) return;
+        const snap = defaultProgramSnapshot(ex);
+        state.params = snap.params;
+        state.body = snap.body;
+        state.tests = snap.tests.map((t) => ({ ...t }));
+        state.selectedMutantId = null;
+        persistCurrent();
+        render();
+      });
+    }
+
+    const reloadBtn = root.querySelector('[data-testid="syntax-cloud-reload"]');
+    if (reloadBtn) {
+      reloadBtn.addEventListener('click', () => { reloadFromCloud({ force: true }); });
+    }
+
+    root.querySelectorAll('[data-operator]').forEach((cb) => {
+      cb.addEventListener('change', () => {
+        const op = cb.dataset.operator;
+        if (cb.checked) state.operators.add(op);
+        else state.operators.delete(op);
+        render();
+      });
+    });
+
+    const params = root.querySelector('[data-testid="syntax-params"]');
+    if (params) {
+      params.addEventListener('input', (e) => { state.params = e.target.value; persistCurrent(); });
+      params.addEventListener('change', (e) => { state.params = e.target.value; persistCurrent(); render(); });
+    }
+
+    const body = root.querySelector('[data-testid="syntax-body"]');
+    if (body) {
+      body.addEventListener('input', (e) => { state.body = e.target.value; persistCurrent(); });
+      body.addEventListener('change', (e) => { state.body = e.target.value; persistCurrent(); render(); });
+    }
+
+    root.querySelectorAll('[data-test-args]').forEach((input) => {
+      input.addEventListener('input', (e) => {
+        const id = input.dataset.testArgs;
+        const t = state.tests.find((x) => x.id === id);
+        if (t) t.argsText = e.target.value;
+        persistCurrent();
+      });
+      input.addEventListener('change', (e) => {
+        const id = input.dataset.testArgs;
+        const t = state.tests.find((x) => x.id === id);
+        if (t) t.argsText = e.target.value;
+        persistCurrent();
+        render();
+      });
+    });
+
+    root.querySelectorAll('[data-test-expected]').forEach((input) => {
+      input.addEventListener('input', (e) => {
+        const id = input.dataset.testExpected;
+        const t = state.tests.find((x) => x.id === id);
+        if (t) t.expectedText = e.target.value;
+        persistCurrent();
+      });
+      input.addEventListener('change', (e) => {
+        const id = input.dataset.testExpected;
+        const t = state.tests.find((x) => x.id === id);
+        if (t) t.expectedText = e.target.value;
+        persistCurrent();
+        render();
+      });
+    });
+
+    root.querySelectorAll('[data-remove-test]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        state.tests = state.tests.filter((t) => t.id !== btn.dataset.removeTest);
+        persistCurrent();
+        render();
+      });
+    });
+
+    const addBtn = root.querySelector('[data-testid="syntax-test-add"]');
+    if (addBtn) {
+      addBtn.addEventListener('click', () => {
+        const next = `t${state.tests.length + 1}`;
+        state.tests.push({ id: next, argsText: '', expectedText: '' });
+        persistCurrent();
+        render();
+      });
+    }
+
+    root.querySelectorAll('[data-mutant-id]').forEach((li) => {
+      li.addEventListener('click', () => {
+        state.selectedMutantId = li.dataset.mutantId;
+        render();
+      });
+    });
+
+    root.querySelectorAll('[data-toggle-equivalent]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const m = state.mutants.find((x) => x.id === btn.dataset.toggleEquivalent);
+        if (!m) return;
+        m.status = m.status === 'equivalent' ? (m.killedBy.length ? 'killed' : 'live') : 'equivalent';
+        state.score = computeMutationScore(state.mutants);
+        render();
+      });
+    });
+  }
+
+  render();
+
+  if (cloudClient && typeof cloudClient.subscribeAuthState === 'function') {
+    cloudClient.subscribeAuthState(async (user) => {
+      state.cloudUser = user || null;
+      if (!user) {
+        state.cloudStatus = 'idle';
+        state.cloudMessage = '';
+        render();
+        return;
+      }
+      await reloadFromCloud();
+    });
+
+    // 視窗切回前景時自動從雲端重新拽取，讓多裝置之間可以同步。
+    if (typeof globalThis.document?.addEventListener === 'function') {
+      globalThis.document.addEventListener('visibilitychange', () => {
+        if (globalThis.document.visibilityState === 'visible' && state.cloudUser) {
+          reloadFromCloud();
+        }
+      });
+    }
+
+    // 離開頁面前 flush 任何 pending save，避免遺失。
+    if (typeof globalThis.addEventListener === 'function') {
+      globalThis.addEventListener('pagehide', () => { flushPendingSave(); });
+      globalThis.addEventListener('beforeunload', () => { flushPendingSave(); });
+    }
+  }
+
+  return root;
+}

--- a/src/data/mutationData.js
+++ b/src/data/mutationData.js
@@ -1,0 +1,60 @@
+// Syntax-Based Testing 範例與設定。
+// MVP：Program Mutation 用的小型 JavaScript 函式 + 對應 test set。
+
+export const mutationOperators = [
+  { id: 'AOR', label: 'Arithmetic Operator Replacement', desc: '替換 + - * / % 等算術運算子。' },
+  { id: 'ROR', label: 'Relational Operator Replacement', desc: '替換 < <= > >= == != === !==。' },
+  { id: 'LOR', label: 'Logical Operator Replacement', desc: '替換 && 與 ||。' },
+  { id: 'COR', label: 'Conditional Operator Replacement', desc: '替換條件運算子（與 LOR 相同集合）。' },
+  { id: 'UOI', label: 'Unary Operator Insertion', desc: '在識別字前插入 ! 或 -。' },
+  { id: 'ABS', label: 'Absolute Value Insertion', desc: '把識別字包成 Math.abs(x) 或 -(x)。' },
+];
+
+export const programExamples = [
+  {
+    id: 'max',
+    name: 'max(a, b)',
+    params: ['a', 'b'],
+    body: 'return a > b ? a : b;',
+    description: '回傳兩數中較大者。',
+    tests: [
+      { id: 't1', args: [3, 5], expected: 5 },
+      { id: 't2', args: [7, 2], expected: 7 },
+      { id: 't3', args: [4, 4], expected: 4 },
+      { id: 't4', args: [-1, -3], expected: -1 },
+    ],
+  },
+  {
+    id: 'isLeapYear',
+    name: 'isLeapYear(y)',
+    params: ['y'],
+    body: 'return (y % 4 === 0 && y % 100 !== 0) || (y % 400 === 0);',
+    description: '判斷是否為閏年。',
+    tests: [
+      { id: 't1', args: [2024], expected: true },
+      { id: 't2', args: [1900], expected: false },
+      { id: 't3', args: [2000], expected: true },
+      { id: 't4', args: [2023], expected: false },
+    ],
+  },
+  {
+    id: 'triangle',
+    name: 'triangle(a, b, c)',
+    params: ['a', 'b', 'c'],
+    body: [
+      'if (a <= 0 || b <= 0 || c <= 0) return "invalid";',
+      'if (a + b <= c || a + c <= b || b + c <= a) return "invalid";',
+      'if (a === b && b === c) return "equilateral";',
+      'if (a === b || b === c || a === c) return "isosceles";',
+      'return "scalene";',
+    ].join('\n'),
+    description: '依三邊長判斷三角形類型。',
+    tests: [
+      { id: 't1', args: [3, 3, 3], expected: 'equilateral' },
+      { id: 't2', args: [3, 3, 4], expected: 'isosceles' },
+      { id: 't3', args: [3, 4, 5], expected: 'scalene' },
+      { id: 't4', args: [1, 2, 5], expected: 'invalid' },
+      { id: 't5', args: [0, 1, 1], expected: 'invalid' },
+    ],
+  },
+];

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -3224,6 +3224,10 @@ Content-Type: ${file.type || "application/octet-stream"}\r
     const auth = firebase.auth(app);
     const db = firebase.firestore(app);
     let driveAccessToken = null;
+    function snapshotExists(snapshot) {
+      if (!snapshot) return false;
+      return typeof snapshot.exists === "function" ? snapshot.exists() : Boolean(snapshot.exists);
+    }
     return {
       isConfigured,
       missingKeys,
@@ -3249,7 +3253,7 @@ Content-Type: ${file.type || "application/octet-stream"}\r
       },
       async loadSettings(userId) {
         const snapshot = await db.collection("users").doc(userId).collection("settings").doc("default").get();
-        if (!snapshot.exists()) {
+        if (!snapshotExists(snapshot)) {
           return null;
         }
         return snapshot.data();
@@ -3262,13 +3266,25 @@ Content-Type: ${file.type || "application/octet-stream"}\r
       },
       async loadLogicRecent(userId) {
         const snapshot = await db.collection("users").doc(userId).collection("settings").doc("logicCoverage").get();
-        if (!snapshot.exists()) return [];
+        if (!snapshotExists(snapshot)) return [];
         const data = snapshot.data() || {};
         return Array.isArray(data.recentPredicates) ? data.recentPredicates.filter((p) => typeof p === "string") : [];
       },
       async saveLogicRecent(userId, list) {
         await db.collection("users").doc(userId).collection("settings").doc("logicCoverage").set({
           recentPredicates: Array.isArray(list) ? list.filter((p) => typeof p === "string") : [],
+          updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+        }, { merge: true });
+      },
+      async loadSyntaxTests(userId) {
+        const snapshot = await db.collection("users").doc(userId).collection("settings").doc("syntaxCoverage").get();
+        if (!snapshotExists(snapshot)) return {};
+        const data = snapshot.data() || {};
+        return data.programs && typeof data.programs === "object" ? data.programs : {};
+      },
+      async saveSyntaxTests(userId, programs) {
+        await db.collection("users").doc(userId).collection("settings").doc("syntaxCoverage").set({
+          programs: programs && typeof programs === "object" ? programs : {},
           updatedAt: firebase.firestore.FieldValue.serverTimestamp()
         }, { merge: true });
       },
@@ -4240,12 +4256,957 @@ Content-Type: ${file.type || "application/octet-stream"}\r
     return root2;
   }
 
+  // src/data/mutationData.js
+  var mutationOperators = [
+    { id: "AOR", label: "Arithmetic Operator Replacement", desc: "\u66FF\u63DB + - * / % \u7B49\u7B97\u8853\u904B\u7B97\u5B50\u3002" },
+    { id: "ROR", label: "Relational Operator Replacement", desc: "\u66FF\u63DB < <= > >= == != === !==\u3002" },
+    { id: "LOR", label: "Logical Operator Replacement", desc: "\u66FF\u63DB && \u8207 ||\u3002" },
+    { id: "COR", label: "Conditional Operator Replacement", desc: "\u66FF\u63DB\u689D\u4EF6\u904B\u7B97\u5B50\uFF08\u8207 LOR \u76F8\u540C\u96C6\u5408\uFF09\u3002" },
+    { id: "UOI", label: "Unary Operator Insertion", desc: "\u5728\u8B58\u5225\u5B57\u524D\u63D2\u5165 ! \u6216 -\u3002" },
+    { id: "ABS", label: "Absolute Value Insertion", desc: "\u628A\u8B58\u5225\u5B57\u5305\u6210 Math.abs(x) \u6216 -(x)\u3002" }
+  ];
+  var programExamples = [
+    {
+      id: "max",
+      name: "max(a, b)",
+      params: ["a", "b"],
+      body: "return a > b ? a : b;",
+      description: "\u56DE\u50B3\u5169\u6578\u4E2D\u8F03\u5927\u8005\u3002",
+      tests: [
+        { id: "t1", args: [3, 5], expected: 5 },
+        { id: "t2", args: [7, 2], expected: 7 },
+        { id: "t3", args: [4, 4], expected: 4 },
+        { id: "t4", args: [-1, -3], expected: -1 }
+      ]
+    },
+    {
+      id: "isLeapYear",
+      name: "isLeapYear(y)",
+      params: ["y"],
+      body: "return (y % 4 === 0 && y % 100 !== 0) || (y % 400 === 0);",
+      description: "\u5224\u65B7\u662F\u5426\u70BA\u958F\u5E74\u3002",
+      tests: [
+        { id: "t1", args: [2024], expected: true },
+        { id: "t2", args: [1900], expected: false },
+        { id: "t3", args: [2e3], expected: true },
+        { id: "t4", args: [2023], expected: false }
+      ]
+    },
+    {
+      id: "triangle",
+      name: "triangle(a, b, c)",
+      params: ["a", "b", "c"],
+      body: [
+        'if (a <= 0 || b <= 0 || c <= 0) return "invalid";',
+        'if (a + b <= c || a + c <= b || b + c <= a) return "invalid";',
+        'if (a === b && b === c) return "equilateral";',
+        'if (a === b || b === c || a === c) return "isosceles";',
+        'return "scalene";'
+      ].join("\n"),
+      description: "\u4F9D\u4E09\u908A\u9577\u5224\u65B7\u4E09\u89D2\u5F62\u985E\u578B\u3002",
+      tests: [
+        { id: "t1", args: [3, 3, 3], expected: "equilateral" },
+        { id: "t2", args: [3, 3, 4], expected: "isosceles" },
+        { id: "t3", args: [3, 4, 5], expected: "scalene" },
+        { id: "t4", args: [1, 2, 5], expected: "invalid" },
+        { id: "t5", args: [0, 1, 1], expected: "invalid" }
+      ]
+    }
+  ];
+
+  // src/utils/mutation.js
+  var OPERATORS = {
+    AOR: ["+", "-", "*", "/", "%"],
+    ROR: ["<", "<=", ">", ">=", "==", "!=", "===", "!=="],
+    LOR: ["&&", "||"],
+    COR: ["&&", "||"]
+    // 同 LOR，但與 ! 一同套用時為條件運算的補集
+  };
+  var SORTED = {
+    AOR: [...OPERATORS.AOR].sort((a, b) => b.length - a.length),
+    ROR: [...OPERATORS.ROR].sort((a, b) => b.length - a.length),
+    LOR: [...OPERATORS.LOR].sort((a, b) => b.length - a.length),
+    COR: [...OPERATORS.COR].sort((a, b) => b.length - a.length)
+  };
+  var ID_REGEX = /[A-Za-z_$][A-Za-z0-9_$]*/y;
+  function buildSkipMap(source) {
+    const skip = new Array(source.length).fill(false);
+    let i = 0;
+    while (i < source.length) {
+      const ch = source[i];
+      const next = source[i + 1];
+      if (ch === "/" && next === "/") {
+        while (i < source.length && source[i] !== "\n") {
+          skip[i] = true;
+          i += 1;
+        }
+      } else if (ch === "/" && next === "*") {
+        while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) {
+          skip[i] = true;
+          i += 1;
+        }
+        if (i < source.length) {
+          skip[i] = skip[i + 1] = true;
+          i += 2;
+        }
+      } else if (ch === '"' || ch === "'" || ch === "`") {
+        const quote = ch;
+        skip[i] = true;
+        i += 1;
+        while (i < source.length && source[i] !== quote) {
+          if (source[i] === "\\") {
+            skip[i] = skip[i + 1] = true;
+            i += 2;
+          } else {
+            skip[i] = true;
+            i += 1;
+          }
+        }
+        if (i < source.length) {
+          skip[i] = true;
+          i += 1;
+        }
+      } else {
+        i += 1;
+      }
+    }
+    return skip;
+  }
+  function lineColOf(source, index) {
+    let line = 1;
+    let col = 1;
+    for (let i = 0; i < index && i < source.length; i += 1) {
+      if (source[i] === "\n") {
+        line += 1;
+        col = 1;
+      } else {
+        col += 1;
+      }
+    }
+    return { line, col };
+  }
+  function applyReplacement(source, start, end, replacement) {
+    return source.slice(0, start) + replacement + source.slice(end);
+  }
+  function findOperatorOccurrences(source, operatorList, skip) {
+    const hits = [];
+    for (let i = 0; i < source.length; i += 1) {
+      if (skip[i]) continue;
+      for (const op of operatorList) {
+        if (i + op.length > source.length) continue;
+        if (source.slice(i, i + op.length) !== op) continue;
+        const before = source[i - 1] || "";
+        const after = source[i + op.length] || "";
+        if (op === "=" || op.endsWith("=")) {
+        }
+        if (after === "=" && op.length === 1 && "+-*/%".includes(op)) continue;
+        if (op === "*" && (before === "*" || after === "*")) continue;
+        if ((op === "||" || op === "&&") && after === "=") continue;
+        if (op === "<" && (after === "<" || before === "<")) continue;
+        if (op === ">" && (after === ">" || before === ">")) continue;
+        hits.push({ start: i, end: i + op.length, text: op });
+        i += op.length - 1;
+        break;
+      }
+    }
+    return hits;
+  }
+  function findIdentifierOccurrences(source, skip) {
+    const hits = [];
+    let i = 0;
+    while (i < source.length) {
+      if (skip[i]) {
+        i += 1;
+        continue;
+      }
+      ID_REGEX.lastIndex = i;
+      const m = ID_REGEX.exec(source);
+      if (m && m.index === i) {
+        const keywords = /* @__PURE__ */ new Set([
+          "true",
+          "false",
+          "null",
+          "undefined",
+          "return",
+          "if",
+          "else",
+          "for",
+          "while",
+          "do",
+          "switch",
+          "case",
+          "break",
+          "continue",
+          "function",
+          "var",
+          "let",
+          "const",
+          "new",
+          "typeof",
+          "in",
+          "of",
+          "this"
+        ]);
+        if (!keywords.has(m[0])) {
+          hits.push({ start: i, end: i + m[0].length, text: m[0] });
+        }
+        i += m[0].length;
+      } else {
+        i += 1;
+      }
+    }
+    return hits;
+  }
+  function generateForOperator(source, opName, skip, idCounter) {
+    const list = SORTED[opName];
+    if (!list) return [];
+    const hits = findOperatorOccurrences(source, list, skip);
+    const mutants = [];
+    hits.forEach((hit) => {
+      list.forEach((replacement) => {
+        if (replacement === hit.text) return;
+        const mutated = applyReplacement(source, hit.start, hit.end, replacement);
+        const { line, col } = lineColOf(source, hit.start);
+        mutants.push({
+          id: `M${idCounter.value++}`,
+          operator: opName,
+          line,
+          col,
+          original: hit.text,
+          mutated: replacement,
+          source: mutated,
+          status: "live",
+          killedBy: []
+        });
+      });
+    });
+    return mutants;
+  }
+  function generateUOI(source, skip, idCounter) {
+    const hits = findIdentifierOccurrences(source, skip);
+    const mutants = [];
+    hits.forEach((hit) => {
+      ["!", "-"].forEach((unary) => {
+        const mutated = applyReplacement(source, hit.start, hit.end, `${unary}${hit.text}`);
+        const { line, col } = lineColOf(source, hit.start);
+        mutants.push({
+          id: `M${idCounter.value++}`,
+          operator: "UOI",
+          line,
+          col,
+          original: hit.text,
+          mutated: `${unary}${hit.text}`,
+          source: mutated,
+          status: "live",
+          killedBy: []
+        });
+      });
+    });
+    return mutants;
+  }
+  function generateABS(source, skip, idCounter) {
+    const hits = findIdentifierOccurrences(source, skip);
+    const mutants = [];
+    hits.forEach((hit) => {
+      const variants = [
+        { suffix: "abs", text: `Math.abs(${hit.text})` },
+        { suffix: "neg", text: `(-(${hit.text}))` }
+      ];
+      variants.forEach(({ suffix, text }) => {
+        const mutated = applyReplacement(source, hit.start, hit.end, text);
+        const { line, col } = lineColOf(source, hit.start);
+        mutants.push({
+          id: `M${idCounter.value++}`,
+          operator: "ABS",
+          line,
+          col,
+          original: hit.text,
+          mutated: text,
+          source: mutated,
+          status: "live",
+          killedBy: [],
+          variant: suffix
+        });
+      });
+    });
+    return mutants;
+  }
+  function generateMutants(source, operators = ["AOR", "ROR", "LOR", "UOI"]) {
+    const skip = buildSkipMap(source);
+    const idCounter = { value: 1 };
+    const out = [];
+    operators.forEach((op) => {
+      if (op === "UOI") {
+        out.push(...generateUOI(source, skip, idCounter));
+      } else if (op === "ABS") {
+        out.push(...generateABS(source, skip, idCounter));
+      } else {
+        out.push(...generateForOperator(source, op, skip, idCounter));
+      }
+    });
+    return out;
+  }
+  function compileFunction(params, body) {
+    return new Function(...params, body);
+  }
+  function deepEqual(a, b) {
+    if (a === b) return true;
+    if (typeof a === "number" && typeof b === "number" && Number.isNaN(a) && Number.isNaN(b)) return true;
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) return false;
+      return a.every((v, i) => deepEqual(v, b[i]));
+    }
+    if (a && b && typeof a === "object" && typeof b === "object") {
+      const ak = Object.keys(a);
+      const bk = Object.keys(b);
+      if (ak.length !== bk.length) return false;
+      return ak.every((k) => deepEqual(a[k], b[k]));
+    }
+    return false;
+  }
+  function runOnce(fn, args) {
+    try {
+      const result = fn(...args);
+      return { ok: true, value: result };
+    } catch (err) {
+      return { ok: false, error: (err == null ? void 0 : err.message) || String(err) };
+    }
+  }
+  function runTestSuite(params, body, tests) {
+    const fn = compileFunction(params, body);
+    return tests.map((t) => {
+      const outcome = runOnce(fn, t.args);
+      const expected = t.expected;
+      const passed = outcome.ok && deepEqual(outcome.value, expected);
+      return { id: t.id, passed, outcome };
+    });
+  }
+  function evaluateMutants(params, body, tests, mutants) {
+    const baseFn = compileFunction(params, body);
+    const baseOutcomes = tests.map((t) => runOnce(baseFn, t.args));
+    return mutants.map((m) => {
+      let mutantFn;
+      try {
+        mutantFn = compileFunction(params, m.source);
+      } catch (err) {
+        return { ...m, status: "killed", killedBy: tests.map((t) => t.id), compileError: err == null ? void 0 : err.message };
+      }
+      const killedBy = [];
+      tests.forEach((t, i) => {
+        const base = baseOutcomes[i];
+        const mut = runOnce(mutantFn, t.args);
+        const sameOk = base.ok === mut.ok;
+        const sameValue = sameOk && (base.ok ? deepEqual(base.value, mut.value) : true);
+        if (!sameOk || !sameValue) killedBy.push(t.id);
+      });
+      return {
+        ...m,
+        status: killedBy.length ? "killed" : "live",
+        killedBy
+      };
+    });
+  }
+  function computeMutationScore(mutants) {
+    const total = mutants.length;
+    const equivalent = mutants.filter((m) => m.status === "equivalent").length;
+    const killed = mutants.filter((m) => m.status === "killed").length;
+    const live = mutants.filter((m) => m.status === "live").length;
+    const denominator = total - equivalent;
+    const score = denominator === 0 ? 1 : killed / denominator;
+    return { total, killed, live, equivalent, score };
+  }
+
+  // src/components/SyntaxCoverageExplorer.js
+  var DEFAULT_OPERATORS = ["AOR", "ROR", "LOR", "UOI"];
+  var STORAGE_KEY = "stvisual.syntaxTests.v1";
+  var SAVE_DEBOUNCE_MS = 600;
+  function loadLocalPrograms() {
+    var _a;
+    try {
+      const raw = (_a = globalThis.localStorage) == null ? void 0 : _a.getItem(STORAGE_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  function saveLocalPrograms(programs) {
+    var _a;
+    try {
+      (_a = globalThis.localStorage) == null ? void 0 : _a.setItem(STORAGE_KEY, JSON.stringify(programs));
+    } catch {
+    }
+  }
+  function defaultProgramSnapshot(ex) {
+    return {
+      params: ex.params.join(", "),
+      body: ex.body,
+      tests: ex.tests.map((t) => ({
+        id: t.id,
+        argsText: t.args.map((a) => JSON.stringify(a)).join(", "),
+        expectedText: JSON.stringify(t.expected)
+      }))
+    };
+  }
+  function escapeHtml3(value = "") {
+    return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+  }
+  function formatValue(v) {
+    if (v === void 0) return "undefined";
+    if (typeof v === "string") return JSON.stringify(v);
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  }
+  function parseTestArgs(text) {
+    const trimmed = text.trim();
+    if (!trimmed) return [];
+    try {
+      return JSON.parse(`[${trimmed}]`);
+    } catch (err) {
+      throw new Error(`\u53C3\u6578\u89E3\u6790\u5931\u6557\uFF1A${err.message}`);
+    }
+  }
+  function parseExpected(text) {
+    const trimmed = text.trim();
+    if (!trimmed) return void 0;
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+  function createSyntaxCoverageExplorer() {
+    var _a;
+    const root2 = document.createElement("div");
+    root2.className = "syntax-coverage";
+    root2.dataset.testid = "syntax-coverage";
+    const initial = programExamples[0];
+    const localPrograms = loadLocalPrograms();
+    const initialSnapshot = localPrograms[initial.id] || defaultProgramSnapshot(initial);
+    const state = {
+      exampleId: initial.id,
+      params: initialSnapshot.params,
+      body: initialSnapshot.body,
+      operators: new Set(DEFAULT_OPERATORS),
+      tests: initialSnapshot.tests.map((t) => ({ ...t })),
+      programs: localPrograms,
+      mutants: [],
+      suiteResults: [],
+      parsedTests: [],
+      parsedParams: [],
+      score: { total: 0, killed: 0, live: 0, equivalent: 0, score: 0 },
+      error: null,
+      selectedMutantId: null,
+      cloudUser: null,
+      cloudStatus: "idle",
+      // 'idle' | 'syncing' | 'synced' | 'error'
+      cloudMessage: ""
+    };
+    let cloudClient = null;
+    try {
+      cloudClient = createCloudIntegrationClient();
+    } catch {
+      cloudClient = null;
+    }
+    function snapshotCurrent() {
+      return {
+        params: state.params,
+        body: state.body,
+        tests: state.tests.map((t) => ({
+          id: t.id,
+          argsText: t.argsText,
+          expectedText: t.expectedText
+        }))
+      };
+    }
+    function persistCurrent() {
+      state.programs[state.exampleId] = snapshotCurrent();
+      saveLocalPrograms(state.programs);
+      pushToCloud();
+    }
+    let saveTimer = null;
+    let pendingSave = null;
+    function pushToCloud() {
+      if (!cloudClient || !state.cloudUser || typeof cloudClient.saveSyntaxTests !== "function") return;
+      if (saveTimer) clearTimeout(saveTimer);
+      state.cloudStatus = "syncing";
+      state.cloudMessage = "";
+      updateCloudIndicator();
+      pendingSave = new Promise((resolve) => {
+        saveTimer = setTimeout(async () => {
+          saveTimer = null;
+          try {
+            await cloudClient.saveSyntaxTests(state.cloudUser.uid, state.programs);
+            state.cloudStatus = "synced";
+            state.cloudMessage = "\u5DF2\u540C\u6B65\u5230\u96F2\u7AEF";
+          } catch (err) {
+            state.cloudStatus = "error";
+            state.cloudMessage = `\u96F2\u7AEF\u5132\u5B58\u5931\u6557\uFF1A${(err == null ? void 0 : err.message) || err}`;
+          }
+          updateCloudIndicator();
+          resolve();
+          pendingSave = null;
+        }, SAVE_DEBOUNCE_MS);
+      });
+    }
+    async function flushPendingSave() {
+      if (!pendingSave) return;
+      if (saveTimer) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+        try {
+          await cloudClient.saveSyntaxTests(state.cloudUser.uid, state.programs);
+        } catch {
+        }
+      } else {
+        await pendingSave;
+      }
+      pendingSave = null;
+    }
+    function updateCloudIndicator() {
+      const node = root2.querySelector('[data-testid="syntax-cloud-indicator"]');
+      if (!node) return;
+      node.dataset.status = state.cloudStatus;
+      node.textContent = cloudIndicatorText();
+    }
+    function cloudIndicatorText() {
+      if (!state.cloudUser) return "";
+      switch (state.cloudStatus) {
+        case "syncing":
+          return "\u2601 \u6B63\u5728\u540C\u6B65\u2026";
+        case "synced":
+          return `\u2601 ${state.cloudMessage || "\u5DF2\u540C\u6B65\u5230\u96F2\u7AEF"}`;
+        case "error":
+          return `\u2601 ${state.cloudMessage || "\u540C\u6B65\u5931\u6557"}`;
+        default:
+          return `\u2601 \u5DF2\u9023\u7D50 ${state.cloudUser.email || state.cloudUser.uid}`;
+      }
+    }
+    async function reloadFromCloud({ force = false } = {}) {
+      var _a2, _b;
+      if (!cloudClient || !state.cloudUser) return;
+      if (typeof cloudClient.loadSyntaxTests !== "function") return;
+      await flushPendingSave();
+      state.cloudStatus = "syncing";
+      state.cloudMessage = force ? "\u91CD\u65B0\u4ECE\u96F2\u7AEF\u8B80\u53D6\u2026" : "";
+      updateCloudIndicator();
+      try {
+        const remote = await cloudClient.loadSyntaxTests(state.cloudUser.uid);
+        const remoteObj = remote && typeof remote === "object" ? remote : {};
+        const localOnly = Object.keys(state.programs).filter((k) => !(k in remoteObj));
+        const merged = { ...remoteObj };
+        localOnly.forEach((k) => {
+          merged[k] = state.programs[k];
+        });
+        state.programs = merged;
+        saveLocalPrograms(state.programs);
+        const current = state.programs[state.exampleId];
+        if (current) {
+          state.params = (_a2 = current.params) != null ? _a2 : state.params;
+          state.body = (_b = current.body) != null ? _b : state.body;
+          state.tests = Array.isArray(current.tests) ? current.tests.map((t) => ({ ...t })) : state.tests;
+          state.selectedMutantId = null;
+        }
+        state.cloudStatus = "synced";
+        state.cloudMessage = "\u5DF2\u5F9E\u96F2\u7AEF\u8F09\u5165";
+        render();
+        if (localOnly.length > 0) pushToCloud();
+      } catch (err) {
+        state.cloudStatus = "error";
+        state.cloudMessage = `\u96F2\u7AEF\u8B80\u53D6\u5931\u6557\uFF1A${(err == null ? void 0 : err.message) || err}`;
+        updateCloudIndicator();
+      }
+    }
+    function recompute() {
+      var _a2;
+      state.error = null;
+      let params;
+      try {
+        params = state.params.split(",").map((s) => s.trim()).filter(Boolean);
+      } catch (err) {
+        state.error = `\u53C3\u6578\u89E3\u6790\u5931\u6557\uFF1A${err.message}`;
+        return;
+      }
+      let parsedTests;
+      try {
+        parsedTests = state.tests.map((t) => ({
+          id: t.id,
+          args: parseTestArgs(t.argsText),
+          expected: parseExpected(t.expectedText)
+        }));
+      } catch (err) {
+        state.error = err.message;
+        return;
+      }
+      let suiteResults;
+      try {
+        suiteResults = runTestSuite(params, state.body, parsedTests);
+      } catch (err) {
+        state.error = `\u539F\u7A0B\u5F0F\u7DE8\u8B6F/\u57F7\u884C\u5931\u6557\uFF1A${err.message}`;
+        return;
+      }
+      const operators = [...state.operators];
+      const generated = generateMutants(state.body, operators);
+      const evaluated = evaluateMutants(params, state.body, parsedTests, generated);
+      const prevEquivalent = new Set(
+        state.mutants.filter((m) => m.status === "equivalent").map((m) => m.id)
+      );
+      const finalMutants = evaluated.map(
+        (m) => prevEquivalent.has(m.id) ? { ...m, status: "equivalent", killedBy: [] } : m
+      );
+      state.suiteResults = suiteResults;
+      state.parsedTests = parsedTests;
+      state.parsedParams = params;
+      state.mutants = finalMutants;
+      state.score = computeMutationScore(finalMutants);
+      if (!state.mutants.find((m) => m.id === state.selectedMutantId)) {
+        state.selectedMutantId = ((_a2 = finalMutants[0]) == null ? void 0 : _a2.id) || null;
+      }
+    }
+    function loadExample(id) {
+      const ex = programExamples.find((e) => e.id === id);
+      if (!ex) return;
+      state.exampleId = id;
+      const snap = state.programs[id] || defaultProgramSnapshot(ex);
+      state.params = snap.params;
+      state.body = snap.body;
+      state.tests = snap.tests.map((t) => ({ ...t }));
+      state.selectedMutantId = null;
+    }
+    function render() {
+      recompute();
+      const exampleButtons = programExamples.map((ex) => `
+      <button
+        type="button"
+        class="syntax-example-btn${state.exampleId === ex.id ? " active" : ""}"
+        data-example="${ex.id}"
+        title="${escapeHtml3(ex.description)}"
+        data-testid="syntax-example-${ex.id}"
+      >${escapeHtml3(ex.name)}</button>
+    `).join("");
+      const operatorButtons = mutationOperators.map((op) => `
+      <label class="syntax-op-btn${state.operators.has(op.id) ? " active" : ""}" title="${escapeHtml3(op.desc)}">
+        <input type="checkbox" data-operator="${op.id}" ${state.operators.has(op.id) ? "checked" : ""} />
+        <span>${escapeHtml3(op.id)}</span>
+      </label>
+    `).join("");
+      const selectedMutant = state.mutants.find((m) => m.id === state.selectedMutantId) || null;
+      let mutantSuiteResults = null;
+      if (selectedMutant) {
+        try {
+          mutantSuiteResults = runTestSuite(
+            state.parsedParams,
+            selectedMutant.source,
+            state.parsedTests
+          );
+        } catch {
+          mutantSuiteResults = state.parsedTests.map(() => ({
+            outcome: { ok: false, error: "compile error" }
+          }));
+        }
+      }
+      const showMutantCol = !!selectedMutant;
+      const killedByIds = selectedMutant ? new Set(selectedMutant.killedBy) : /* @__PURE__ */ new Set();
+      const testRows = state.tests.map((t, i) => {
+        const result = state.suiteResults[i];
+        const passClass = (result == null ? void 0 : result.passed) ? "pass" : result ? "fail" : "";
+        const actual = (result == null ? void 0 : result.outcome.ok) ? formatValue(result.outcome.value) : `\u26A0 ${(result == null ? void 0 : result.outcome.error) || ""}`;
+        let mutantCell = "";
+        let killClass = "";
+        if (showMutantCol) {
+          const mr = mutantSuiteResults == null ? void 0 : mutantSuiteResults[i];
+          const mutantActual = (mr == null ? void 0 : mr.outcome.ok) ? formatValue(mr.outcome.value) : `\u26A0 ${(mr == null ? void 0 : mr.outcome.error) || ""}`;
+          const isKilled = killedByIds.has(t.id);
+          killClass = isKilled ? "killed-by" : "survived-by";
+          mutantCell = `<td class="syntax-test-mutant ${killClass}"><code>${escapeHtml3(mutantActual)}</code>${isKilled ? '<span class="syntax-test-kill-badge">killed</span>' : ""}</td>`;
+        }
+        return `
+        <tr class="syntax-test-row ${passClass} ${killClass}" data-testid="syntax-test-row-${t.id}">
+          <td><code>${escapeHtml3(t.id)}</code></td>
+          <td><input type="text" class="syntax-test-input" data-test-args="${t.id}" value="${escapeHtml3(t.argsText)}" /></td>
+          <td><input type="text" class="syntax-test-input" data-test-expected="${t.id}" value="${escapeHtml3(t.expectedText)}" /></td>
+          <td><code>${escapeHtml3(actual)}</code></td>
+          ${mutantCell}
+          <td>
+            <button type="button" class="syntax-test-remove" data-remove-test="${t.id}" aria-label="\u79FB\u9664">\xD7</button>
+          </td>
+        </tr>
+      `;
+      }).join("");
+      const mutantHeaderCol = showMutantCol ? `<th class="syntax-test-mutant-head">mutant actual${selectedMutant ? `<br><small>(${escapeHtml3(selectedMutant.id)})</small>` : ""}</th>` : "";
+      const grouped = /* @__PURE__ */ new Map();
+      state.mutants.forEach((m) => {
+        if (!grouped.has(m.operator)) grouped.set(m.operator, []);
+        grouped.get(m.operator).push(m);
+      });
+      const mutantList = [...grouped.entries()].map(([op, list]) => {
+        const items = list.map((m) => `
+        <li class="syntax-mutant-item ${m.status}${state.selectedMutantId === m.id ? " selected" : ""}" data-mutant-id="${m.id}" data-testid="syntax-mutant-${m.id}">
+          <span class="syntax-mutant-id">${escapeHtml3(m.id)}</span>
+          <span class="syntax-mutant-loc">L${m.line}:${m.col}</span>
+          <span class="syntax-mutant-diff"><code>${escapeHtml3(m.original)}</code> \u2192 <code>${escapeHtml3(m.mutated)}</code></span>
+          <span class="syntax-mutant-status">${escapeHtml3(m.status)}</span>
+        </li>
+      `).join("");
+        return `
+        <div class="syntax-mutant-group" data-testid="syntax-mutant-group-${op}">
+          <h5>${escapeHtml3(op)}\uFF08${list.length}\uFF09</h5>
+          <ul>${items}</ul>
+        </div>
+      `;
+      }).join("");
+      const selected = selectedMutant;
+      const selectedDetail = selected ? `
+      <div class="syntax-mutant-detail" data-testid="syntax-mutant-detail">
+        <h4>${escapeHtml3(selected.id)} <span class="syntax-mutant-op">${escapeHtml3(selected.operator)}</span></h4>
+        <p class="syntax-mutant-meta">L${selected.line}:${selected.col} \xB7 \u72C0\u614B\uFF1A<strong>${escapeHtml3(selected.status)}</strong></p>
+        <pre class="syntax-mutant-source"><code>${escapeHtml3(selected.source)}</code></pre>
+        <p class="syntax-mutant-killed">
+          ${selected.killedBy.length ? `\u88AB\u4EE5\u4E0B test killed\uFF1A${selected.killedBy.map((id) => `<code>${escapeHtml3(id)}</code>`).join(", ")}` : "\u6B64 mutant \u4ECD live\uFF1B\u53EF\u624B\u52D5\u6A19\u70BA equivalent\u3002"}
+        </p>
+        <div class="syntax-mutant-actions">
+          <button type="button" data-toggle-equivalent="${selected.id}">
+            ${selected.status === "equivalent" ? "\u53D6\u6D88\u6A19\u8A18\u70BA equivalent" : "\u6A19\u8A18\u70BA equivalent"}
+          </button>
+        </div>
+      </div>
+    ` : '<p class="syntax-mutant-empty">\u9EDE\u9078\u5DE6\u5074 mutant \u67E5\u770B\u7D30\u7BC0\u3002</p>';
+      const scorePct = Math.round(state.score.score * 100);
+      root2.innerHTML = `
+      <div class="syntax-toolbar">
+        <div class="syntax-examples" role="tablist">${exampleButtons}</div>
+        <div class="syntax-operators" data-testid="syntax-operators">${operatorButtons}</div>
+      </div>
+      <div class="syntax-cloud-bar">
+        <span
+          class="syntax-cloud-indicator"
+          data-testid="syntax-cloud-indicator"
+          data-status="${state.cloudStatus}"
+        >${escapeHtml3(cloudIndicatorText())}</span>
+        <span class="syntax-cloud-actions">
+          ${state.cloudUser ? '<button type="button" class="syntax-reload-btn" data-testid="syntax-cloud-reload">\u21BB \u5F9E\u96F2\u7AEF\u91CD\u65B0\u8F09\u5165</button>' : ""}
+          <button type="button" class="syntax-reset-btn" data-testid="syntax-reset-program">\u21BA \u9084\u539F\u6B64\u7BC4\u4F8B\u9810\u8A2D</button>
+        </span>
+      </div>
+
+      <div class="syntax-grid">
+        <section class="syntax-program">
+          <label class="syntax-label">\u53C3\u6578\uFF08\u9017\u865F\u5206\u9694\uFF09</label>
+          <input type="text" class="syntax-params" data-testid="syntax-params" value="${escapeHtml3(state.params)}" />
+          <label class="syntax-label">\u51FD\u5F0F\u5167\u5BB9</label>
+          <textarea class="syntax-body" rows="8" data-testid="syntax-body">${escapeHtml3(state.body)}</textarea>
+        </section>
+
+        <section class="syntax-tests">
+          <header class="syntax-tests-header">
+            <h4>\u6E2C\u8A66\u6848\u4F8B</h4>
+            <button type="button" class="syntax-test-add" data-testid="syntax-test-add">\uFF0B \u65B0\u589E test</button>
+          </header>
+          <table class="syntax-test-table" data-testid="syntax-test-table">
+            <thead>
+              <tr>
+                <th>id</th>
+                <th>args\uFF08JSON \u5143\u7D20\uFF0C\u9017\u865F\u5206\u9694\uFF09</th>
+                <th>expected\uFF08JSON\uFF09</th>
+                <th>actual</th>
+                ${mutantHeaderCol}
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>${testRows}</tbody>
+          </table>
+        </section>
+      </div>
+
+      ${state.error ? `<p class="syntax-error" data-testid="syntax-error">${escapeHtml3(state.error)}</p>` : ""}
+
+      <section class="syntax-score-section">
+        <div class="syntax-score-bar">
+          <div class="syntax-score-fill" style="width:${scorePct}%" data-testid="syntax-score-fill"></div>
+        </div>
+        <p class="syntax-score-stats" data-testid="syntax-score-stats">
+          Mutation Score\uFF1A<strong>${scorePct}%</strong>
+          <span class="syntax-divider">\xB7</span>
+          \u7E3D\u6578 ${state.score.total}
+          <span class="syntax-divider">\xB7</span>
+          killed <strong>${state.score.killed}</strong>
+          <span class="syntax-divider">\xB7</span>
+          live <strong>${state.score.live}</strong>
+          <span class="syntax-divider">\xB7</span>
+          equivalent <strong>${state.score.equivalent}</strong>
+        </p>
+      </section>
+
+      <section class="syntax-mutant-section">
+        <div class="syntax-mutant-list" data-testid="syntax-mutant-list">${mutantList || '<p class="syntax-mutant-empty">\u7121 mutants\uFF08\u8ACB\u9078\u64C7\u81F3\u5C11\u4E00\u500B operator\uFF09\u3002</p>'}</div>
+        ${selectedDetail}
+      </section>
+    `;
+      bindEvents();
+    }
+    function bindEvents() {
+      root2.querySelectorAll("[data-example]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          loadExample(btn.dataset.example);
+          render();
+        });
+      });
+      const resetBtn = root2.querySelector('[data-testid="syntax-reset-program"]');
+      if (resetBtn) {
+        resetBtn.addEventListener("click", () => {
+          const ex = programExamples.find((e) => e.id === state.exampleId);
+          if (!ex) return;
+          const snap = defaultProgramSnapshot(ex);
+          state.params = snap.params;
+          state.body = snap.body;
+          state.tests = snap.tests.map((t) => ({ ...t }));
+          state.selectedMutantId = null;
+          persistCurrent();
+          render();
+        });
+      }
+      const reloadBtn = root2.querySelector('[data-testid="syntax-cloud-reload"]');
+      if (reloadBtn) {
+        reloadBtn.addEventListener("click", () => {
+          reloadFromCloud({ force: true });
+        });
+      }
+      root2.querySelectorAll("[data-operator]").forEach((cb) => {
+        cb.addEventListener("change", () => {
+          const op = cb.dataset.operator;
+          if (cb.checked) state.operators.add(op);
+          else state.operators.delete(op);
+          render();
+        });
+      });
+      const params = root2.querySelector('[data-testid="syntax-params"]');
+      if (params) {
+        params.addEventListener("input", (e) => {
+          state.params = e.target.value;
+          persistCurrent();
+        });
+        params.addEventListener("change", (e) => {
+          state.params = e.target.value;
+          persistCurrent();
+          render();
+        });
+      }
+      const body = root2.querySelector('[data-testid="syntax-body"]');
+      if (body) {
+        body.addEventListener("input", (e) => {
+          state.body = e.target.value;
+          persistCurrent();
+        });
+        body.addEventListener("change", (e) => {
+          state.body = e.target.value;
+          persistCurrent();
+          render();
+        });
+      }
+      root2.querySelectorAll("[data-test-args]").forEach((input) => {
+        input.addEventListener("input", (e) => {
+          const id = input.dataset.testArgs;
+          const t = state.tests.find((x) => x.id === id);
+          if (t) t.argsText = e.target.value;
+          persistCurrent();
+        });
+        input.addEventListener("change", (e) => {
+          const id = input.dataset.testArgs;
+          const t = state.tests.find((x) => x.id === id);
+          if (t) t.argsText = e.target.value;
+          persistCurrent();
+          render();
+        });
+      });
+      root2.querySelectorAll("[data-test-expected]").forEach((input) => {
+        input.addEventListener("input", (e) => {
+          const id = input.dataset.testExpected;
+          const t = state.tests.find((x) => x.id === id);
+          if (t) t.expectedText = e.target.value;
+          persistCurrent();
+        });
+        input.addEventListener("change", (e) => {
+          const id = input.dataset.testExpected;
+          const t = state.tests.find((x) => x.id === id);
+          if (t) t.expectedText = e.target.value;
+          persistCurrent();
+          render();
+        });
+      });
+      root2.querySelectorAll("[data-remove-test]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          state.tests = state.tests.filter((t) => t.id !== btn.dataset.removeTest);
+          persistCurrent();
+          render();
+        });
+      });
+      const addBtn = root2.querySelector('[data-testid="syntax-test-add"]');
+      if (addBtn) {
+        addBtn.addEventListener("click", () => {
+          const next = `t${state.tests.length + 1}`;
+          state.tests.push({ id: next, argsText: "", expectedText: "" });
+          persistCurrent();
+          render();
+        });
+      }
+      root2.querySelectorAll("[data-mutant-id]").forEach((li) => {
+        li.addEventListener("click", () => {
+          state.selectedMutantId = li.dataset.mutantId;
+          render();
+        });
+      });
+      root2.querySelectorAll("[data-toggle-equivalent]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const m = state.mutants.find((x) => x.id === btn.dataset.toggleEquivalent);
+          if (!m) return;
+          m.status = m.status === "equivalent" ? m.killedBy.length ? "killed" : "live" : "equivalent";
+          state.score = computeMutationScore(state.mutants);
+          render();
+        });
+      });
+    }
+    render();
+    if (cloudClient && typeof cloudClient.subscribeAuthState === "function") {
+      cloudClient.subscribeAuthState(async (user) => {
+        state.cloudUser = user || null;
+        if (!user) {
+          state.cloudStatus = "idle";
+          state.cloudMessage = "";
+          render();
+          return;
+        }
+        await reloadFromCloud();
+      });
+      if (typeof ((_a = globalThis.document) == null ? void 0 : _a.addEventListener) === "function") {
+        globalThis.document.addEventListener("visibilitychange", () => {
+          if (globalThis.document.visibilityState === "visible" && state.cloudUser) {
+            reloadFromCloud();
+          }
+        });
+      }
+      if (typeof globalThis.addEventListener === "function") {
+        globalThis.addEventListener("pagehide", () => {
+          flushPendingSave();
+        });
+        globalThis.addEventListener("beforeunload", () => {
+          flushPendingSave();
+        });
+      }
+    }
+    return root2;
+  }
+
   // src/app.js
   var sectionsConfig = [
     { id: "all", label: "\u5168\u89BD" },
     { id: "methods", label: "\u6E2C\u8A66\u65B9\u6CD5" },
     { id: "graph", label: "Graph Coverage" },
     { id: "logic", label: "Logic Coverage" },
+    { id: "syntax", label: "Syntax-Based Testing" },
     { id: "cloud", label: "\u96F2\u7AEF\u6574\u5408" },
     { id: "flow", label: "\u6E2C\u8A66\u6D41\u7A0B" },
     { id: "types", label: "\u6E2C\u8A66\u985E\u578B" }
@@ -4273,6 +5234,10 @@ Content-Type: ${file.type || "application/octet-stream"}\r
           <h2>Logic Coverage \u8996\u89BA\u5316</h2>
           <div data-slot="logic"></div>
         </section>
+        <section data-testid="section-syntax">
+          <h2>Syntax-Based Testing\uFF1AProgram Mutation</h2>
+          <div data-slot="syntax"></div>
+        </section>
         <section data-testid="section-cloud">
           <h2>Google \u96F2\u7AEF\u6574\u5408</h2>
           <div data-slot="cloud"></div>
@@ -4298,6 +5263,7 @@ Content-Type: ${file.type || "application/octet-stream"}\r
       methods: main.querySelector('[data-testid="section-methods"]'),
       graph: main.querySelector('[data-testid="section-graph"]'),
       logic: main.querySelector('[data-testid="section-logic"]'),
+      syntax: main.querySelector('[data-testid="section-syntax"]'),
       cloud: main.querySelector('[data-testid="section-cloud"]'),
       flow: main.querySelector('[data-testid="section-flow"]'),
       types: main.querySelector('[data-testid="section-types"]')
@@ -4306,6 +5272,7 @@ Content-Type: ${file.type || "application/octet-stream"}\r
       methods: createTestingMethodTree(),
       graph: createGraphCoverageExplorer(),
       logic: createLogicCoverageExplorer(),
+      syntax: createSyntaxCoverageExplorer(),
       cloud: createCloudStoragePanel(),
       flow: createTestingFlow(),
       types: createTestingTypesTable()
@@ -4313,6 +5280,7 @@ Content-Type: ${file.type || "application/octet-stream"}\r
     container.querySelector('[data-slot="methods"]').appendChild(components.methods);
     container.querySelector('[data-slot="graph"]').appendChild(components.graph);
     container.querySelector('[data-slot="logic"]').appendChild(components.logic);
+    container.querySelector('[data-slot="syntax"]').appendChild(components.syntax);
     container.querySelector('[data-slot="cloud"]').appendChild(components.cloud);
     container.querySelector('[data-slot="flow"]').appendChild(components.flow);
     container.querySelector('[data-slot="types"]').appendChild(components.types);

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,4 +4,5 @@
 @import url('./components/TestingTypesTable.css');
 @import url('./components/GraphCoverageExplorer.css');
 @import url('./components/LogicCoverageExplorer.css');
+@import url('./components/SyntaxCoverageExplorer.css');
 @import url('./components/CloudStoragePanel.css');

--- a/src/tests/SyntaxCoverageExplorer.cloud.test.jsx
+++ b/src/tests/SyntaxCoverageExplorer.cloud.test.jsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// 必須在 import 元件之前準備 globalThis.firebase mock，
+// 因為 createSyntaxCoverageExplorer() 會在建立時呼叫 createCloudIntegrationClient()。
+let authCallback = null;
+const saveSpy = vi.fn().mockResolvedValue();
+const loadSpy = vi.fn().mockResolvedValue({});
+
+function installFirebaseMock() {
+  const fakeApp = {};
+  const fakeAuth = {
+    onAuthStateChanged: (cb) => {
+      authCallback = cb;
+      cb(null);
+      return () => {};
+    },
+    signOut: async () => {},
+  };
+  const fakeFirestore = {
+    collection: () => ({
+      doc: () => ({
+        collection: () => ({
+          doc: () => ({
+            get: async () => ({ exists: () => false, data: () => ({}) }),
+            set: async (data) => {
+              // 如果是 syntaxCoverage 的 set，紀錄
+              saveSpy(data);
+            },
+          }),
+        }),
+        get: async () => ({ exists: () => false, data: () => ({}) }),
+        set: async (data) => {
+          saveSpy(data);
+        },
+      }),
+    }),
+  };
+
+  globalThis.firebase = {
+    apps: [fakeApp],
+    app: () => fakeApp,
+    initializeApp: () => fakeApp,
+    auth: () => fakeAuth,
+    firestore: Object.assign(() => fakeFirestore, {
+      FieldValue: { serverTimestamp: () => 'TS' },
+    }),
+  };
+
+  // 覆寫 cloudIntegration 中對 syntaxCoverage doc 的呼叫，攔截在更具體的位置
+  const realCollection = fakeFirestore.collection;
+  fakeFirestore.collection = (name) => ({
+    doc: (uid) => ({
+      collection: (sub) => ({
+        doc: (key) => ({
+          get: async () => {
+            if (key === 'syntaxCoverage') {
+              const result = await loadSpy(uid);
+              return {
+                exists: () => !!result,
+                data: () => ({ programs: result || {} }),
+              };
+            }
+            return { exists: () => false, data: () => ({}) };
+          },
+          set: async (data) => {
+            if (key === 'syntaxCoverage') {
+              saveSpy(uid, data);
+            }
+          },
+        }),
+      }),
+    }),
+  });
+}
+
+function uninstallFirebaseMock() {
+  delete globalThis.firebase;
+  authCallback = null;
+}
+
+let createSyntaxCoverageExplorer;
+
+beforeEach(async () => {
+  saveSpy.mockClear();
+  loadSpy.mockClear();
+  loadSpy.mockResolvedValue({});
+  installFirebaseMock();
+  // 重新 import 以避免模組層快取
+  vi.resetModules();
+  ({ createSyntaxCoverageExplorer } = await import('../components/SyntaxCoverageExplorer.js'));
+  globalThis.localStorage?.clear?.();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  uninstallFirebaseMock();
+  vi.useRealTimers();
+});
+
+describe('SyntaxCoverageExplorer 雲端同步', () => {
+  it('未登入時雲端指示器為 idle 狀態', () => {
+    const el = createSyntaxCoverageExplorer();
+    document.body.appendChild(el);
+    const indicator = el.querySelector('[data-testid="syntax-cloud-indicator"]');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.dataset.status).toBe('idle');
+  });
+
+  it('登入後新增測試案例會 debounce 後寫入雲端', async () => {
+    vi.useFakeTimers();
+    const el = createSyntaxCoverageExplorer();
+    document.body.appendChild(el);
+
+    // 模擬 auth 觸發登入
+    expect(typeof authCallback).toBe('function');
+    authCallback({ uid: 'user-123', email: 'tester@example.com' });
+    // 等待 loadSyntaxTests 的 microtasks resolve
+    await vi.runAllTimersAsync();
+
+    // 點選 ＋ 新增 test 按鈕（會立即呼叫 persistCurrent → pushToCloud）
+    const addBtn = el.querySelector('[data-testid="syntax-test-add"]');
+    expect(addBtn).toBeInTheDocument();
+    addBtn.click();
+
+    // 等待 debounce
+    await vi.advanceTimersByTimeAsync(800);
+    await vi.runAllTimersAsync();
+
+    expect(saveSpy).toHaveBeenCalled();
+    const lastCall = saveSpy.mock.calls.at(-1);
+    expect(lastCall[0]).toBe('user-123');
+    expect(lastCall[1]).toHaveProperty('programs');
+    // 預設範例 max 應在 programs 中，且至少有一個 test
+    const programs = lastCall[1].programs;
+    expect(programs).toHaveProperty('max');
+    expect(Array.isArray(programs.max.tests)).toBe(true);
+  });
+
+  it('編輯 expected 欄位後 change 事件會觸發雲端寫入', async () => {
+    vi.useFakeTimers();
+    const el = createSyntaxCoverageExplorer();
+    document.body.appendChild(el);
+    authCallback({ uid: 'user-xyz' });
+    await vi.runAllTimersAsync();
+    saveSpy.mockClear();
+
+    const expectedInput = el.querySelector('[data-test-expected="t1"]');
+    expect(expectedInput).toBeInTheDocument();
+    expectedInput.value = '999';
+    expectedInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(800);
+    await vi.runAllTimersAsync();
+
+    expect(saveSpy).toHaveBeenCalled();
+    const programs = saveSpy.mock.calls.at(-1)[1].programs;
+    const t1 = programs.max.tests.find((t) => t.id === 't1');
+    expect(t1.expectedText).toBe('999');
+  });
+
+  it('登入後若雲端有資料會載入並覆蓋本地（顯示 synced 訊息）', async () => {
+    vi.useFakeTimers();
+    loadSpy.mockResolvedValue({
+      max: {
+        params: 'a, b',
+        body: 'return a;',
+        tests: [{ id: 'tCloud', argsText: '1, 2', expectedText: '1' }],
+      },
+    });
+
+    const el = createSyntaxCoverageExplorer();
+    document.body.appendChild(el);
+    authCallback({ uid: 'user-cloud', email: 'me@e.com' });
+    await vi.runAllTimersAsync();
+
+    // 重新 render 後應該出現 tCloud
+    const row = el.querySelector('[data-testid="syntax-test-row-tCloud"]');
+    expect(row).toBeInTheDocument();
+
+    const indicator = el.querySelector('[data-testid="syntax-cloud-indicator"]');
+    // 載入完成後狀態應為 synced 或 syncing（取決於是否觸發回寫）
+    expect(['synced', 'syncing']).toContain(indicator.dataset.status);
+  });
+});

--- a/src/tests/mutation.test.js
+++ b/src/tests/mutation.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateMutants,
+  evaluateMutants,
+  computeMutationScore,
+  runTestSuite,
+} from '../utils/mutation.js';
+
+describe('generateMutants', () => {
+  it('AOR：a + b 產生 sub/mul/div/mod 共 4 個 mutants', () => {
+    const mutants = generateMutants('return a + b;', ['AOR']);
+    expect(mutants).toHaveLength(4);
+    const replacements = mutants.map((m) => m.mutated).sort();
+    expect(replacements).toEqual(['%', '*', '-', '/'].sort());
+    expect(mutants.every((m) => m.operator === 'AOR')).toBe(true);
+  });
+
+  it('ROR：a > b 產生 7 個替換', () => {
+    const mutants = generateMutants('return a > b;', ['ROR']);
+    expect(mutants).toHaveLength(7);
+  });
+
+  it('LOR：a && b 產生 1 個 mutant（變 ||）', () => {
+    const mutants = generateMutants('return a && b;', ['LOR']);
+    expect(mutants).toHaveLength(1);
+    expect(mutants[0].mutated).toBe('||');
+  });
+
+  it('UOI：每個識別字產生 ! 與 - 共 2 個 mutants', () => {
+    const mutants = generateMutants('return a + b;', ['UOI']);
+    expect(mutants).toHaveLength(4);
+    const variants = mutants.map((m) => m.mutated).sort();
+    expect(variants).toEqual(['!a', '!b', '-a', '-b']);
+  });
+
+  it('忽略字串字面值內的運算子', () => {
+    const mutants = generateMutants('return "a + b";', ['AOR']);
+    expect(mutants).toHaveLength(0);
+  });
+
+  it('忽略註解中的運算子', () => {
+    const mutants = generateMutants('return a; // a + b', ['AOR']);
+    expect(mutants).toHaveLength(0);
+  });
+
+  it('不會把 += 當成 +', () => {
+    const mutants = generateMutants('let x = 0; x += a; return x;', ['AOR']);
+    // 只有 += 的位置不會被視為 +，但 `let x = 0` 中沒有算術運算子；應為 0
+    expect(mutants).toHaveLength(0);
+  });
+});
+
+describe('evaluateMutants 與 mutation score', () => {
+  it('完整 test suite 能 kill 所有 AOR mutants', () => {
+    const params = ['a', 'b'];
+    const body = 'return a + b;';
+    const tests = [
+      { id: 't1', args: [2, 3], expected: 5 },
+      { id: 't2', args: [10, 4], expected: 14 },
+    ];
+    const mutants = generateMutants(body, ['AOR']);
+    const evaluated = evaluateMutants(params, body, tests, mutants);
+    expect(evaluated.every((m) => m.status === 'killed')).toBe(true);
+    const score = computeMutationScore(evaluated);
+    expect(score.score).toBe(1);
+    expect(score.killed).toBe(4);
+    expect(score.live).toBe(0);
+  });
+
+  it('弱 test suite 會留下 live mutants', () => {
+    const params = ['a', 'b'];
+    const body = 'return a + b;';
+    const tests = [{ id: 't1', args: [0, 0], expected: 0 }];
+    const mutants = generateMutants(body, ['AOR']);
+    const evaluated = evaluateMutants(params, body, tests, mutants);
+    // 0+0 = 0-0 = 0*0 = 0, 0/0 = NaN, 0%0 = NaN
+    // 因此 - 與 * 的 mutants 不會被 killed
+    const live = evaluated.filter((m) => m.status === 'live');
+    expect(live.length).toBeGreaterThan(0);
+  });
+
+  it('runTestSuite 能正確判斷 pass/fail', () => {
+    const results = runTestSuite(['a', 'b'], 'return a + b;', [
+      { id: 't1', args: [1, 2], expected: 3 },
+      { id: 't2', args: [1, 2], expected: 99 },
+    ]);
+    expect(results[0].passed).toBe(true);
+    expect(results[1].passed).toBe(false);
+  });
+
+  it('mutation score 排除 equivalent mutants', () => {
+    const mutants = [
+      { id: 'M1', status: 'killed', killedBy: ['t1'] },
+      { id: 'M2', status: 'live', killedBy: [] },
+      { id: 'M3', status: 'equivalent', killedBy: [] },
+    ];
+    const score = computeMutationScore(mutants);
+    expect(score.total).toBe(3);
+    expect(score.killed).toBe(1);
+    expect(score.live).toBe(1);
+    expect(score.equivalent).toBe(1);
+    expect(score.score).toBeCloseTo(0.5);
+  });
+});

--- a/src/utils/cloudIntegration.js
+++ b/src/utils/cloudIntegration.js
@@ -120,6 +120,12 @@ export function createCloudIntegrationClient() {
   const db = firebase.firestore(app);
   let driveAccessToken = null;
 
+  function snapshotExists(snapshot) {
+    if (!snapshot) return false;
+    // compat SDK 是 boolean property；modular SDK 是 function。
+    return typeof snapshot.exists === 'function' ? snapshot.exists() : Boolean(snapshot.exists);
+  }
+
   return {
     isConfigured,
     missingKeys,
@@ -148,7 +154,7 @@ export function createCloudIntegrationClient() {
     async loadSettings(userId) {
       const snapshot = await db.collection('users').doc(userId).collection('settings').doc('default').get();
 
-      if (!snapshot.exists()) {
+      if (!snapshotExists(snapshot)) {
         return null;
       }
 
@@ -162,7 +168,7 @@ export function createCloudIntegrationClient() {
     },
     async loadLogicRecent(userId) {
       const snapshot = await db.collection('users').doc(userId).collection('settings').doc('logicCoverage').get();
-      if (!snapshot.exists()) return [];
+      if (!snapshotExists(snapshot)) return [];
       const data = snapshot.data() || {};
       return Array.isArray(data.recentPredicates)
         ? data.recentPredicates.filter((p) => typeof p === 'string')
@@ -171,6 +177,18 @@ export function createCloudIntegrationClient() {
     async saveLogicRecent(userId, list) {
       await db.collection('users').doc(userId).collection('settings').doc('logicCoverage').set({
         recentPredicates: Array.isArray(list) ? list.filter((p) => typeof p === 'string') : [],
+        updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    },
+    async loadSyntaxTests(userId) {
+      const snapshot = await db.collection('users').doc(userId).collection('settings').doc('syntaxCoverage').get();
+      if (!snapshotExists(snapshot)) return {};
+      const data = snapshot.data() || {};
+      return (data.programs && typeof data.programs === 'object') ? data.programs : {};
+    },
+    async saveSyntaxTests(userId, programs) {
+      await db.collection('users').doc(userId).collection('settings').doc('syntaxCoverage').set({
+        programs: programs && typeof programs === 'object' ? programs : {},
         updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
       }, { merge: true });
     },

--- a/src/utils/mutation.js
+++ b/src/utils/mutation.js
@@ -1,0 +1,312 @@
+// Program Mutation utilities (Ammann & Offutt, Chapter 9 — Syntax-Based Testing).
+//
+// MVP 範圍：
+//   - 目標語言：純 JavaScript 函式（單一 return / 無副作用為主）。
+//   - Mutation operators：
+//       AOR (Arithmetic Operator Replacement)
+//       ROR (Relational Operator Replacement)
+//       LOR (Logical Operator Replacement)
+//       COR (Conditional Operator Replacement，含位元/條件）
+//       UOI (Unary Operator Insertion，僅 ! 與 -)
+//       ABS (Absolute Value Insertion，將 expr 取代為 Math.abs(expr))
+//
+// 突變方式：以 token 取代為主（不依賴完整 AST），確保 MVP 可控。
+// 評估方式：使用 new Function(...params, body) 在當前 JS engine 內執行。
+//   - 若執行拋例外 / 超過步數限制，視該 mutant 為被該 test「killed」。
+//   - 若所有 test 結果都與原程式相同，mutant 為 live；可由使用者標記 equivalent。
+
+const OPERATORS = {
+  AOR: ['+', '-', '*', '/', '%'],
+  ROR: ['<', '<=', '>', '>=', '==', '!=', '===', '!=='],
+  LOR: ['&&', '||'],
+  COR: ['&&', '||'], // 同 LOR，但與 ! 一同套用時為條件運算的補集
+};
+
+// 排序使長 token 先比對（避免 `==` 被 `=` 比中）。
+const SORTED = {
+  AOR: [...OPERATORS.AOR].sort((a, b) => b.length - a.length),
+  ROR: [...OPERATORS.ROR].sort((a, b) => b.length - a.length),
+  LOR: [...OPERATORS.LOR].sort((a, b) => b.length - a.length),
+  COR: [...OPERATORS.COR].sort((a, b) => b.length - a.length),
+};
+
+// 內建 AOI 與 UOI 的位置條件：在識別字 / 數字 / 右括號之前 / 之後插入 `!` 或 `-`。
+const ID_REGEX = /[A-Za-z_$][A-Za-z0-9_$]*/y;
+const NUM_REGEX = /\d+(?:\.\d+)?/y;
+
+function isIdentChar(ch) {
+  return /[A-Za-z0-9_$]/.test(ch);
+}
+
+// 判斷某個位置是否在字串字面值或註解中（避免 mutate 字串內容）。
+function buildSkipMap(source) {
+  const skip = new Array(source.length).fill(false);
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') { skip[i] = true; i += 1; }
+    } else if (ch === '/' && next === '*') {
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        skip[i] = true;
+        i += 1;
+      }
+      if (i < source.length) { skip[i] = skip[i + 1] = true; i += 2; }
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      const quote = ch;
+      skip[i] = true;
+      i += 1;
+      while (i < source.length && source[i] !== quote) {
+        if (source[i] === '\\') { skip[i] = skip[i + 1] = true; i += 2; }
+        else { skip[i] = true; i += 1; }
+      }
+      if (i < source.length) { skip[i] = true; i += 1; }
+    } else {
+      i += 1;
+    }
+  }
+  return skip;
+}
+
+function lineColOf(source, index) {
+  let line = 1;
+  let col = 1;
+  for (let i = 0; i < index && i < source.length; i += 1) {
+    if (source[i] === '\n') { line += 1; col = 1; } else { col += 1; }
+  }
+  return { line, col };
+}
+
+function applyReplacement(source, start, end, replacement) {
+  return source.slice(0, start) + replacement + source.slice(end);
+}
+
+function findOperatorOccurrences(source, operatorList, skip) {
+  const hits = [];
+  for (let i = 0; i < source.length; i += 1) {
+    if (skip[i]) continue;
+    for (const op of operatorList) {
+      if (i + op.length > source.length) continue;
+      if (source.slice(i, i + op.length) !== op) continue;
+      // 防止 `=` 取到 `==`：左右字元不可組成更長運算子。
+      const before = source[i - 1] || '';
+      const after = source[i + op.length] || '';
+      // 排除 `===` 在比 `==` 時被誤截斷：若 after 也是 `=` 而 op 不含 `=`，跳過。
+      if (op === '=' || op.endsWith('=')) {
+        // 不應出現，因為 OPERATORS 不包含 `=`
+      }
+      // 排除 `+=` `-=` `*=` 等指派
+      if (after === '=' && op.length === 1 && '+-*/%'.includes(op)) continue;
+      // 排除 `**` 連寫被當成 `*`
+      if (op === '*' && (before === '*' || after === '*')) continue;
+      // 排除 `||=` `&&=`
+      if ((op === '||' || op === '&&') && after === '=') continue;
+      // 排除 `<<` `>>` `>>>` 被當成 `<` 或 `>`
+      if (op === '<' && (after === '<' || before === '<')) continue;
+      if (op === '>' && (after === '>' || before === '>')) continue;
+      hits.push({ start: i, end: i + op.length, text: op });
+      i += op.length - 1;
+      break;
+    }
+  }
+  return hits;
+}
+
+function findIdentifierOccurrences(source, skip) {
+  const hits = [];
+  let i = 0;
+  while (i < source.length) {
+    if (skip[i]) { i += 1; continue; }
+    ID_REGEX.lastIndex = i;
+    const m = ID_REGEX.exec(source);
+    if (m && m.index === i) {
+      // 過濾關鍵字
+      const keywords = new Set([
+        'true', 'false', 'null', 'undefined', 'return', 'if', 'else', 'for',
+        'while', 'do', 'switch', 'case', 'break', 'continue', 'function',
+        'var', 'let', 'const', 'new', 'typeof', 'in', 'of', 'this',
+      ]);
+      if (!keywords.has(m[0])) {
+        hits.push({ start: i, end: i + m[0].length, text: m[0] });
+      }
+      i += m[0].length;
+    } else {
+      i += 1;
+    }
+  }
+  return hits;
+}
+
+function generateForOperator(source, opName, skip, idCounter) {
+  const list = SORTED[opName];
+  if (!list) return [];
+  const hits = findOperatorOccurrences(source, list, skip);
+  const mutants = [];
+  hits.forEach((hit) => {
+    list.forEach((replacement) => {
+      if (replacement === hit.text) return;
+      const mutated = applyReplacement(source, hit.start, hit.end, replacement);
+      const { line, col } = lineColOf(source, hit.start);
+      mutants.push({
+        id: `M${idCounter.value++}`,
+        operator: opName,
+        line, col,
+        original: hit.text,
+        mutated: replacement,
+        source: mutated,
+        status: 'live',
+        killedBy: [],
+      });
+    });
+  });
+  return mutants;
+}
+
+function generateUOI(source, skip, idCounter) {
+  const hits = findIdentifierOccurrences(source, skip);
+  const mutants = [];
+  hits.forEach((hit) => {
+    ['!', '-'].forEach((unary) => {
+      const mutated = applyReplacement(source, hit.start, hit.end, `${unary}${hit.text}`);
+      const { line, col } = lineColOf(source, hit.start);
+      mutants.push({
+        id: `M${idCounter.value++}`,
+        operator: 'UOI',
+        line, col,
+        original: hit.text,
+        mutated: `${unary}${hit.text}`,
+        source: mutated,
+        status: 'live',
+        killedBy: [],
+      });
+    });
+  });
+  return mutants;
+}
+
+function generateABS(source, skip, idCounter) {
+  // 將每個識別字（變數）替換為 (-x) 與 ((x)===0 ? 1 : x) 兩種變體較複雜，
+  // MVP 採用 Math.abs(x) 與 -(x)（負值化）兩種突變。
+  const hits = findIdentifierOccurrences(source, skip);
+  const mutants = [];
+  hits.forEach((hit) => {
+    const variants = [
+      { suffix: 'abs', text: `Math.abs(${hit.text})` },
+      { suffix: 'neg', text: `(-(${hit.text}))` },
+    ];
+    variants.forEach(({ suffix, text }) => {
+      const mutated = applyReplacement(source, hit.start, hit.end, text);
+      const { line, col } = lineColOf(source, hit.start);
+      mutants.push({
+        id: `M${idCounter.value++}`,
+        operator: 'ABS',
+        line, col,
+        original: hit.text,
+        mutated: text,
+        source: mutated,
+        status: 'live',
+        killedBy: [],
+        variant: suffix,
+      });
+    });
+  });
+  return mutants;
+}
+
+export function generateMutants(source, operators = ['AOR', 'ROR', 'LOR', 'UOI']) {
+  const skip = buildSkipMap(source);
+  const idCounter = { value: 1 };
+  const out = [];
+  operators.forEach((op) => {
+    if (op === 'UOI') {
+      out.push(...generateUOI(source, skip, idCounter));
+    } else if (op === 'ABS') {
+      out.push(...generateABS(source, skip, idCounter));
+    } else {
+      out.push(...generateForOperator(source, op, skip, idCounter));
+    }
+  });
+  return out;
+}
+
+// ---------------- 執行與計分 ----------------
+
+function compileFunction(params, body) {
+  // 安全：函式只接受指定 params；body 由使用者輸入，視同信任本機開發者。
+  // eslint-disable-next-line no-new-func
+  return new Function(...params, body);
+}
+
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a === 'number' && typeof b === 'number' && Number.isNaN(a) && Number.isNaN(b)) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    const ak = Object.keys(a); const bk = Object.keys(b);
+    if (ak.length !== bk.length) return false;
+    return ak.every((k) => deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+function runOnce(fn, args) {
+  try {
+    const result = fn(...args);
+    return { ok: true, value: result };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
+  }
+}
+
+export function runTestSuite(params, body, tests) {
+  const fn = compileFunction(params, body);
+  return tests.map((t) => {
+    const outcome = runOnce(fn, t.args);
+    const expected = t.expected;
+    const passed = outcome.ok && deepEqual(outcome.value, expected);
+    return { id: t.id, passed, outcome };
+  });
+}
+
+export function evaluateMutants(params, body, tests, mutants) {
+  // 先計算原程式輸出，作為 oracle。
+  const baseFn = compileFunction(params, body);
+  const baseOutcomes = tests.map((t) => runOnce(baseFn, t.args));
+
+  return mutants.map((m) => {
+    let mutantFn;
+    try {
+      mutantFn = compileFunction(params, m.source);
+    } catch (err) {
+      // 編譯錯誤視為被所有 test killed（語法等價已被消除）。
+      return { ...m, status: 'killed', killedBy: tests.map((t) => t.id), compileError: err?.message };
+    }
+    const killedBy = [];
+    tests.forEach((t, i) => {
+      const base = baseOutcomes[i];
+      const mut = runOnce(mutantFn, t.args);
+      const sameOk = base.ok === mut.ok;
+      const sameValue = sameOk && (base.ok ? deepEqual(base.value, mut.value) : true);
+      if (!sameOk || !sameValue) killedBy.push(t.id);
+    });
+    return {
+      ...m,
+      status: killedBy.length ? 'killed' : 'live',
+      killedBy,
+    };
+  });
+}
+
+export function computeMutationScore(mutants) {
+  const total = mutants.length;
+  const equivalent = mutants.filter((m) => m.status === 'equivalent').length;
+  const killed = mutants.filter((m) => m.status === 'killed').length;
+  const live = mutants.filter((m) => m.status === 'live').length;
+  const denominator = total - equivalent;
+  const score = denominator === 0 ? 1 : killed / denominator;
+  return { total, killed, live, equivalent, score };
+}


### PR DESCRIPTION
Closes #30

## 摘要

新增 **Syntax-Based Testing** 章節（Program Mutation MVP），加上 mutation 結果上的 per-test actual output 對照、Google 雲端同步；並修復 cloud 整合中發現的兩個 bug。詳細內容見 #30。

## 變動檔案

新增
- `src/utils/mutation.js`、`src/data/mutationData.js`
- `src/components/SyntaxCoverageExplorer.{js,css}`
- `src/tests/mutation.test.js`、`src/tests/SyntaxCoverageExplorer.cloud.test.jsx`

修改
- `src/app.js`、`src/styles.css`：掛載新 section
- `src/utils/cloudIntegration.js`：`loadSyntaxTests` / `saveSyntaxTests` + `snapshotExists()` helper
- `src/standalone.js`：rebuild

## 測試

```
Test Files  12 passed (12)
     Tests  138 passed (138)
```

## Checklist

- [x] 單元測試通過 (Vitest 138/138)
- [x] standalone bundle 已重建
- [x] Safari snapshot.exists bug 已修復
- [x] 新增 test 後立即離開頁面也會寫雲端（pagehide flush + input debounce）
