### PR TITLE
fix(graph): preserve function header so parameters become defs

### DIFF
--- a/e2e/code-upload.spec.js
+++ b/e2e/code-upload.spec.js
@@ -29,7 +29,7 @@ test.describe('Code Upload to CFG', () => {
     await expect(page.getByTestId('graph-source-status')).toContainText('已根據 calendar.js 自動產生簡化 CFG。');
     await expect(page.getByTestId('program-source-code')).toContainText('switch (month)');
 
-    await page.locator('[data-requirement-id]').nth(1).click();
+    await page.locator('[data-requirement-id]').nth(2).click();
 
     await expect(page.getByTestId('program-source-line-2')).toHaveClass(/graph-source-line--active/);
     await expect(page.getByTestId('detail-source-mapping')).toContainText('L2');

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1780,6 +1780,9 @@
       }
       if ((line.text.startsWith("function ") || line.text.startsWith("export function ")) && line.text.endsWith("{")) {
         consumeLine(state);
+        statements.push(createAstNode("statement", line, {
+          text: line.text.replace(/\{$/, "").trim()
+        }));
         statements.push(...parseJavascriptStatements(state));
         continue;
       }

--- a/src/tests/GraphCoverageExplorer.test.jsx
+++ b/src/tests/GraphCoverageExplorer.test.jsx
@@ -122,7 +122,7 @@ describe('GraphCoverageExplorer', () => {
     select.value = 'calendar-days';
     select.dispatchEvent(new Event('change', { bubbles: true }));
 
-    document.querySelectorAll('[data-requirement-id]')[1].click();
+    document.querySelectorAll('[data-requirement-id]')[2].click();
 
     expect(document.querySelector('[data-testid="program-source-line-2"]')).toBeInTheDocument();
     expect(document.querySelector('[data-testid="detail-source-mapping"]')).toHaveTextContent('L2');
@@ -195,7 +195,7 @@ describe('GraphCoverageExplorer', () => {
     uploadInput.dispatchEvent(new Event('change', { bubbles: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    document.querySelectorAll('[data-requirement-id]')[1].click();
+    document.querySelectorAll('[data-requirement-id]')[2].click();
 
     expect(document.querySelector('[data-testid="program-source-name"]')).toHaveTextContent('triangle');
     expect(document.querySelector('[data-testid="graph-source-status"]')).toHaveTextContent('已根據 triangle.js 自動產生簡化 CFG。');

--- a/src/utils/programToGraph.js
+++ b/src/utils/programToGraph.js
@@ -249,7 +249,12 @@ function parseJavascriptStatements(state, stopWhen = ['}']) {
     }
 
     if ((line.text.startsWith('function ') || line.text.startsWith('export function ')) && line.text.endsWith('{')) {
+      // Emit the header as a node so the parameter list is preserved for
+      // data-flow analysis (parameters count as definitions on entry).
       consumeLine(state);
+      statements.push(createAstNode('statement', line, {
+        text: line.text.replace(/\{$/, '').trim(),
+      }));
       statements.push(...parseJavascriptStatements(state));
       continue;
     }


### PR DESCRIPTION
Closes #48.

## Problem
The CFG entry node had no `sourceText`, so any per-node data-flow walk missed the function parameters. `extractDefUse()` in `src/utils/dataFlow.js` already has a `function name(params)` regex that would add each parameter to `defs`, but it never received the header line.

## Cause
`parseJavascriptStatements` (`src/utils/programToGraph.js`) consumed lines starting with `function ` / `export function ` and discarded them, descending straight into the body. The header — including the parameter list — never reached `createAstNode`.

## Fix
Emit the function header as a `statement` AST node before recursing. Parameters now surface as defs at the entry node, so anything that consumes the per-node def/use map sees them.

## Files
- `src/utils/programToGraph.js` — emit a statement node for the function header.
- `src/tests/GraphCoverageExplorer.test.jsx` — bumped two `data-requirement-id` click indices by 1 (the requirement list now contains the header line as well).
- `src/standalone.js` — bundle rebuilt.

## Validation
- `npm run test:run` → **180/180 passing**.
- `node scripts/build-standalone.mjs` → bundle rebuilt.

Independent of #47 (which adds the actual All-Defs / All-Uses / All-DU-Paths criteria); this one stands on its own and benefits any future per-node data-flow consumer.