### PR TITLE
fix(graph): push CFG back-edge control outside intermediate nodes

### DIFF
--- a/src/standalone.js
+++ b/src/standalone.js
@@ -2595,8 +2595,24 @@
         const meta = backEdgeOrder.get(edge) || { side: 1, idx: 0 };
         const baseAnchor = meta.side > 0 ? Math.max(fromNode.x, toNode.x) : Math.min(fromNode.x, toNode.x);
         const offset = Math.max(120, Math.abs(toNode.y - fromNode.y) / 2 + 80) + meta.idx * 60;
+        let controlX = baseAnchor + meta.side * (offset + fan * FAN_STEP);
+        const NODE_CLEAR = 32 + 18;
+        const yLo = Math.min(fromNode.y, toNode.y);
+        const yHi = Math.max(fromNode.y, toNode.y);
+        const blockers = nodes.filter((n) => n.id !== edge.from && n.id !== edge.to && n.y >= yLo - 1 && n.y <= yHi + 1);
+        if (blockers.length) {
+          if (meta.side > 0) {
+            const limitX = Math.max(...blockers.map((n) => n.x + NODE_CLEAR));
+            const requiredCx = 2 * limitX - (fromNode.x + toNode.x) / 2;
+            if (controlX < requiredCx) controlX = requiredCx + 24;
+          } else {
+            const limitX = Math.min(...blockers.map((n) => n.x - NODE_CLEAR));
+            const requiredCx = 2 * limitX - (fromNode.x + toNode.x) / 2;
+            if (controlX > requiredCx) controlX = requiredCx - 24;
+          }
+        }
         edge.control = {
-          x: baseAnchor + meta.side * (offset + fan * FAN_STEP),
+          x: controlX,
           y: (fromNode.y + toNode.y) / 2
         };
       } else if (toNode.y - fromNode.y > LAYER_SPACING_Y * 1.5) {

--- a/src/utils/programToGraph.js
+++ b/src/utils/programToGraph.js
@@ -774,8 +774,36 @@ function assignLayout(nodes, edges) {
         ? Math.max(fromNode.x, toNode.x)
         : Math.min(fromNode.x, toNode.x);
       const offset = Math.max(120, Math.abs(toNode.y - fromNode.y) / 2 + 80) + meta.idx * 60;
+      let controlX = baseAnchor + meta.side * (offset + fan * FAN_STEP);
+
+      // Push the arc outside any node that sits inside the y-band of
+      // this back-edge so the curve doesn't cut through the node body.
+      // For a quadratic Bézier P(t) = (1-t)^2*A + 2(1-t)t*C + t^2*B the
+      // midpoint sits at (A.x + B.x)/4 + C.x/2; require this midpoint
+      // to clear every blocker (node radius ~32 + small buffer).
+      const NODE_CLEAR = 32 + 18;
+      const yLo = Math.min(fromNode.y, toNode.y);
+      const yHi = Math.max(fromNode.y, toNode.y);
+      const blockers = nodes.filter((n) => (
+        n.id !== edge.from
+        && n.id !== edge.to
+        && n.y >= yLo - 1
+        && n.y <= yHi + 1
+      ));
+      if (blockers.length) {
+        if (meta.side > 0) {
+          const limitX = Math.max(...blockers.map((n) => n.x + NODE_CLEAR));
+          const requiredCx = 2 * limitX - (fromNode.x + toNode.x) / 2;
+          if (controlX < requiredCx) controlX = requiredCx + 24;
+        } else {
+          const limitX = Math.min(...blockers.map((n) => n.x - NODE_CLEAR));
+          const requiredCx = 2 * limitX - (fromNode.x + toNode.x) / 2;
+          if (controlX > requiredCx) controlX = requiredCx - 24;
+        }
+      }
+
       edge.control = {
-        x: baseAnchor + meta.side * (offset + fan * FAN_STEP),
+        x: controlX,
         y: (fromNode.y + toNode.y) / 2,
       };
     } else if (toNode.y - fromNode.y > LAYER_SPACING_Y * 1.5) {


### PR DESCRIPTION
Closes #54.

## Problem
Back-edges already avoid crossing other edges via the side-split + per-side stagger from #45, but they could still cut through node circles when a long loop bowed at a small offset.

## Fix
After computing the candidate `control.x` for a back-edge, scan blockers — other nodes whose y sits inside the back-edge y-band — and push `control.x` outward until the quadratic-Bézier midpoint clears every blocker by node radius + 18 px buffer.

Bézier midpoint formula:

```
P(0.5) = (A + 2C + B) / 4
       ⇒ midX = (A.x + B.x)/4 + C.x/2
```

Required `C.x` (right side) is therefore `2 * (blockerX + clearance) - (A.x + B.x)/2`, with the symmetric form for the left side. When the candidate fails the check, the new value is the requirement + 24 px slack.

## Validation
- 187/187 unit tests still pass.
- Bundle rebuilt.

Independent of any open PR (touches only `programToGraph.js` + bundle).