### PR TITLE
fix(pages): include src/i18n/ in deployed artifact

### DIFF
--- a/scripts/prepare-pages.mjs
+++ b/scripts/prepare-pages.mjs
@@ -21,6 +21,7 @@ await cp(path.join(projectRoot, 'src', 'components'), path.join(outputDir, 'src'
 await cp(path.join(projectRoot, 'src', 'data'), path.join(outputDir, 'src', 'data'), { recursive: true });
 await cp(path.join(projectRoot, 'src', 'config'), path.join(outputDir, 'src', 'config'), { recursive: true });
 await cp(path.join(projectRoot, 'src', 'utils'), path.join(outputDir, 'src', 'utils'), { recursive: true });
+await cp(path.join(projectRoot, 'src', 'i18n'), path.join(outputDir, 'src', 'i18n'), { recursive: true });
 await writeFile(path.join(outputDir, '.nojekyll'), '');
 
 console.log(`Prepared GitHub Pages site at ${outputDir}`);


### PR DESCRIPTION
**Hotfix for live site 404.**

Live site reports:
```
GET https://skhuang.github.io/stvisual/src/i18n/index.js 404 (Not Found)
TypeError: Failed to fetch dynamically imported module: …/src/main.js
```

PR #34 added `src/i18n/index.js` + `src/i18n/dict.js` but `scripts/prepare-pages.mjs` was only copying `components/`, `data/`, `config/`, `utils/` — not `i18n/` — so the Pages artifact ships without the new module and ESM imports fail.

This PR adds a single `cp(..., recursive)` for `src/i18n/` alongside the existing copies. (The same fix is also queued in the Phase-2 grammar PR but that one's larger; merging this small one first restores the live site.)