### PR TITLE
feat(graph): add Data Flow Graph view derived from program source

### DIFF
--- a/src/components/GraphCoverageExplorer.css
+++ b/src/components/GraphCoverageExplorer.css
@@ -319,6 +319,60 @@
   height: auto;
 }
 
+/* Data-flow graph view */
+.graph-dfg-card {
+  margin-top: 16px;
+  padding: 16px;
+  border-radius: 18px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+.graph-dfg-header { margin-bottom: 8px; }
+.graph-dfg-header h4 {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  color: #0f172a;
+}
+.graph-dfg-header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+.graph-dfg-canvas {
+  background:
+    radial-gradient(circle at 30% 30%, rgba(14, 165, 233, 0.1), transparent 30%),
+    linear-gradient(180deg, #f0f9ff 0%, #fdfdfd 100%);
+}
+.graph-dfg-edge path {
+  stroke: #0ea5e9;
+  stroke-width: 2.4;
+  stroke-dasharray: 6 4;
+  fill: none;
+}
+.graph-dfg-edge text {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 12px;
+  fill: #0369a1;
+  paint-order: stroke;
+  stroke: #ffffff;
+  stroke-width: 3;
+}
+.graph-dfg-node circle {
+  fill: #ffffff;
+  stroke: #0ea5e9;
+  stroke-width: 2;
+}
+.graph-dfg-node text {
+  font-size: 12px;
+  fill: #0f172a;
+}
+.graph-dfg-empty {
+  margin: 8px 0 0;
+  font-size: 0.85rem;
+  color: #64748b;
+  font-style: italic;
+}
+
 .graph-edge {
   stroke: #9aa8b6;
   stroke-width: 4;

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -574,7 +574,7 @@ export function createGraphCoverageExplorer() {
       <div class="graph-coverage-layout">
         <div class="graph-main-panel">
           ${createGraphCanvas(graph, selectedRequirement)}
-          ${activeProgram.sourceCode ? createDataFlowCanvas(graph) : ''}
+          ${createDataFlowCanvas(graph)}
           <div class="graph-selected-summary" data-testid="selected-requirement-summary">
             <span class="summary-label">${t('graph.summary.current')}</span>
             <strong>${selectedRequirement?.label || t('common.none')}</strong>

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -6,6 +6,7 @@ import {
 } from '../data/testingData.js';
 import { buildTestPathSetForRequirements, getCoverageRequirements } from '../utils/graphCoverage.js';
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
+import { buildDataFlowGraph } from '../utils/dataFlow.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
 
 function cloneGraph(graph) {
@@ -306,6 +307,75 @@ function createGraphCanvas(graph, requirement) {
   `;
 }
 
+function createDataFlowCanvas(graph) {
+  const dfg = buildDataFlowGraph(graph);
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
+  const width = Math.max(920, ...graph.nodes.map((node) => node.x + 120));
+  const height = Math.max(340, ...graph.nodes.map((node) => node.y + 90));
+
+  // Group edges between the same pair so labels stack instead of overlap.
+  const grouped = new Map();
+  for (const e of dfg.edges) {
+    const key = `${e.from}->${e.to}`;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(e);
+  }
+
+  const edgeMarkup = [...grouped.entries()].map(([key, group]) => {
+    const sample = group[0];
+    const a = nodeById.get(sample.from);
+    const b = nodeById.get(sample.to);
+    if (!a || !b) return '';
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const len = Math.hypot(dx, dy) || 1;
+    // Curve up-and-over for forward, down for back-edges so the DFG view
+    // doesn't overlap the CFG straight lines.
+    const sign = a.y <= b.y ? -1 : 1;
+    const offset = 28 + group.length * 6;
+    const cx = (a.x + b.x) / 2 + (-dy / len) * offset * sign;
+    const cy = (a.y + b.y) / 2 + (dx / len) * offset * sign;
+    const labels = group.map((e) => e.variable).join(', ');
+    return `
+      <g class="graph-dfg-edge" data-testid="dfg-edge-${escapeHtml(key)}">
+        <path d="M ${a.x} ${a.y} Q ${cx} ${cy} ${b.x} ${b.y}"
+              marker-end="url(#dfg-arrow)"></path>
+        <text x="${cx}" y="${cy}" text-anchor="middle">${escapeHtml(labels)}</text>
+      </g>
+    `;
+  }).join('');
+
+  const empty = dfg.edges.length === 0
+    ? `<p class="graph-dfg-empty" data-testid="graph-dfg-empty">${t('graph.dfg.empty')}</p>`
+    : '';
+
+  return `
+    <div class="graph-dfg-card" data-testid="graph-dfg-card">
+      <div class="graph-dfg-header">
+        <h4>${t('graph.dfg.title')}</h4>
+        <p>${t('graph.dfg.help')}</p>
+      </div>
+      <div class="graph-canvas graph-dfg-canvas" data-testid="graph-dfg-canvas">
+        <svg viewBox="0 0 ${width} ${height}" role="img" aria-label="${t('graph.dfg.aria')}">
+          <defs>
+            <marker id="dfg-arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+              <path d="M0,0 L12,6 L0,12 z" fill="#0ea5e9"></path>
+            </marker>
+          </defs>
+          ${edgeMarkup}
+          ${graph.nodes.map((node) => `
+            <g class="graph-node graph-dfg-node" data-testid="dfg-node-${node.id}">
+              <circle cx="${node.x}" cy="${node.y}" r="24"></circle>
+              <text x="${node.x}" y="${node.y + 5}" text-anchor="middle">${node.label}</text>
+            </g>
+          `).join('')}
+        </svg>
+      </div>
+      ${empty}
+    </div>
+  `;
+}
+
 export function createGraphCoverageExplorer() {
   const root = document.createElement('div');
   const defaultGraph = cloneGraph(graphCoverageGraph);
@@ -504,6 +574,7 @@ export function createGraphCoverageExplorer() {
       <div class="graph-coverage-layout">
         <div class="graph-main-panel">
           ${createGraphCanvas(graph, selectedRequirement)}
+          ${activeProgram.sourceCode ? createDataFlowCanvas(graph) : ''}
           <div class="graph-selected-summary" data-testid="selected-requirement-summary">
             <span class="summary-label">${t('graph.summary.current')}</span>
             <strong>${selectedRequirement?.label || t('common.none')}</strong>

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -144,6 +144,10 @@ export const messages = {
 
     // Graph coverage
     'graph.aria.canvas': 'Graph coverage CFG',
+    'graph.dfg.title': 'Data Flow Graph (def → use)',
+    'graph.dfg.help': 'Definition-clear edges derived from each statement’s assignments. Edges are labelled with the variable carried.',
+    'graph.dfg.empty': 'No definition→use pair detected from the current source.',
+    'graph.dfg.aria': 'Data flow graph',
     'graph.aria.switcher': 'Switch coverage criteria',
     'graph.customTitle': 'Custom Control Flow Graph',
     'graph.source.empty': 'This source only provides a graph; no source code snippet attached.',
@@ -476,6 +480,10 @@ export const messages = {
     'common.none': '無',
 
     'graph.aria.canvas': 'Graph coverage 控制流程圖',
+    'graph.dfg.title': '資料流程圖（def → use）',
+    'graph.dfg.help': '依每個句的賦值推導定義與使用，沿 CFG 走到未被中間 def 覆寫的 use。邊上標示變數名。',
+    'graph.dfg.empty': '從目前原始程式未偵測到 def→use 關係。',
+    'graph.dfg.aria': '資料流程圖',
     'graph.aria.switcher': 'coverage criteria 切換',
     'graph.customTitle': '自訂控制流程圖',
     'graph.source.empty': '這個來源目前只提供 graph，沒有附帶程式碼片段。',

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -2793,7 +2793,7 @@
       <div class="graph-coverage-layout">
         <div class="graph-main-panel">
           ${createGraphCanvas(graph, selectedRequirement)}
-          ${activeProgram.sourceCode ? createDataFlowCanvas(graph) : ""}
+          ${createDataFlowCanvas(graph)}
           <div class="graph-selected-summary" data-testid="selected-requirement-summary">
             <span class="summary-label">${t("graph.summary.current")}</span>
             <strong>${(selectedRequirement == null ? void 0 : selectedRequirement.label) || t("common.none")}</strong>

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -545,6 +545,10 @@
       "common.none": "(none)",
       // Graph coverage
       "graph.aria.canvas": "Graph coverage CFG",
+      "graph.dfg.title": "Data Flow Graph (def \u2192 use)",
+      "graph.dfg.help": "Definition-clear edges derived from each statement\u2019s assignments. Edges are labelled with the variable carried.",
+      "graph.dfg.empty": "No definition\u2192use pair detected from the current source.",
+      "graph.dfg.aria": "Data flow graph",
       "graph.aria.switcher": "Switch coverage criteria",
       "graph.customTitle": "Custom Control Flow Graph",
       "graph.source.empty": "This source only provides a graph; no source code snippet attached.",
@@ -862,6 +866,10 @@
       "graph.parseError": "\u89E3\u6790\u932F\u8AA4\uFF1A{msg}",
       "common.none": "\u7121",
       "graph.aria.canvas": "Graph coverage \u63A7\u5236\u6D41\u7A0B\u5716",
+      "graph.dfg.title": "\u8CC7\u6599\u6D41\u7A0B\u5716\uFF08def \u2192 use\uFF09",
+      "graph.dfg.help": "\u4F9D\u6BCF\u500B\u53E5\u7684\u8CE6\u503C\u63A8\u5C0E\u5B9A\u7FA9\u8207\u4F7F\u7528\uFF0C\u6CBF CFG \u8D70\u5230\u672A\u88AB\u4E2D\u9593 def \u8986\u5BEB\u7684 use\u3002\u908A\u4E0A\u6A19\u793A\u8B8A\u6578\u540D\u3002",
+      "graph.dfg.empty": "\u5F9E\u76EE\u524D\u539F\u59CB\u7A0B\u5F0F\u672A\u5075\u6E2C\u5230 def\u2192use \u95DC\u4FC2\u3002",
+      "graph.dfg.aria": "\u8CC7\u6599\u6D41\u7A0B\u5716",
       "graph.aria.switcher": "coverage criteria \u5207\u63DB",
       "graph.customTitle": "\u81EA\u8A02\u63A7\u5236\u6D41\u7A0B\u5716",
       "graph.source.empty": "\u9019\u500B\u4F86\u6E90\u76EE\u524D\u53EA\u63D0\u4F9B graph\uFF0C\u6C92\u6709\u9644\u5E36\u7A0B\u5F0F\u78BC\u7247\u6BB5\u3002",
@@ -2141,6 +2149,161 @@
     };
   }
 
+  // src/utils/dataFlow.js
+  var KEYWORDS = /* @__PURE__ */ new Set([
+    "if",
+    "else",
+    "while",
+    "for",
+    "do",
+    "switch",
+    "case",
+    "default",
+    "break",
+    "continue",
+    "return",
+    "function",
+    "let",
+    "const",
+    "var",
+    "true",
+    "false",
+    "null",
+    "undefined",
+    "new",
+    "in",
+    "of",
+    "typeof",
+    "instanceof",
+    "void",
+    "this",
+    "try",
+    "catch",
+    "throw",
+    "finally",
+    "class",
+    "extends",
+    "import",
+    "from",
+    "export",
+    "yield",
+    "async",
+    "await",
+    "and",
+    "or",
+    "not",
+    "then",
+    "end",
+    "do"
+  ]);
+  var IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
+  function tokensIn(text) {
+    const found = [];
+    for (const m of text.matchAll(IDENT_RE)) {
+      if (!KEYWORDS.has(m[0])) found.push(m[0]);
+    }
+    return found;
+  }
+  function stripStringsAndComments(text) {
+    return String(text).replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/g, " ").replace(/"(?:[^"\\]|\\.)*"/g, ' ""').replace(/'(?:[^'\\]|\\.)*'/g, " ''").replace(/`(?:[^`\\]|\\.)*`/g, " ``");
+  }
+  function extractDefUse(node) {
+    const defs = /* @__PURE__ */ new Set();
+    const uses = /* @__PURE__ */ new Set();
+    if (!node) return { defs, uses };
+    const raw = node.sourceText || node.label || "";
+    const text = stripStringsAndComments(raw);
+    const fn = text.match(/function\s+[A-Za-z_][\w]*\s*\(([^)]*)\)/) || text.match(/\(([^)]*)\)\s*=>/);
+    if (fn) {
+      for (const p of fn[1].split(",").map((s) => s.trim()).filter(Boolean)) {
+        const name = p.replace(/=.*$/, "").trim();
+        if (name && !KEYWORDS.has(name)) defs.add(name);
+      }
+      for (const u of tokensIn(text.replace(/function\s+[A-Za-z_][\w]*/, ""))) uses.add(u);
+      for (const d of defs) uses.delete(d);
+      return { defs, uses };
+    }
+    const forMatch = text.match(/for\s*\(([^;]*);([^;]*);([^)]*)\)/);
+    if (forMatch) {
+      const [, init, cond, upd] = forMatch;
+      collectAssignment(init, defs, uses);
+      for (const u of tokensIn(cond)) uses.add(u);
+      collectAssignment(upd, defs, uses);
+      return { defs, uses };
+    }
+    const matched = collectAssignment(text, defs, uses);
+    if (!matched) {
+      for (const u of tokensIn(text)) uses.add(u);
+    }
+    return { defs, uses };
+  }
+  function collectAssignment(text, defs, uses) {
+    if (!text) return false;
+    const incDec = text.match(/^[\s(]*([A-Za-z_][\w]*)\s*(\+\+|--)/);
+    if (incDec) {
+      defs.add(incDec[1]);
+      uses.add(incDec[1]);
+      return true;
+    }
+    const compound = text.match(
+      /^[\s(]*([A-Za-z_][\w]*)\s*(?:\+|-|\*|\/|%|&|\||\^|<<|>>|>>>)=(.*)$/
+    );
+    if (compound) {
+      const [, name, rhs] = compound;
+      if (!KEYWORDS.has(name)) {
+        defs.add(name);
+        uses.add(name);
+      }
+      for (const u of tokensIn(rhs)) uses.add(u);
+      return true;
+    }
+    const assign = text.match(
+      /^[\s(]*(?:let\s+|const\s+|var\s+)?([A-Za-z_][\w]*)\s*=(?!=)(.*)$/
+    );
+    if (assign) {
+      const [, name, rhs] = assign;
+      if (!KEYWORDS.has(name)) defs.add(name);
+      for (const u of tokensIn(rhs)) uses.add(u);
+      if (!KEYWORDS.has(name)) uses.delete(name);
+      return true;
+    }
+    return false;
+  }
+  function buildDataFlowGraph(cfg) {
+    var _a2;
+    const out = { nodes: (cfg == null ? void 0 : cfg.nodes) || [], edges: [], defUseByNode: /* @__PURE__ */ new Map() };
+    if (!((_a2 = cfg == null ? void 0 : cfg.nodes) == null ? void 0 : _a2.length)) return out;
+    const preds = new Map(cfg.nodes.map((n) => [n.id, []]));
+    for (const e of cfg.edges || []) {
+      if (preds.has(e.to)) preds.get(e.to).push(e.from);
+    }
+    for (const n of cfg.nodes) out.defUseByNode.set(n.id, extractDefUse(n));
+    const seenEdges = /* @__PURE__ */ new Set();
+    for (const useNode of cfg.nodes) {
+      const { uses } = out.defUseByNode.get(useNode.id);
+      for (const v of uses) {
+        const visited = /* @__PURE__ */ new Set([useNode.id]);
+        const stack = [...preds.get(useNode.id)];
+        while (stack.length) {
+          const cur = stack.pop();
+          if (visited.has(cur)) continue;
+          visited.add(cur);
+          const du = out.defUseByNode.get(cur);
+          if (du && du.defs.has(v)) {
+            const id = `du-${cur}-${useNode.id}-${v}`;
+            if (!seenEdges.has(id)) {
+              seenEdges.add(id);
+              out.edges.push({ id, from: cur, to: useNode.id, variable: v });
+            }
+            continue;
+          }
+          for (const p of preds.get(cur) || []) stack.push(p);
+        }
+      }
+    }
+    return out;
+  }
+
   // src/components/GraphCoverageExplorer.js
   function cloneGraph(graph) {
     return {
@@ -2382,6 +2545,65 @@
     </div>
   `;
   }
+  function createDataFlowCanvas(graph) {
+    const dfg = buildDataFlowGraph(graph);
+    const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
+    const width = Math.max(920, ...graph.nodes.map((node) => node.x + 120));
+    const height = Math.max(340, ...graph.nodes.map((node) => node.y + 90));
+    const grouped = /* @__PURE__ */ new Map();
+    for (const e of dfg.edges) {
+      const key = `${e.from}->${e.to}`;
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key).push(e);
+    }
+    const edgeMarkup = [...grouped.entries()].map(([key, group]) => {
+      const sample = group[0];
+      const a = nodeById.get(sample.from);
+      const b = nodeById.get(sample.to);
+      if (!a || !b) return "";
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const len = Math.hypot(dx, dy) || 1;
+      const sign = a.y <= b.y ? -1 : 1;
+      const offset = 28 + group.length * 6;
+      const cx = (a.x + b.x) / 2 + -dy / len * offset * sign;
+      const cy = (a.y + b.y) / 2 + dx / len * offset * sign;
+      const labels = group.map((e) => e.variable).join(", ");
+      return `
+      <g class="graph-dfg-edge" data-testid="dfg-edge-${escapeHtml(key)}">
+        <path d="M ${a.x} ${a.y} Q ${cx} ${cy} ${b.x} ${b.y}"
+              marker-end="url(#dfg-arrow)"></path>
+        <text x="${cx}" y="${cy}" text-anchor="middle">${escapeHtml(labels)}</text>
+      </g>
+    `;
+    }).join("");
+    const empty = dfg.edges.length === 0 ? `<p class="graph-dfg-empty" data-testid="graph-dfg-empty">${t("graph.dfg.empty")}</p>` : "";
+    return `
+    <div class="graph-dfg-card" data-testid="graph-dfg-card">
+      <div class="graph-dfg-header">
+        <h4>${t("graph.dfg.title")}</h4>
+        <p>${t("graph.dfg.help")}</p>
+      </div>
+      <div class="graph-canvas graph-dfg-canvas" data-testid="graph-dfg-canvas">
+        <svg viewBox="0 0 ${width} ${height}" role="img" aria-label="${t("graph.dfg.aria")}">
+          <defs>
+            <marker id="dfg-arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+              <path d="M0,0 L12,6 L0,12 z" fill="#0ea5e9"></path>
+            </marker>
+          </defs>
+          ${edgeMarkup}
+          ${graph.nodes.map((node) => `
+            <g class="graph-node graph-dfg-node" data-testid="dfg-node-${node.id}">
+              <circle cx="${node.x}" cy="${node.y}" r="24"></circle>
+              <text x="${node.x}" y="${node.y + 5}" text-anchor="middle">${node.label}</text>
+            </g>
+          `).join("")}
+        </svg>
+      </div>
+      ${empty}
+    </div>
+  `;
+  }
   function createGraphCoverageExplorer() {
     const root2 = document.createElement("div");
     const defaultGraph = cloneGraph(graphCoverageGraph);
@@ -2571,6 +2793,7 @@
       <div class="graph-coverage-layout">
         <div class="graph-main-panel">
           ${createGraphCanvas(graph, selectedRequirement)}
+          ${activeProgram.sourceCode ? createDataFlowCanvas(graph) : ""}
           <div class="graph-selected-summary" data-testid="selected-requirement-summary">
             <span class="summary-label">${t("graph.summary.current")}</span>
             <strong>${(selectedRequirement == null ? void 0 : selectedRequirement.label) || t("common.none")}</strong>

--- a/src/tests/dataFlow.test.js
+++ b/src/tests/dataFlow.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { extractDefUse, buildDataFlowGraph } from '../utils/dataFlow.js';
+import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
+
+describe('extractDefUse', () => {
+  it('treats LHS of an assignment as def and RHS as use', () => {
+    const { defs, uses } = extractDefUse({ sourceText: 'sum = a + b' });
+    expect([...defs]).toEqual(['sum']);
+    expect([...uses].sort()).toEqual(['a', 'b']);
+  });
+
+  it('handles let / const / var', () => {
+    const { defs, uses } = extractDefUse({ sourceText: 'let i = n - 1' });
+    expect([...defs]).toEqual(['i']);
+    expect([...uses]).toEqual(['n']);
+  });
+
+  it('handles compound assignment', () => {
+    const { defs, uses } = extractDefUse({ sourceText: 'count += step' });
+    expect([...defs]).toEqual(['count']);
+    expect([...uses].sort()).toEqual(['count', 'step']);
+  });
+
+  it('handles ++/--', () => {
+    const { defs, uses } = extractDefUse({ sourceText: 'i++' });
+    expect([...defs]).toEqual(['i']);
+    expect([...uses]).toEqual(['i']);
+  });
+
+  it('treats function-header parameters as defs', () => {
+    const { defs } = extractDefUse({ sourceText: 'function add(a, b) {' });
+    expect([...defs].sort()).toEqual(['a', 'b']);
+  });
+
+  it('treats for-init as def, condition/update as use+def', () => {
+    const { defs, uses } = extractDefUse({ sourceText: 'for (let i = 0; i < n; i++) {' });
+    expect([...defs].sort()).toEqual(['i']);
+    expect([...uses].sort()).toEqual(['i', 'n']);
+  });
+
+  it('treats a bare condition as pure uses', () => {
+    const { defs, uses } = extractDefUse({ sourceText: 'if (a > b)' });
+    expect(defs.size).toBe(0);
+    expect([...uses].sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildDataFlowGraph', () => {
+  it('produces a def→use edge along a straight CFG', () => {
+    const cfg = {
+      nodes: [
+        { id: 'n1', sourceText: 'a = 1' },
+        { id: 'n2', sourceText: 'b = a + 2' },
+      ],
+      edges: [{ id: 'e1', from: 'n1', to: 'n2' }],
+    };
+    const dfg = buildDataFlowGraph(cfg);
+    expect(dfg.edges).toHaveLength(1);
+    expect(dfg.edges[0]).toMatchObject({ from: 'n1', to: 'n2', variable: 'a' });
+  });
+
+  it('a redefinition kills earlier defs (definition-clear paths only)', () => {
+    const cfg = {
+      nodes: [
+        { id: 'n1', sourceText: 'x = 1' },
+        { id: 'n2', sourceText: 'x = 2' },
+        { id: 'n3', sourceText: 'y = x + 1' },
+      ],
+      edges: [
+        { id: 'e1', from: 'n1', to: 'n2' },
+        { id: 'e2', from: 'n2', to: 'n3' },
+      ],
+    };
+    const dfg = buildDataFlowGraph(cfg);
+    // Only n2 → n3 should remain for x; n1 → n3 is killed by n2.
+    const xEdges = dfg.edges.filter((e) => e.variable === 'x');
+    expect(xEdges).toHaveLength(1);
+    expect(xEdges[0]).toMatchObject({ from: 'n2', to: 'n3' });
+  });
+
+  it('integrates with programToGraph for a small JS function', () => {
+    const cfg = generateControlFlowGraphFromProgram({
+      sourceCode: [
+        'function f(n) {',
+        '  let s = 0;',
+        '  for (let i = 0; i < n; i++) {',
+        '    s = s + i;',
+        '  }',
+        '  return s;',
+        '}',
+      ].join('\n'),
+      language: 'javascript',
+      title: 'f',
+    });
+    const dfg = buildDataFlowGraph(cfg);
+    // We expect at least one edge for `s` and one for `i` reaching the body / return.
+    expect(dfg.edges.some((e) => e.variable === 's')).toBe(true);
+    expect(dfg.edges.some((e) => e.variable === 'i')).toBe(true);
+  });
+});

--- a/src/utils/dataFlow.js
+++ b/src/utils/dataFlow.js
@@ -1,0 +1,169 @@
+// Lightweight intra-procedural data-flow analyzer.
+//
+// Input: a CFG produced by programToGraph.js (nodes have `id`, `kind`,
+// `sourceText`, `sourceLine`; edges have `id`, `from`, `to`).
+// Output:
+//   - extractDefUse(node) → { defs: Set<string>, uses: Set<string> }
+//   - buildDataFlowGraph(cfg) → { nodes, edges } where each edge is a
+//     definition-clear def→use pair (`{ id, from, to, variable }`).
+//
+// The parser is a small heuristic that recognises the JavaScript-ish
+// subset already understood by programToGraph (assignments, ++/--, +=,
+// for-init, function parameters in the header). It is intentionally
+// conservative: anything it does not recognise as a definition is
+// treated as a pure use.
+
+const KEYWORDS = new Set([
+  'if', 'else', 'while', 'for', 'do', 'switch', 'case', 'default',
+  'break', 'continue', 'return', 'function', 'let', 'const', 'var',
+  'true', 'false', 'null', 'undefined', 'new', 'in', 'of', 'typeof',
+  'instanceof', 'void', 'this', 'try', 'catch', 'throw', 'finally',
+  'class', 'extends', 'import', 'from', 'export', 'yield', 'async',
+  'await', 'and', 'or', 'not', 'then', 'end', 'do',
+]);
+
+const IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
+
+function tokensIn(text) {
+  const found = [];
+  for (const m of text.matchAll(IDENT_RE)) {
+    if (!KEYWORDS.has(m[0])) found.push(m[0]);
+  }
+  return found;
+}
+
+function stripStringsAndComments(text) {
+  return String(text)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/.*$/g, ' ')
+    .replace(/"(?:[^"\\]|\\.)*"/g, ' ""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, " ''")
+    .replace(/`(?:[^`\\]|\\.)*`/g, ' ``');
+}
+
+/**
+ * Heuristically extract definitions and uses for a single CFG-node line.
+ * @param {{ kind?: string, sourceText?: string, label?: string }} node
+ * @returns {{ defs: Set<string>, uses: Set<string> }}
+ */
+export function extractDefUse(node) {
+  const defs = new Set();
+  const uses = new Set();
+  if (!node) return { defs, uses };
+
+  const raw = node.sourceText || node.label || '';
+  const text = stripStringsAndComments(raw);
+
+  // Function parameters as definitions on the entry line.
+  const fn = text.match(/function\s+[A-Za-z_][\w]*\s*\(([^)]*)\)/)
+    || text.match(/\(([^)]*)\)\s*=>/);
+  if (fn) {
+    for (const p of fn[1].split(',').map((s) => s.trim()).filter(Boolean)) {
+      const name = p.replace(/=.*$/, '').trim();
+      if (name && !KEYWORDS.has(name)) defs.add(name);
+    }
+    for (const u of tokensIn(text.replace(/function\s+[A-Za-z_][\w]*/, ''))) uses.add(u);
+    for (const d of defs) uses.delete(d);
+    return { defs, uses };
+  }
+
+  // for ( init ; cond ; update )
+  const forMatch = text.match(/for\s*\(([^;]*);([^;]*);([^)]*)\)/);
+  if (forMatch) {
+    const [, init, cond, upd] = forMatch;
+    collectAssignment(init, defs, uses);
+    for (const u of tokensIn(cond)) uses.add(u);
+    collectAssignment(upd, defs, uses);
+    return { defs, uses };
+  }
+
+  // Plain assignment(s) on a single line, including `let x = …`.
+  const matched = collectAssignment(text, defs, uses);
+
+  // Anything else is treated as a pure use (conditions, return, calls…).
+  if (!matched) {
+    for (const u of tokensIn(text)) uses.add(u);
+  }
+  return { defs, uses };
+}
+
+function collectAssignment(text, defs, uses) {
+  if (!text) return false;
+  // `let a = b + c`, `a = b`, `a += b`, `a++`, `a--`
+  // Match a single (non-property) lvalue followed by an assignment op.
+  const incDec = text.match(/^[\s(]*([A-Za-z_][\w]*)\s*(\+\+|--)/);
+  if (incDec) {
+    defs.add(incDec[1]);
+    uses.add(incDec[1]);
+    return true;
+  }
+  const compound = text.match(
+    /^[\s(]*([A-Za-z_][\w]*)\s*(?:\+|-|\*|\/|%|&|\||\^|<<|>>|>>>)=(.*)$/,
+  );
+  if (compound) {
+    const [, name, rhs] = compound;
+    if (!KEYWORDS.has(name)) {
+      defs.add(name);
+      uses.add(name); // compound: lvalue is also a use
+    }
+    for (const u of tokensIn(rhs)) uses.add(u);
+    return true;
+  }
+  const assign = text.match(
+    /^[\s(]*(?:let\s+|const\s+|var\s+)?([A-Za-z_][\w]*)\s*=(?!=)(.*)$/,
+  );
+  if (assign) {
+    const [, name, rhs] = assign;
+    if (!KEYWORDS.has(name)) defs.add(name);
+    for (const u of tokensIn(rhs)) uses.add(u);
+    // Strip the freshly-defined name from uses (RHS may not reference it).
+    if (!KEYWORDS.has(name)) uses.delete(name);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Build the data-flow graph (definition-clear def→use edges) for a CFG.
+ * @param {{ nodes: Array, edges: Array, startNodeId?: string }} cfg
+ * @returns {{ nodes: Array, edges: Array<{id:string,from:string,to:string,variable:string}>, defUseByNode: Map }}
+ */
+export function buildDataFlowGraph(cfg) {
+  const out = { nodes: cfg?.nodes || [], edges: [], defUseByNode: new Map() };
+  if (!cfg?.nodes?.length) return out;
+
+  // Predecessor map.
+  const preds = new Map(cfg.nodes.map((n) => [n.id, []]));
+  for (const e of cfg.edges || []) {
+    if (preds.has(e.to)) preds.get(e.to).push(e.from);
+  }
+
+  // Per-node defs/uses.
+  for (const n of cfg.nodes) out.defUseByNode.set(n.id, extractDefUse(n));
+
+  const seenEdges = new Set();
+  for (const useNode of cfg.nodes) {
+    const { uses } = out.defUseByNode.get(useNode.id);
+    for (const v of uses) {
+      // Walk predecessors to find every definition-clear def of `v`.
+      const visited = new Set([useNode.id]);
+      const stack = [...preds.get(useNode.id)];
+      while (stack.length) {
+        const cur = stack.pop();
+        if (visited.has(cur)) continue;
+        visited.add(cur);
+        const du = out.defUseByNode.get(cur);
+        if (du && du.defs.has(v)) {
+          const id = `du-${cur}-${useNode.id}-${v}`;
+          if (!seenEdges.has(id)) {
+            seenEdges.add(id);
+            out.edges.push({ id, from: cur, to: useNode.id, variable: v });
+          }
+          continue; // Stop: this path's def is killed by `cur`.
+        }
+        for (const p of preds.get(cur) || []) stack.push(p);
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #42.

## What
Adds a Data Flow Graph view inside Graph Coverage Explorer, derived from the same program source as the existing CFG.

### Algorithm (`src/utils/dataFlow.js`)
- `extractDefUse(node)` — heuristic JS-flavored parser of `node.sourceText`:
  - assignments / `let` / `const` / `var` → LHS as def, RHS as uses
  - compound ops (`+=`, `-=` …) and `++`/`--` → LHS is both def and use
  - function-header parameters → defs
  - `for (init; cond; update)` → init/update collect, cond is pure use
- `buildDataFlowGraph(cfg)` — for each use of `v`, walks predecessor edges and stops at the first node that redefines `v` (kill), emitting one `du-{from}-{to}-{var}` edge per definition-clear path.

### UI (`GraphCoverageExplorer.js` + `.css`)
- New `createDataFlowCanvas(graph)` rendered directly under the CFG canvas when the active program has source code.
- Reuses CFG node positions for visual alignment; draws curved dashed sky-blue edges (`#0ea5e9`) labelled with the variable name (multi-var pairs are concatenated).
- `.graph-dfg-card`, `.graph-dfg-edge`, `.graph-dfg-node`, `.graph-dfg-empty`.

### i18n
- `graph.dfg.{title,help,empty,aria}` mirrored EN + zh.

## Tests
- `src/tests/dataFlow.test.js` — 10 unit tests:
  - 7 `extractDefUse` cases (assignment / let / compound / ++/-- / function params / for-loop / pure condition)
  - 3 `buildDataFlowGraph` cases (straight chain / kill by redefinition / round-trip via `programToGraph` on a small JS function)
- `npm run test:run` → **180/180 passing**.

## Files
6 files, +625 / -0 (no changes to existing CFG generation, coverage criteria, or test path planner).