### PR TITLE
feat(graph): add Quadrilateral Program and Next Week examples

### DIFF
--- a/src/data/testingData.js
+++ b/src/data/testingData.js
@@ -290,6 +290,65 @@ export const graphCoverageProgramExamples = [
   }
 }`,
   },
+  {
+    id: 'quadrilateral-problem',
+    name: 'The Quadrilateral Program',
+    language: 'javascript',
+    description: 'Classify a quadrilateral from four side lengths and two diagonals into square, rectangle, rhombus, parallelogram, trapezoid, or general.',
+    sourceCode: `function classifyQuadrilateral(a, b, c, d, p, q) {
+  if (a <= 0 || b <= 0 || c <= 0 || d <= 0) {
+    return 'invalid';
+  }
+
+  if (a === b && b === c && c === d) {
+    if (p === q) {
+      return 'square';
+    }
+    return 'rhombus';
+  }
+
+  if (a === c && b === d) {
+    if (p === q) {
+      return 'rectangle';
+    }
+    return 'parallelogram';
+  }
+
+  if (a === c || b === d) {
+    return 'trapezoid';
+  }
+
+  return 'general';
+}`,
+  },
+  {
+    id: 'next-week',
+    name: 'Next Week',
+    language: 'javascript',
+    description: 'Advance a date by seven days, handling month-end and year rollover.',
+    sourceCode: `function nextWeek(year, month, day) {
+  if (!isValidDate(year, month, day)) {
+    return 'invalid';
+  }
+
+  let newDay = day + 7;
+  let newMonth = month;
+  let newYear = year;
+  const limit = daysInMonth(newYear, newMonth);
+
+  if (newDay > limit) {
+    newDay = newDay - limit;
+    if (newMonth === 12) {
+      newMonth = 1;
+      newYear = newYear + 1;
+    } else {
+      newMonth = newMonth + 1;
+    }
+  }
+
+  return { year: newYear, month: newMonth, day: newDay };
+}`,
+  },
 ];
 
 export const logicCoverageCriteria = [

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -285,6 +285,65 @@
       return 31;
   }
 }`
+    },
+    {
+      id: "quadrilateral-problem",
+      name: "The Quadrilateral Program",
+      language: "javascript",
+      description: "Classify a quadrilateral from four side lengths and two diagonals into square, rectangle, rhombus, parallelogram, trapezoid, or general.",
+      sourceCode: `function classifyQuadrilateral(a, b, c, d, p, q) {
+  if (a <= 0 || b <= 0 || c <= 0 || d <= 0) {
+    return 'invalid';
+  }
+
+  if (a === b && b === c && c === d) {
+    if (p === q) {
+      return 'square';
+    }
+    return 'rhombus';
+  }
+
+  if (a === c && b === d) {
+    if (p === q) {
+      return 'rectangle';
+    }
+    return 'parallelogram';
+  }
+
+  if (a === c || b === d) {
+    return 'trapezoid';
+  }
+
+  return 'general';
+}`
+    },
+    {
+      id: "next-week",
+      name: "Next Week",
+      language: "javascript",
+      description: "Advance a date by seven days, handling month-end and year rollover.",
+      sourceCode: `function nextWeek(year, month, day) {
+  if (!isValidDate(year, month, day)) {
+    return 'invalid';
+  }
+
+  let newDay = day + 7;
+  let newMonth = month;
+  let newYear = year;
+  const limit = daysInMonth(newYear, newMonth);
+
+  if (newDay > limit) {
+    newDay = newDay - limit;
+    if (newMonth === 12) {
+      newMonth = 1;
+      newYear = newYear + 1;
+    } else {
+      newMonth = newMonth + 1;
+    }
+  }
+
+  return { year: newYear, month: newMonth, day: newDay };
+}`
     }
   ];
   var logicCoverageCriteria = [

--- a/src/tests/testingData.test.js
+++ b/src/tests/testingData.test.js
@@ -196,6 +196,8 @@ describe('graphCoverage data', () => {
       'commission-problem',
       'next-date-leap-year',
       'calendar-days',
+      'quadrilateral-problem',
+      'next-week',
     ]);
     graphCoverageProgramExamples.forEach((item) => {
       expect(item.language).toBeTruthy();


### PR DESCRIPTION
Closes #52.

## What
Two new entries in `graphCoverageProgramExamples` (`src/data/testingData.js`):

- **The Quadrilateral Program** (`quadrilateral-problem`) — classifies a quadrilateral from four sides + two diagonals into square / rectangle / rhombus / parallelogram / trapezoid / general. Mirrors the Triangle Problem at higher branching depth.
- **Next Week** (`next-week`) — advances a date by 7 days with month-end and year-end rollover. Companion to Next Date / Next Date (Leap Year).

Both are JavaScript snippets; the existing JS-to-CFG parser auto-generates their control-flow graphs (no hand-written graph fixture needed).

## Files
- `src/data/testingData.js` (+2 entries)
- `src/tests/testingData.test.js` — fixture list extended
- `src/standalone.js` — bundle rebuilt

## Validation
- 187/187 unit tests pass.
- Bundle rebuilt.