### PR TITLE
feat(graph): data flow coverage (All-Defs / All-Uses / All-DU-Paths)

### DIFF
--- a/src/data/testingData.js
+++ b/src/data/testingData.js
@@ -70,6 +70,9 @@ export const graphCoverageCriteria = [
   { id: 'prime-path',    label: 'Prime Path Coverage',    labelZh: 'Prime Path 覆蓋', description: '所有 prime path 都必須被測試需求涵蓋，包含迴圈。', descriptionEn: 'All prime paths (including loops) must be covered.' },
   { id: 'edge-pair',     label: 'Edge-Pair Coverage',     labelZh: '邊對覆蓋',     description: '每一組相鄰的兩條邊都要至少被一條測試路徑覆蓋。', descriptionEn: 'Every pair of adjacent edges must be covered by some test path.' },
   { id: 'complete-path', label: 'Complete Path Coverage', labelZh: '完整路徑覆蓋', description: '以有限深度列舉 start 到 end 的完整可行路徑集合。', descriptionEn: 'Enumerate all complete feasible paths from start to end up to a finite depth.' },
+  { id: 'all-defs',      label: 'All-Defs Coverage',      labelZh: '所有定義覆蓋',     description: '對於每個 (節點, 變數) 的定義，至少有一條從該定義到某個使用的 def-clear 路徑被覆蓋。', descriptionEn: 'For every (node, variable) definition, cover at least one definition-clear path from the def to some use of that variable.' },
+  { id: 'all-uses',      label: 'All-Uses Coverage',      labelZh: '所有使用覆蓋',     description: '對於每對 (定義, 使用, 變數)，至少有一條 def-clear 路徑被測試路徑覆蓋。', descriptionEn: 'For every (def, use, variable) pair, cover at least one definition-clear path from the def to that use.' },
+  { id: 'all-du-paths',  label: 'All-DU-Paths Coverage',  labelZh: '所有 DU 路徑覆蓋', description: '對於每對 (定義, 使用, 變數)，所有 def-clear 簡單路徑都必須被測試路徑覆蓋。', descriptionEn: 'For every (def, use, variable) pair, every definition-clear simple path from the def to that use must be covered.' },
 ];
 
 export const graphCoverageCodeLanguages = [

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -68,7 +68,10 @@
     { id: "edge", label: "Edge Coverage", labelZh: "\u908A\u8986\u84CB", description: "\u6BCF\u689D\u6709\u5411\u908A\u81F3\u5C11\u88AB\u4E00\u500B\u6E2C\u8A66\u8DEF\u5F91\u7D93\u904E\u4E00\u6B21\u3002", descriptionEn: "Every directed edge is traversed by at least one test path." },
     { id: "prime-path", label: "Prime Path Coverage", labelZh: "Prime Path \u8986\u84CB", description: "\u6240\u6709 prime path \u90FD\u5FC5\u9808\u88AB\u6E2C\u8A66\u9700\u6C42\u6DB5\u84CB\uFF0C\u5305\u542B\u8FF4\u5708\u3002", descriptionEn: "All prime paths (including loops) must be covered." },
     { id: "edge-pair", label: "Edge-Pair Coverage", labelZh: "\u908A\u5C0D\u8986\u84CB", description: "\u6BCF\u4E00\u7D44\u76F8\u9130\u7684\u5169\u689D\u908A\u90FD\u8981\u81F3\u5C11\u88AB\u4E00\u689D\u6E2C\u8A66\u8DEF\u5F91\u8986\u84CB\u3002", descriptionEn: "Every pair of adjacent edges must be covered by some test path." },
-    { id: "complete-path", label: "Complete Path Coverage", labelZh: "\u5B8C\u6574\u8DEF\u5F91\u8986\u84CB", description: "\u4EE5\u6709\u9650\u6DF1\u5EA6\u5217\u8209 start \u5230 end \u7684\u5B8C\u6574\u53EF\u884C\u8DEF\u5F91\u96C6\u5408\u3002", descriptionEn: "Enumerate all complete feasible paths from start to end up to a finite depth." }
+    { id: "complete-path", label: "Complete Path Coverage", labelZh: "\u5B8C\u6574\u8DEF\u5F91\u8986\u84CB", description: "\u4EE5\u6709\u9650\u6DF1\u5EA6\u5217\u8209 start \u5230 end \u7684\u5B8C\u6574\u53EF\u884C\u8DEF\u5F91\u96C6\u5408\u3002", descriptionEn: "Enumerate all complete feasible paths from start to end up to a finite depth." },
+    { id: "all-defs", label: "All-Defs Coverage", labelZh: "\u6240\u6709\u5B9A\u7FA9\u8986\u84CB", description: "\u5C0D\u65BC\u6BCF\u500B (\u7BC0\u9EDE, \u8B8A\u6578) \u7684\u5B9A\u7FA9\uFF0C\u81F3\u5C11\u6709\u4E00\u689D\u5F9E\u8A72\u5B9A\u7FA9\u5230\u67D0\u500B\u4F7F\u7528\u7684 def-clear \u8DEF\u5F91\u88AB\u8986\u84CB\u3002", descriptionEn: "For every (node, variable) definition, cover at least one definition-clear path from the def to some use of that variable." },
+    { id: "all-uses", label: "All-Uses Coverage", labelZh: "\u6240\u6709\u4F7F\u7528\u8986\u84CB", description: "\u5C0D\u65BC\u6BCF\u5C0D (\u5B9A\u7FA9, \u4F7F\u7528, \u8B8A\u6578)\uFF0C\u81F3\u5C11\u6709\u4E00\u689D def-clear \u8DEF\u5F91\u88AB\u6E2C\u8A66\u8DEF\u5F91\u8986\u84CB\u3002", descriptionEn: "For every (def, use, variable) pair, cover at least one definition-clear path from the def to that use." },
+    { id: "all-du-paths", label: "All-DU-Paths Coverage", labelZh: "\u6240\u6709 DU \u8DEF\u5F91\u8986\u84CB", description: "\u5C0D\u65BC\u6BCF\u5C0D (\u5B9A\u7FA9, \u4F7F\u7528, \u8B8A\u6578)\uFF0C\u6240\u6709 def-clear \u7C21\u55AE\u8DEF\u5F91\u90FD\u5FC5\u9808\u88AB\u6E2C\u8A66\u8DEF\u5F91\u8986\u84CB\u3002", descriptionEn: "For every (def, use, variable) pair, every definition-clear simple path from the def to that use must be covered." }
   ];
   var graphCoverageCodeLanguages = [
     { id: "javascript", label: "JavaScript" },
@@ -1220,6 +1223,161 @@
     return root2;
   }
 
+  // src/utils/dataFlow.js
+  var KEYWORDS = /* @__PURE__ */ new Set([
+    "if",
+    "else",
+    "while",
+    "for",
+    "do",
+    "switch",
+    "case",
+    "default",
+    "break",
+    "continue",
+    "return",
+    "function",
+    "let",
+    "const",
+    "var",
+    "true",
+    "false",
+    "null",
+    "undefined",
+    "new",
+    "in",
+    "of",
+    "typeof",
+    "instanceof",
+    "void",
+    "this",
+    "try",
+    "catch",
+    "throw",
+    "finally",
+    "class",
+    "extends",
+    "import",
+    "from",
+    "export",
+    "yield",
+    "async",
+    "await",
+    "and",
+    "or",
+    "not",
+    "then",
+    "end",
+    "do"
+  ]);
+  var IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
+  function tokensIn(text) {
+    const found = [];
+    for (const m of text.matchAll(IDENT_RE)) {
+      if (!KEYWORDS.has(m[0])) found.push(m[0]);
+    }
+    return found;
+  }
+  function stripStringsAndComments(text) {
+    return String(text).replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/g, " ").replace(/"(?:[^"\\]|\\.)*"/g, ' ""').replace(/'(?:[^'\\]|\\.)*'/g, " ''").replace(/`(?:[^`\\]|\\.)*`/g, " ``");
+  }
+  function extractDefUse(node) {
+    const defs = /* @__PURE__ */ new Set();
+    const uses = /* @__PURE__ */ new Set();
+    if (!node) return { defs, uses };
+    const raw = node.sourceText || node.label || "";
+    const text = stripStringsAndComments(raw);
+    const fn = text.match(/function\s+[A-Za-z_][\w]*\s*\(([^)]*)\)/) || text.match(/\(([^)]*)\)\s*=>/);
+    if (fn) {
+      for (const p of fn[1].split(",").map((s) => s.trim()).filter(Boolean)) {
+        const name = p.replace(/=.*$/, "").trim();
+        if (name && !KEYWORDS.has(name)) defs.add(name);
+      }
+      for (const u of tokensIn(text.replace(/function\s+[A-Za-z_][\w]*/, ""))) uses.add(u);
+      for (const d of defs) uses.delete(d);
+      return { defs, uses };
+    }
+    const forMatch = text.match(/for\s*\(([^;]*);([^;]*);([^)]*)\)/);
+    if (forMatch) {
+      const [, init, cond, upd] = forMatch;
+      collectAssignment(init, defs, uses);
+      for (const u of tokensIn(cond)) uses.add(u);
+      collectAssignment(upd, defs, uses);
+      return { defs, uses };
+    }
+    const matched = collectAssignment(text, defs, uses);
+    if (!matched) {
+      for (const u of tokensIn(text)) uses.add(u);
+    }
+    return { defs, uses };
+  }
+  function collectAssignment(text, defs, uses) {
+    if (!text) return false;
+    const incDec = text.match(/^[\s(]*([A-Za-z_][\w]*)\s*(\+\+|--)/);
+    if (incDec) {
+      defs.add(incDec[1]);
+      uses.add(incDec[1]);
+      return true;
+    }
+    const compound = text.match(
+      /^[\s(]*([A-Za-z_][\w]*)\s*(?:\+|-|\*|\/|%|&|\||\^|<<|>>|>>>)=(.*)$/
+    );
+    if (compound) {
+      const [, name, rhs] = compound;
+      if (!KEYWORDS.has(name)) {
+        defs.add(name);
+        uses.add(name);
+      }
+      for (const u of tokensIn(rhs)) uses.add(u);
+      return true;
+    }
+    const assign = text.match(
+      /^[\s(]*(?:let\s+|const\s+|var\s+)?([A-Za-z_][\w]*)\s*=(?!=)(.*)$/
+    );
+    if (assign) {
+      const [, name, rhs] = assign;
+      if (!KEYWORDS.has(name)) defs.add(name);
+      for (const u of tokensIn(rhs)) uses.add(u);
+      if (!KEYWORDS.has(name)) uses.delete(name);
+      return true;
+    }
+    return false;
+  }
+  function buildDataFlowGraph(cfg) {
+    var _a2;
+    const out = { nodes: (cfg == null ? void 0 : cfg.nodes) || [], edges: [], defUseByNode: /* @__PURE__ */ new Map() };
+    if (!((_a2 = cfg == null ? void 0 : cfg.nodes) == null ? void 0 : _a2.length)) return out;
+    const preds = new Map(cfg.nodes.map((n) => [n.id, []]));
+    for (const e of cfg.edges || []) {
+      if (preds.has(e.to)) preds.get(e.to).push(e.from);
+    }
+    for (const n of cfg.nodes) out.defUseByNode.set(n.id, extractDefUse(n));
+    const seenEdges = /* @__PURE__ */ new Set();
+    for (const useNode of cfg.nodes) {
+      const { uses } = out.defUseByNode.get(useNode.id);
+      for (const v of uses) {
+        const visited = /* @__PURE__ */ new Set([useNode.id]);
+        const stack = [...preds.get(useNode.id)];
+        while (stack.length) {
+          const cur = stack.pop();
+          if (visited.has(cur)) continue;
+          visited.add(cur);
+          const du = out.defUseByNode.get(cur);
+          if (du && du.defs.has(v)) {
+            const id = `du-${cur}-${useNode.id}-${v}`;
+            if (!seenEdges.has(id)) {
+              seenEdges.add(id);
+              out.edges.push({ id, from: cur, to: useNode.id, variable: v });
+            }
+            continue;
+          }
+          for (const p of preds.get(cur) || []) stack.push(p);
+        }
+      }
+    }
+    return out;
+  }
+
   // src/utils/graphCoverage.js
   function buildAdjacency(graph) {
     const adjacency = /* @__PURE__ */ new Map();
@@ -1310,7 +1468,165 @@
     if (requirement.type === "prime-path" || requirement.type === "complete-path") {
       return containsNodePath(record.path, requirement.nodes);
     }
+    if (requirement.type === "all-defs" || requirement.type === "all-uses" || requirement.type === "all-du-paths") {
+      return containsNodePath(record.path, requirement.path || requirement.nodes);
+    }
     return false;
+  }
+  function buildDefUseMap(graph) {
+    const map = /* @__PURE__ */ new Map();
+    graph.nodes.forEach((node) => {
+      map.set(node.id, extractDefUse(node));
+    });
+    return map;
+  }
+  function enumerateDefClearPaths(graph, defNodeId, useNodeId, variable, defUseMap, maxDepth) {
+    const adjacency = buildAdjacency(graph);
+    const limit = maxDepth != null ? maxDepth : Math.max(8, graph.nodes.length * 2);
+    const results = [];
+    function walk(currentId, path, visited) {
+      if (path.length > limit) return;
+      if (currentId === useNodeId && path.length >= 2) {
+        results.push([...path]);
+        return;
+      }
+      const out = adjacency.get(currentId) || [];
+      for (const edge of out) {
+        const next = edge.to;
+        if (visited.has(next)) continue;
+        if (next !== useNodeId) {
+          const du = defUseMap.get(next);
+          if (du && du.defs.has(variable)) continue;
+        }
+        visited.add(next);
+        path.push(next);
+        walk(next, path, visited);
+        path.pop();
+        visited.delete(next);
+      }
+    }
+    walk(defNodeId, [defNodeId], /* @__PURE__ */ new Set([defNodeId]));
+    return results;
+  }
+  function shortestDefClearPath(graph, defNodeId, useNodeId, variable, defUseMap) {
+    const adjacency = buildAdjacency(graph);
+    const queue = [[defNodeId]];
+    const seenStates = /* @__PURE__ */ new Set([defNodeId]);
+    while (queue.length) {
+      const path = queue.shift();
+      const head = path[path.length - 1];
+      if (head === useNodeId && path.length >= 2) return path;
+      const out = adjacency.get(head) || [];
+      for (const edge of out) {
+        const next = edge.to;
+        if (path.includes(next)) continue;
+        if (next !== useNodeId) {
+          const du = defUseMap.get(next);
+          if (du && du.defs.has(variable)) continue;
+        }
+        const stateKey = `${path.join(">")}>${next}`;
+        if (seenStates.has(stateKey)) continue;
+        seenStates.add(stateKey);
+        queue.push([...path, next]);
+      }
+    }
+    return null;
+  }
+  function collectDefUsePairs(graph, defUseMap) {
+    const pairs = [];
+    graph.nodes.forEach((defNode) => {
+      var _a2;
+      const defs = (_a2 = defUseMap.get(defNode.id)) == null ? void 0 : _a2.defs;
+      if (!defs || defs.size === 0) return;
+      defs.forEach((variable) => {
+        graph.nodes.forEach((useNode) => {
+          var _a3;
+          const uses = (_a3 = defUseMap.get(useNode.id)) == null ? void 0 : _a3.uses;
+          if (!uses || !uses.has(variable)) return;
+          const sample = shortestDefClearPath(graph, defNode.id, useNode.id, variable, defUseMap);
+          if (sample) {
+            pairs.push({ defNodeId: defNode.id, useNodeId: useNode.id, variable, samplePath: sample });
+          }
+        });
+      });
+    });
+    return pairs;
+  }
+  function nodeLabelOf(graph, nodeId) {
+    var _a2;
+    return ((_a2 = graph.nodes.find((n) => n.id === nodeId)) == null ? void 0 : _a2.label) || nodeId;
+  }
+  function getAllDefsRequirements(graph) {
+    const normalizedGraph = normalizeGraph(graph);
+    const defUseMap = buildDefUseMap(normalizedGraph);
+    const pairs = collectDefUsePairs(normalizedGraph, defUseMap);
+    const byDef = /* @__PURE__ */ new Map();
+    pairs.forEach((p) => {
+      const key = `${p.defNodeId}|${p.variable}`;
+      const existing = byDef.get(key);
+      if (!existing || p.samplePath.length < existing.samplePath.length) {
+        byDef.set(key, p);
+      }
+    });
+    return Array.from(byDef.values()).map((p, index) => ({
+      id: `all-defs-${index + 1}-${p.defNodeId}-${p.variable}`,
+      type: "all-defs",
+      label: `Def ${nodeLabelOf(normalizedGraph, p.defNodeId)} (${p.variable}) -> use ${nodeLabelOf(normalizedGraph, p.useNodeId)}`,
+      displayText: `${p.variable}@${p.defNodeId} -> ${p.useNodeId} : ${p.samplePath.join(" -> ")}`,
+      nodes: [...new Set(p.samplePath)],
+      edges: edgeIdsFromPath(normalizedGraph, p.samplePath),
+      path: p.samplePath,
+      variable: p.variable,
+      defNodeId: p.defNodeId,
+      useNodeId: p.useNodeId
+    }));
+  }
+  function getAllUsesRequirements(graph) {
+    const normalizedGraph = normalizeGraph(graph);
+    const defUseMap = buildDefUseMap(normalizedGraph);
+    const pairs = collectDefUsePairs(normalizedGraph, defUseMap);
+    return pairs.map((p, index) => ({
+      id: `all-uses-${index + 1}-${p.defNodeId}-${p.useNodeId}-${p.variable}`,
+      type: "all-uses",
+      label: `Use ${nodeLabelOf(normalizedGraph, p.useNodeId)} of ${p.variable} from ${nodeLabelOf(normalizedGraph, p.defNodeId)}`,
+      displayText: `${p.variable}: ${p.defNodeId} -> ${p.useNodeId} : ${p.samplePath.join(" -> ")}`,
+      nodes: [...new Set(p.samplePath)],
+      edges: edgeIdsFromPath(normalizedGraph, p.samplePath),
+      path: p.samplePath,
+      variable: p.variable,
+      defNodeId: p.defNodeId,
+      useNodeId: p.useNodeId
+    }));
+  }
+  function getAllDuPathsRequirements(graph) {
+    const normalizedGraph = normalizeGraph(graph);
+    const defUseMap = buildDefUseMap(normalizedGraph);
+    const pairs = collectDefUsePairs(normalizedGraph, defUseMap);
+    const requirements = [];
+    pairs.forEach((p) => {
+      const allPaths = enumerateDefClearPaths(
+        normalizedGraph,
+        p.defNodeId,
+        p.useNodeId,
+        p.variable,
+        defUseMap
+      );
+      allPaths.forEach((path, idx) => {
+        requirements.push({
+          id: `all-du-paths-${requirements.length + 1}-${p.defNodeId}-${p.useNodeId}-${p.variable}-${idx + 1}`,
+          type: "all-du-paths",
+          label: `DU-Path ${p.variable}: ${path.join(" -> ")}`,
+          displayText: `${p.variable}: ${path.join(" -> ")}`,
+          nodes: [...new Set(path)],
+          edges: edgeIdsFromPath(normalizedGraph, path),
+          path,
+          variable: p.variable,
+          defNodeId: p.defNodeId,
+          useNodeId: p.useNodeId
+        });
+      });
+    });
+    return requirements;
   }
   function greedySetCover(pathRecords, requirements) {
     const uncovered = new Set(requirements.map((item) => item.id));
@@ -1582,6 +1898,15 @@
     }
     if (criterion === "complete-path") {
       return getCompletePathRequirements(graph);
+    }
+    if (criterion === "all-defs") {
+      return getAllDefsRequirements(graph);
+    }
+    if (criterion === "all-uses") {
+      return getAllUsesRequirements(graph);
+    }
+    if (criterion === "all-du-paths") {
+      return getAllDuPathsRequirements(graph);
     }
     return [];
   }
@@ -2265,161 +2590,6 @@
       nodes: builder.nodes,
       edges: builder.edges
     };
-  }
-
-  // src/utils/dataFlow.js
-  var KEYWORDS = /* @__PURE__ */ new Set([
-    "if",
-    "else",
-    "while",
-    "for",
-    "do",
-    "switch",
-    "case",
-    "default",
-    "break",
-    "continue",
-    "return",
-    "function",
-    "let",
-    "const",
-    "var",
-    "true",
-    "false",
-    "null",
-    "undefined",
-    "new",
-    "in",
-    "of",
-    "typeof",
-    "instanceof",
-    "void",
-    "this",
-    "try",
-    "catch",
-    "throw",
-    "finally",
-    "class",
-    "extends",
-    "import",
-    "from",
-    "export",
-    "yield",
-    "async",
-    "await",
-    "and",
-    "or",
-    "not",
-    "then",
-    "end",
-    "do"
-  ]);
-  var IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
-  function tokensIn(text) {
-    const found = [];
-    for (const m of text.matchAll(IDENT_RE)) {
-      if (!KEYWORDS.has(m[0])) found.push(m[0]);
-    }
-    return found;
-  }
-  function stripStringsAndComments(text) {
-    return String(text).replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/g, " ").replace(/"(?:[^"\\]|\\.)*"/g, ' ""').replace(/'(?:[^'\\]|\\.)*'/g, " ''").replace(/`(?:[^`\\]|\\.)*`/g, " ``");
-  }
-  function extractDefUse(node) {
-    const defs = /* @__PURE__ */ new Set();
-    const uses = /* @__PURE__ */ new Set();
-    if (!node) return { defs, uses };
-    const raw = node.sourceText || node.label || "";
-    const text = stripStringsAndComments(raw);
-    const fn = text.match(/function\s+[A-Za-z_][\w]*\s*\(([^)]*)\)/) || text.match(/\(([^)]*)\)\s*=>/);
-    if (fn) {
-      for (const p of fn[1].split(",").map((s) => s.trim()).filter(Boolean)) {
-        const name = p.replace(/=.*$/, "").trim();
-        if (name && !KEYWORDS.has(name)) defs.add(name);
-      }
-      for (const u of tokensIn(text.replace(/function\s+[A-Za-z_][\w]*/, ""))) uses.add(u);
-      for (const d of defs) uses.delete(d);
-      return { defs, uses };
-    }
-    const forMatch = text.match(/for\s*\(([^;]*);([^;]*);([^)]*)\)/);
-    if (forMatch) {
-      const [, init, cond, upd] = forMatch;
-      collectAssignment(init, defs, uses);
-      for (const u of tokensIn(cond)) uses.add(u);
-      collectAssignment(upd, defs, uses);
-      return { defs, uses };
-    }
-    const matched = collectAssignment(text, defs, uses);
-    if (!matched) {
-      for (const u of tokensIn(text)) uses.add(u);
-    }
-    return { defs, uses };
-  }
-  function collectAssignment(text, defs, uses) {
-    if (!text) return false;
-    const incDec = text.match(/^[\s(]*([A-Za-z_][\w]*)\s*(\+\+|--)/);
-    if (incDec) {
-      defs.add(incDec[1]);
-      uses.add(incDec[1]);
-      return true;
-    }
-    const compound = text.match(
-      /^[\s(]*([A-Za-z_][\w]*)\s*(?:\+|-|\*|\/|%|&|\||\^|<<|>>|>>>)=(.*)$/
-    );
-    if (compound) {
-      const [, name, rhs] = compound;
-      if (!KEYWORDS.has(name)) {
-        defs.add(name);
-        uses.add(name);
-      }
-      for (const u of tokensIn(rhs)) uses.add(u);
-      return true;
-    }
-    const assign = text.match(
-      /^[\s(]*(?:let\s+|const\s+|var\s+)?([A-Za-z_][\w]*)\s*=(?!=)(.*)$/
-    );
-    if (assign) {
-      const [, name, rhs] = assign;
-      if (!KEYWORDS.has(name)) defs.add(name);
-      for (const u of tokensIn(rhs)) uses.add(u);
-      if (!KEYWORDS.has(name)) uses.delete(name);
-      return true;
-    }
-    return false;
-  }
-  function buildDataFlowGraph(cfg) {
-    var _a2;
-    const out = { nodes: (cfg == null ? void 0 : cfg.nodes) || [], edges: [], defUseByNode: /* @__PURE__ */ new Map() };
-    if (!((_a2 = cfg == null ? void 0 : cfg.nodes) == null ? void 0 : _a2.length)) return out;
-    const preds = new Map(cfg.nodes.map((n) => [n.id, []]));
-    for (const e of cfg.edges || []) {
-      if (preds.has(e.to)) preds.get(e.to).push(e.from);
-    }
-    for (const n of cfg.nodes) out.defUseByNode.set(n.id, extractDefUse(n));
-    const seenEdges = /* @__PURE__ */ new Set();
-    for (const useNode of cfg.nodes) {
-      const { uses } = out.defUseByNode.get(useNode.id);
-      for (const v of uses) {
-        const visited = /* @__PURE__ */ new Set([useNode.id]);
-        const stack = [...preds.get(useNode.id)];
-        while (stack.length) {
-          const cur = stack.pop();
-          if (visited.has(cur)) continue;
-          visited.add(cur);
-          const du = out.defUseByNode.get(cur);
-          if (du && du.defs.has(v)) {
-            const id = `du-${cur}-${useNode.id}-${v}`;
-            if (!seenEdges.has(id)) {
-              seenEdges.add(id);
-              out.edges.push({ id, from: cur, to: useNode.id, variable: v });
-            }
-            continue;
-          }
-          for (const p of preds.get(cur) || []) stack.push(p);
-        }
-      }
-    }
-    return out;
   }
 
   // src/components/GraphCoverageExplorer.js

--- a/src/tests/dataFlowCoverage.test.js
+++ b/src/tests/dataFlowCoverage.test.js
@@ -69,6 +69,13 @@ describe('data flow coverage', () => {
     expect(plan.uncoveredRequirements.length).toBeLessThan(reqs.length);
   });
 
+  it('函式參數視為入口節點的 def', () => {
+    const reqs = getAllDefsRequirements(graph);
+    const variables = new Set(reqs.map((r) => r.variable));
+    // sum(n) — parameter `n` should appear as a definition
+    expect(variables.has('n')).toBe(true);
+  });
+
   it('沒有 sourceText 的 graph 回傳空 requirements', () => {
     const plain = {
       startNodeId: 'A',

--- a/src/tests/dataFlowCoverage.test.js
+++ b/src/tests/dataFlowCoverage.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTestPathSetForRequirements,
+  getAllDefsRequirements,
+  getAllDuPathsRequirements,
+  getAllUsesRequirements,
+  getCoverageRequirements,
+} from '../utils/graphCoverage.js';
+import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
+
+const sumProgram = `function sum(n) {
+  let total = 0;
+  let i = 1;
+  while (i <= n) {
+    total = total + i;
+    i = i + 1;
+  }
+  return total;
+}`;
+
+function buildSumGraph() {
+  return generateControlFlowGraphFromProgram({
+    sourceCode: sumProgram,
+    language: 'javascript',
+  });
+}
+
+describe('data flow coverage', () => {
+  const graph = buildSumGraph();
+
+  it('All-Defs 對每個 (節點, 變數) 定義產生一個 requirement', () => {
+    const reqs = getAllDefsRequirements(graph);
+    expect(reqs.length).toBeGreaterThan(0);
+    reqs.forEach((req) => {
+      expect(req.type).toBe('all-defs');
+      expect(req.path[0]).toBe(req.defNodeId);
+      expect(req.path[req.path.length - 1]).toBe(req.useNodeId);
+      expect(req.variable).toBeTruthy();
+    });
+  });
+
+  it('All-Uses 至少包含 i 與 total 的 def-use 對', () => {
+    const reqs = getAllUsesRequirements(graph);
+    const variables = new Set(reqs.map((r) => r.variable));
+    expect(variables.has('i')).toBe(true);
+    expect(variables.has('total')).toBe(true);
+  });
+
+  it('All-DU-Paths 數量 >= All-Uses 數量 (每對至少一條路徑)', () => {
+    const uses = getAllUsesRequirements(graph);
+    const duPaths = getAllDuPathsRequirements(graph);
+    expect(duPaths.length).toBeGreaterThanOrEqual(uses.length);
+    duPaths.forEach((req) => {
+      expect(req.type).toBe('all-du-paths');
+      expect(req.path.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('getCoverageRequirements 支援 all-defs / all-uses / all-du-paths', () => {
+    expect(getCoverageRequirements(graph, 'all-defs').length).toBeGreaterThan(0);
+    expect(getCoverageRequirements(graph, 'all-uses').length).toBeGreaterThan(0);
+    expect(getCoverageRequirements(graph, 'all-du-paths').length).toBeGreaterThan(0);
+  });
+
+  it('All-Uses 的測試路徑集合可覆蓋大多數 requirements', () => {
+    const reqs = getAllUsesRequirements(graph);
+    const plan = buildTestPathSetForRequirements(graph, reqs);
+    expect(plan.selectedPaths.length).toBeGreaterThan(0);
+    expect(plan.uncoveredRequirements.length).toBeLessThan(reqs.length);
+  });
+
+  it('沒有 sourceText 的 graph 回傳空 requirements', () => {
+    const plain = {
+      startNodeId: 'A',
+      endNodeId: 'B',
+      nodes: [
+        { id: 'A', label: 'A' },
+        { id: 'B', label: 'B' },
+      ],
+      edges: [{ id: 'A-B', from: 'A', to: 'B' }],
+    };
+    expect(getAllDefsRequirements(plain)).toHaveLength(0);
+    expect(getAllUsesRequirements(plain)).toHaveLength(0);
+    expect(getAllDuPathsRequirements(plain)).toHaveLength(0);
+  });
+});

--- a/src/tests/testingData.test.js
+++ b/src/tests/testingData.test.js
@@ -156,9 +156,18 @@ describe('testingTypes', () => {
 });
 
 describe('graphCoverage data', () => {
-  it('包含五種 coverage criteria', () => {
-    expect(graphCoverageCriteria).toHaveLength(5);
-    expect(graphCoverageCriteria.map((item) => item.id)).toEqual(['node', 'edge', 'prime-path', 'edge-pair', 'complete-path']);
+  it('包含八種 coverage criteria', () => {
+    expect(graphCoverageCriteria).toHaveLength(8);
+    expect(graphCoverageCriteria.map((item) => item.id)).toEqual([
+      'node',
+      'edge',
+      'prime-path',
+      'edge-pair',
+      'complete-path',
+      'all-defs',
+      'all-uses',
+      'all-du-paths',
+    ]);
   });
 
   it('包含程式碼語言選項', () => {

--- a/src/utils/graphCoverage.js
+++ b/src/utils/graphCoverage.js
@@ -1,3 +1,5 @@
+import { extractDefUse } from './dataFlow.js';
+
 function buildAdjacency(graph) {
   const adjacency = new Map();
 
@@ -114,7 +116,193 @@ function requirementCoveredByRecord(requirement, record) {
     return containsNodePath(record.path, requirement.nodes);
   }
 
+  if (
+    requirement.type === 'all-defs'
+    || requirement.type === 'all-uses'
+    || requirement.type === 'all-du-paths'
+  ) {
+    return containsNodePath(record.path, requirement.path || requirement.nodes);
+  }
+
   return false;
+}
+
+// ---------- Data flow coverage helpers ----------
+
+function buildDefUseMap(graph) {
+  const map = new Map();
+  graph.nodes.forEach((node) => {
+    map.set(node.id, extractDefUse(node));
+  });
+  return map;
+}
+
+// Enumerate every simple, definition-clear path n -> m for variable v in the CFG.
+// "Definition-clear" means no interior node redefines v. Path length is capped
+// to keep the enumeration bounded for All-DU-Paths.
+function enumerateDefClearPaths(graph, defNodeId, useNodeId, variable, defUseMap, maxDepth) {
+  const adjacency = buildAdjacency(graph);
+  const limit = maxDepth ?? Math.max(8, graph.nodes.length * 2);
+  const results = [];
+
+  function walk(currentId, path, visited) {
+    if (path.length > limit) return;
+    if (currentId === useNodeId && path.length >= 2) {
+      results.push([...path]);
+      return;
+    }
+    const out = adjacency.get(currentId) || [];
+    for (const edge of out) {
+      const next = edge.to;
+      if (visited.has(next)) continue;
+      // Forbid redefinition of `variable` at any interior node (next !== useNodeId
+      // is "interior" relative to the def→use walk we're building).
+      if (next !== useNodeId) {
+        const du = defUseMap.get(next);
+        if (du && du.defs.has(variable)) continue;
+      }
+      visited.add(next);
+      path.push(next);
+      walk(next, path, visited);
+      path.pop();
+      visited.delete(next);
+    }
+  }
+
+  walk(defNodeId, [defNodeId], new Set([defNodeId]));
+  return results;
+}
+
+function shortestDefClearPath(graph, defNodeId, useNodeId, variable, defUseMap) {
+  // BFS — first time we pop useNodeId we've found a shortest def-clear walk.
+  const adjacency = buildAdjacency(graph);
+  const queue = [[defNodeId]];
+  const seenStates = new Set([defNodeId]);
+  while (queue.length) {
+    const path = queue.shift();
+    const head = path[path.length - 1];
+    if (head === useNodeId && path.length >= 2) return path;
+    const out = adjacency.get(head) || [];
+    for (const edge of out) {
+      const next = edge.to;
+      if (path.includes(next)) continue;
+      if (next !== useNodeId) {
+        const du = defUseMap.get(next);
+        if (du && du.defs.has(variable)) continue;
+      }
+      const stateKey = `${path.join('>')}>${next}`;
+      if (seenStates.has(stateKey)) continue;
+      seenStates.add(stateKey);
+      queue.push([...path, next]);
+    }
+  }
+  return null;
+}
+
+function collectDefUsePairs(graph, defUseMap) {
+  // A pair (defNode, useNode, variable) is admissible iff at least one
+  // def-clear simple path connects them.
+  const pairs = [];
+  graph.nodes.forEach((defNode) => {
+    const defs = defUseMap.get(defNode.id)?.defs;
+    if (!defs || defs.size === 0) return;
+    defs.forEach((variable) => {
+      graph.nodes.forEach((useNode) => {
+        const uses = defUseMap.get(useNode.id)?.uses;
+        if (!uses || !uses.has(variable)) return;
+        const sample = shortestDefClearPath(graph, defNode.id, useNode.id, variable, defUseMap);
+        if (sample) {
+          pairs.push({ defNodeId: defNode.id, useNodeId: useNode.id, variable, samplePath: sample });
+        }
+      });
+    });
+  });
+  return pairs;
+}
+
+function nodeLabelOf(graph, nodeId) {
+  return graph.nodes.find((n) => n.id === nodeId)?.label || nodeId;
+}
+
+export function getAllDefsRequirements(graph) {
+  const normalizedGraph = normalizeGraph(graph);
+  const defUseMap = buildDefUseMap(normalizedGraph);
+  const pairs = collectDefUsePairs(normalizedGraph, defUseMap);
+
+  // For each (defNode, variable) keep ONE representative def→use path
+  // (shortest among the admissible uses).
+  const byDef = new Map();
+  pairs.forEach((p) => {
+    const key = `${p.defNodeId}|${p.variable}`;
+    const existing = byDef.get(key);
+    if (!existing || p.samplePath.length < existing.samplePath.length) {
+      byDef.set(key, p);
+    }
+  });
+
+  return Array.from(byDef.values()).map((p, index) => ({
+    id: `all-defs-${index + 1}-${p.defNodeId}-${p.variable}`,
+    type: 'all-defs',
+    label: `Def ${nodeLabelOf(normalizedGraph, p.defNodeId)} (${p.variable}) -> use ${nodeLabelOf(normalizedGraph, p.useNodeId)}`,
+    displayText: `${p.variable}@${p.defNodeId} -> ${p.useNodeId} : ${p.samplePath.join(' -> ')}`,
+    nodes: [...new Set(p.samplePath)],
+    edges: edgeIdsFromPath(normalizedGraph, p.samplePath),
+    path: p.samplePath,
+    variable: p.variable,
+    defNodeId: p.defNodeId,
+    useNodeId: p.useNodeId,
+  }));
+}
+
+export function getAllUsesRequirements(graph) {
+  const normalizedGraph = normalizeGraph(graph);
+  const defUseMap = buildDefUseMap(normalizedGraph);
+  const pairs = collectDefUsePairs(normalizedGraph, defUseMap);
+
+  return pairs.map((p, index) => ({
+    id: `all-uses-${index + 1}-${p.defNodeId}-${p.useNodeId}-${p.variable}`,
+    type: 'all-uses',
+    label: `Use ${nodeLabelOf(normalizedGraph, p.useNodeId)} of ${p.variable} from ${nodeLabelOf(normalizedGraph, p.defNodeId)}`,
+    displayText: `${p.variable}: ${p.defNodeId} -> ${p.useNodeId} : ${p.samplePath.join(' -> ')}`,
+    nodes: [...new Set(p.samplePath)],
+    edges: edgeIdsFromPath(normalizedGraph, p.samplePath),
+    path: p.samplePath,
+    variable: p.variable,
+    defNodeId: p.defNodeId,
+    useNodeId: p.useNodeId,
+  }));
+}
+
+export function getAllDuPathsRequirements(graph) {
+  const normalizedGraph = normalizeGraph(graph);
+  const defUseMap = buildDefUseMap(normalizedGraph);
+  const pairs = collectDefUsePairs(normalizedGraph, defUseMap);
+
+  const requirements = [];
+  pairs.forEach((p) => {
+    const allPaths = enumerateDefClearPaths(
+      normalizedGraph,
+      p.defNodeId,
+      p.useNodeId,
+      p.variable,
+      defUseMap,
+    );
+    allPaths.forEach((path, idx) => {
+      requirements.push({
+        id: `all-du-paths-${requirements.length + 1}-${p.defNodeId}-${p.useNodeId}-${p.variable}-${idx + 1}`,
+        type: 'all-du-paths',
+        label: `DU-Path ${p.variable}: ${path.join(' -> ')}`,
+        displayText: `${p.variable}: ${path.join(' -> ')}`,
+        nodes: [...new Set(path)],
+        edges: edgeIdsFromPath(normalizedGraph, path),
+        path,
+        variable: p.variable,
+        defNodeId: p.defNodeId,
+        useNodeId: p.useNodeId,
+      });
+    });
+  });
+  return requirements;
 }
 
 function greedySetCover(pathRecords, requirements) {
@@ -452,6 +640,18 @@ export function getCoverageRequirements(graph, criterion) {
 
   if (criterion === 'complete-path') {
     return getCompletePathRequirements(graph);
+  }
+
+  if (criterion === 'all-defs') {
+    return getAllDefsRequirements(graph);
+  }
+
+  if (criterion === 'all-uses') {
+    return getAllUsesRequirements(graph);
+  }
+
+  if (criterion === 'all-du-paths') {
+    return getAllDuPathsRequirements(graph);
   }
 
   return [];


### PR DESCRIPTION
Closes #46.

## What
Three new graph-coverage criteria on top of the data-flow analyzer added in #43.

| Criterion | Requirement | Path strategy |
|-----------|-------------|---------------|
| **All-Defs** | one def-clear path per (def-node, variable) reaching some use | shortest def-clear path (BFS) to *any* use |
| **All-Uses** | one def-clear path per (def, use, variable) triple | shortest def-clear path (BFS) to *that* use |
| **All-DU-Paths** | every simple def-clear path per (def, use, variable) | enumerate, capped at 2·\|nodes\| depth |

Each generated requirement carries a `path: [n1…nk]` so the existing test-path planner reuses sub-walk containment (same mechanic as prime-path / complete-path). When the active CFG has no \`sourceText\` (the bare sample), the criteria return empty lists by design.

## Files
- `src/utils/graphCoverage.js` — new helpers `buildDefUseMap`, `enumerateDefClearPaths`, `shortestDefClearPath`, `collectDefUsePairs`; new generators `getAllDefsRequirements`, `getAllUsesRequirements`, `getAllDuPathsRequirements`; switch + matcher extended.
- `src/data/testingData.js` — three new entries in `graphCoverageCriteria` (EN + zh).
- `src/tests/dataFlowCoverage.test.js` — new (6 tests) using a sum-function CFG generated by `programToGraph`.
- `src/tests/testingData.test.js` — updated criterion list.

## Validation
- `npm run test:run` → **186/186 passing** (5 new tests in dataFlowCoverage + criterion list update).
- `node scripts/build-standalone.mjs` → bundle rebuilt.

Independent of PR #45 (different files; can land in either order).