### PR TITLE
test(e2e): pin code-upload requirement click to switch label

### DIFF
--- a/e2e/code-upload.spec.js
+++ b/e2e/code-upload.spec.js
@@ -29,7 +29,7 @@ test.describe('Code Upload to CFG', () => {
     await expect(page.getByTestId('graph-source-status')).toContainText('已根據 calendar.js 自動產生簡化 CFG。');
     await expect(page.getByTestId('program-source-code')).toContainText('switch (month)');
 
-    await page.locator('[data-requirement-id]').nth(2).click();
+    await page.getByTestId('requirement-list').locator('button', { hasText: /switch/i }).first().click();
 
     await expect(page.getByTestId('program-source-line-2')).toHaveClass(/graph-source-line--active/);
     await expect(page.getByTestId('detail-source-mapping')).toContainText('L2');


### PR DESCRIPTION
Closes #50.

## Problem
`e2e/code-upload.spec.js` first test intermittently failed on CI with the `program-source-line-2` highlight assertion (and sometimes a `locator.click` timeout). Root cause: the test picked the requirement using a positional `nth(N)` over `[data-requirement-id]`. After PR #49 the function header is its own node, but more importantly any future change to the requirement list ordering would silently retarget the wrong row.

## Fix
Click by **label**: the requirement button inside `requirement-list` whose text matches `/switch/i`. That uniquely identifies the switch decision node and benefits from Playwright's built-in visibility / stability wait.

## Validation
- `npx playwright test e2e/code-upload.spec.js --repeat-each=2` → 6 / 6 passed locally.
