### PR TITLE
fix(logic): localize Logic Coverage messages so EN locale stops showing Chinese

### DIFF
--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -275,7 +275,7 @@ export function createLogicCoverageExplorer() {
           class="logic-example-btn${state.expression === p.expression ? ' active' : ''}"
           data-expression="${escapeHtml(p.expression)}"
           data-testid="logic-example-${p.id}"
-          title="${escapeHtml(p.description)}"
+          title="${escapeHtml(pickField(p, 'description') || '')}"
         >
           ${escapeHtml(p.name)}
         </button>
@@ -317,8 +317,8 @@ export function createLogicCoverageExplorer() {
           data-criterion="${c.id}"
           data-testid="logic-criterion-${c.id}"
         >
-          <span class="logic-criterion-label">${escapeHtml(c.label)}</span>
-          <span class="logic-criterion-zh">${escapeHtml(getLocale() === 'en' ? (c.descriptionEn || c.description || '') : c.labelZh)}</span>
+          <span class="logic-criterion-label">${escapeHtml(pickField(c, 'label') || c.label)}</span>
+          <span class="logic-criterion-zh">${escapeHtml(getLocale() === 'en' ? (c.descriptionEn || c.description || '') : (c.labelZh || ''))}</span>
         </button>
       `)
       .join('');
@@ -602,7 +602,7 @@ export function createLogicCoverageExplorer() {
 
     return `
       <h3 class="logic-summary-title">${escapeHtml(set.name)}</h3>
-      <p class="logic-summary-desc">${escapeHtml(set.description)}</p>
+      <p class="logic-summary-desc">${escapeHtml(set.description || '')}</p>
       ${dnfMarkup}
       ${kmapMarkup}
       <p class="logic-summary-stats">

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -3406,6 +3406,7 @@
   }
 
   // src/utils/logicCoverage.js
+  var L = (en, zh) => getLocale() === "en" ? en : zh;
   var TOKEN_REGEX = /\s*(?:(\()|(\))|(&&)|(\|\|)|(\+)|(!)|([A-Za-z][0-9]*))/y;
   function tokenize(expression) {
     const tokens = [];
@@ -3417,7 +3418,7 @@
       if (!match) {
         const remainder = expression.slice(start).trim();
         if (!remainder) break;
-        throw new Error(`\u4E0D\u652F\u63F4\u7684\u5B57\u5143\uFF1A\u300C${remainder[0]}\u300D\u65BC\u4F4D\u7F6E ${start + 1}`);
+        throw new Error(L(`Unsupported character "${remainder[0]}" at position ${start + 1}`, `\u4E0D\u652F\u63F4\u7684\u5B57\u5143\uFF1A\u300C${remainder[0]}\u300D\u65BC\u4F4D\u7F6E ${start + 1}`));
       }
       const [, lparen, rparen, andOp, orOp, plusOp, notOp, ident] = match;
       if (lparen) tokens.push({ type: "lparen" });
@@ -3429,7 +3430,7 @@
       lastIndex = TOKEN_REGEX.lastIndex;
     }
     if (lastIndex < expression.length && expression.slice(lastIndex).trim()) {
-      throw new Error(`\u7121\u6CD5\u89E3\u6790\u5269\u9918\u5B57\u4E32\uFF1A\u300C${expression.slice(lastIndex).trim()}\u300D`);
+      throw new Error(L(`Could not parse trailing input "${expression.slice(lastIndex).trim()}"`, `\u7121\u6CD5\u89E3\u6790\u5269\u9918\u5B57\u4E32\uFF1A\u300C${expression.slice(lastIndex).trim()}\u300D`));
     }
     return tokens;
   }
@@ -3441,7 +3442,7 @@
     function consume(type) {
       const token = tokens[pos];
       if (!token || token.type !== type) {
-        throw new Error(`\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u9810\u671F ${type}\uFF0C\u5BE6\u969B ${token ? token.type : "EOF"}`);
+        throw new Error(L(`Syntax error: expected ${type}, got ${token ? token.type : "EOF"}`, `\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u9810\u671F ${type}\uFF0C\u5BE6\u969B ${token ? token.type : "EOF"}`));
       }
       pos += 1;
       return token;
@@ -3481,7 +3482,7 @@
     }
     function parseAtom() {
       const token = peek();
-      if (!token) throw new Error("\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u672A\u9810\u671F\u7684\u7D50\u5C3E\u3002");
+      if (!token) throw new Error(L("Syntax error: unexpected end of input.", "\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u672A\u9810\u671F\u7684\u7D50\u5C3E\u3002"));
       if (token.type === "lparen") {
         consume("lparen");
         const node = parseOr();
@@ -3492,11 +3493,11 @@
         consume("ident");
         return { type: "clause", name: token.value };
       }
-      throw new Error(`\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u672A\u9810\u671F\u7684 ${token.type}`);
+      throw new Error(L(`Syntax error: unexpected ${token.type}`, `\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u672A\u9810\u671F\u7684 ${token.type}`));
     }
     const ast = parseOr();
     if (pos !== tokens.length) {
-      throw new Error("\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u5269\u9918 token \u672A\u89E3\u6790\u3002");
+      throw new Error(L("Syntax error: trailing tokens were not parsed.", "\u8A9E\u6CD5\u932F\u8AA4\uFF1A\u5269\u9918 token \u672A\u89E3\u6790\u3002"));
     }
     return ast;
   }
@@ -3504,7 +3505,7 @@
     switch (ast.type) {
       case "clause": {
         if (!(ast.name in values)) {
-          throw new Error(`\u7F3A\u5C11\u5B50\u53E5\u503C\uFF1A${ast.name}`);
+          throw new Error(L(`Missing clause value: ${ast.name}`, `\u7F3A\u5C11\u5B50\u53E5\u503C\uFF1A${ast.name}`));
         }
         return Boolean(values[ast.name]);
       }
@@ -3515,7 +3516,7 @@
       case "or":
         return evaluateAst(ast.left, values) || evaluateAst(ast.right, values);
       default:
-        throw new Error(`\u672A\u77E5 AST \u7BC0\u9EDE\uFF1A${ast.type}`);
+        throw new Error(L(`Unknown AST node: ${ast.type}`, `\u672A\u77E5 AST \u7BC0\u9EDE\uFF1A${ast.type}`));
     }
   }
   function collectClauses(ast, accumulator = []) {
@@ -3532,11 +3533,11 @@
   function parsePredicate(expression) {
     const trimmed = String(expression || "").trim();
     if (!trimmed) {
-      throw new Error("Predicate \u4E0D\u80FD\u70BA\u7A7A\u3002");
+      throw new Error(L("Predicate must not be empty.", "Predicate \u4E0D\u80FD\u70BA\u7A7A\u3002"));
     }
     const tokens = tokenize(trimmed);
     if (!tokens.length) {
-      throw new Error("Predicate \u4E0D\u542B\u4EFB\u4F55 token\u3002");
+      throw new Error(L("Predicate did not yield any token.", "Predicate \u4E0D\u542B\u4EFB\u4F55 token\u3002"));
     }
     const ast = parseExpression(tokens);
     const clauses = collectClauses(ast);
@@ -3574,7 +3575,7 @@
     return {
       id: "pc",
       name: "Predicate Coverage",
-      description: "\u8B93\u6574\u500B predicate \u81F3\u5C11\u8A55\u4F30\u70BA true \u8207 false \u5404\u4E00\u6B21\u3002",
+      description: L("Make the predicate evaluate to true and false at least once each.", "\u8B93\u6574\u500B predicate \u81F3\u5C11\u8A55\u4F30\u70BA true \u8207 false \u5404\u4E00\u6B21\u3002"),
       tests,
       requirementCount: 2
     };
@@ -3596,7 +3597,7 @@
     return {
       id: "cc",
       name: "Clause Coverage",
-      description: "\u6BCF\u500B\u5B50\u53E5\u90FD\u5FC5\u9808\u5404\u53D6 true \u8207 false \u4E00\u6B21\u3002",
+      description: L("Each clause must take both true and false at least once.", "\u6BCF\u500B\u5B50\u53E5\u90FD\u5FC5\u9808\u5404\u53D6 true \u8207 false \u4E00\u6B21\u3002"),
       tests,
       requirementCount: clauses.length * 2
     };
@@ -3605,7 +3606,7 @@
     return {
       id: "coc",
       name: "Combinatorial Coverage",
-      description: "\u5217\u8209\u6240\u6709\u5B50\u53E5\u771F\u5047\u7D44\u5408\uFF08\u5171 2^n \u5217\uFF09\u3002",
+      description: L("Enumerate all clause T/F combinations (2^n rows).", "\u5217\u8209\u6240\u6709\u5B50\u53E5\u771F\u5047\u7D44\u5408\uFF08\u5171 2^n \u5217\uFF09\u3002"),
       tests: rows.map((row) => ({ id: rowKey(row), row, label: `Row ${row.index}` })),
       requirementCount: rows.length
     };
@@ -3661,7 +3662,7 @@
         tests.push({
           id: testId,
           row,
-          label: `${clause}=${row.values[clause] ? "T" : "F"} (\u4E3B\u5C0E ${clause})`,
+          label: `${clause}=${row.values[clause] ? "T" : "F"} ${L(`(major ${clause})`, `(\u4E3B\u5C0E ${clause})`)}`,
           majorClause: clause
         });
       });
@@ -3679,7 +3680,7 @@
     return buildActiveClauseSet(
       "gacc",
       "General Active Clause Coverage",
-      "\u5C0D\u6BCF\u500B\u4E3B\u5B50\u53E5\uFF0C\u627E\u4E00\u5C0D\u5217\u4F7F\u5176\u6C7A\u5B9A predicate \u7684\u503C\uFF0C\u6B21\u5B50\u53E5\u53EF\u4EFB\u610F\u3002",
+      L("For each major clause, find a row pair such that the major clause determines the predicate while minor clauses are unconstrained.", "\u5C0D\u6BCF\u500B\u4E3B\u5B50\u53E5\uFF0C\u627E\u4E00\u5C0D\u5217\u4F7F\u5176\u6C7A\u5B9A predicate \u7684\u503C\uFF0C\u6B21\u5B50\u53E5\u53EF\u4EFB\u610F\u3002"),
       rows,
       clauses,
       "gacc"
@@ -3689,7 +3690,7 @@
     return buildActiveClauseSet(
       "cacc",
       "Correlated Active Clause Coverage",
-      "\u4E3B\u5B50\u53E5\u6C7A\u5B9A predicate \u7D50\u679C\uFF0C\u4E14\u5169\u5217\u7522\u751F\u4E0D\u540C\u7684 predicate \u503C\u3002",
+      L("The major clause determines the predicate, and the two rows produce different predicate values.", "\u4E3B\u5B50\u53E5\u6C7A\u5B9A predicate \u7D50\u679C\uFF0C\u4E14\u5169\u5217\u7522\u751F\u4E0D\u540C\u7684 predicate \u503C\u3002"),
       rows,
       clauses,
       "cacc"
@@ -3699,7 +3700,7 @@
     return buildActiveClauseSet(
       "racc",
       "Restricted Active Clause Coverage",
-      "\u4E3B\u5B50\u53E5\u6C7A\u5B9A predicate \u7D50\u679C\uFF0C\u4E14\u5169\u5217\u7684\u6B21\u5B50\u53E5\u503C\u5B8C\u5168\u76F8\u540C\u3002",
+      L("The major clause determines the predicate, and the two rows have identical minor-clause values.", "\u4E3B\u5B50\u53E5\u6C7A\u5B9A predicate \u7D50\u679C\uFF0C\u4E14\u5169\u5217\u7684\u6B21\u5B50\u53E5\u503C\u5B8C\u5168\u76F8\u540C\u3002"),
       rows,
       clauses,
       "racc"
@@ -3724,7 +3725,7 @@
         tests.push({
           id: testId,
           row,
-          label: `${clause}=${row.values[clause] ? "T" : "F"}, P=${row.predicate ? "T" : "F"} (\u975E\u4E3B\u5C0E ${clause})`,
+          label: `${clause}=${row.values[clause] ? "T" : "F"}, P=${row.predicate ? "T" : "F"} ${L(`(minor ${clause})`, `(\u975E\u4E3B\u5C0E ${clause})`)}`,
           majorClause: clause
         });
       }
@@ -3778,7 +3779,7 @@
     return buildInactiveClauseSet(
       "gicc",
       "General Inactive Clause Coverage",
-      "\u5C0D\u6BCF\u500B\u4E3B\u5B50\u53E5\uFF0C\u65BC\u4E0D\u6C7A\u5B9A predicate \u7684\u5217\u4E2D\uFF0C\u8986\u84CB (c=T/F)\xD7(P=T/F) \u5171 4 \u7A2E\u7D44\u5408\u3002",
+      L("For each major clause, in rows where it does not determine the predicate, cover all (c=T/F) \xD7 (P=T/F) combinations.", "\u5C0D\u6BCF\u500B\u4E3B\u5B50\u53E5\uFF0C\u65BC\u4E0D\u6C7A\u5B9A predicate \u7684\u5217\u4E2D\uFF0C\u8986\u84CB (c=T/F)\xD7(P=T/F) \u5171 4 \u7A2E\u7D44\u5408\u3002"),
       rows,
       clauses,
       "gicc"
@@ -3788,7 +3789,7 @@
     return buildInactiveClauseSet(
       "ricc",
       "Restricted Inactive Clause Coverage",
-      "\u540C GICC\uFF0C\u4F46\u6210\u5C0D\u5217\uFF08\u540C P \u503C\uFF09\u9700\u6240\u6709\u6B21\u5B50\u53E5\u5B8C\u5168\u76F8\u540C\uFF0C\u50C5\u4E3B\u5B50\u53E5\u7FFB\u8F49\u3002",
+      L("Same as GICC, but paired rows (same P) must agree on every minor clause; only the major clause flips.", "\u540C GICC\uFF0C\u4F46\u6210\u5C0D\u5217\uFF08\u540C P \u503C\uFF09\u9700\u6240\u6709\u6B21\u5B50\u53E5\u5B8C\u5168\u76F8\u540C\uFF0C\u50C5\u4E3B\u5B50\u53E5\u7FFB\u8F49\u3002"),
       rows,
       clauses,
       "ricc"
@@ -4004,7 +4005,7 @@
     return {
       id: "ic",
       name: "Implicant Coverage",
-      description: "\u5C0D f \u8207 \xACf \u7684\u6700\u5C0F DNF \u4E2D\u6BCF\u500B prime implicant\uFF0C\u81F3\u5C11\u627E\u5230\u4E00\u500B\u4F7F\u5176\u70BA\u771F\u7684 row\uFF08\u5DF2\u6700\u5C0F\u5316\u6E2C\u8A66\u5217\u6578\uFF09\u3002",
+      description: L("For every prime implicant in the minimal DNF of f and \xACf, find at least one row that satisfies it (test rows are minimised).", "\u5C0D f \u8207 \xACf \u7684\u6700\u5C0F DNF \u4E2D\u6BCF\u500B prime implicant\uFF0C\u81F3\u5C11\u627E\u5230\u4E00\u500B\u4F7F\u5176\u70BA\u771F\u7684 row\uFF08\u5DF2\u6700\u5C0F\u5316\u6E2C\u8A66\u5217\u6578\uFF09\u3002"),
       tests,
       requirementCount: dnf.length + negDnf.length,
       unsatisfied
@@ -4035,7 +4036,7 @@
     return {
       id: "utpc",
       name: "Unique True Point Coverage",
-      description: "\u5C0D\u6BCF\u500B implicant\uFF0C\u5217\u51FA\u6240\u6709\u53EA\u6EFF\u8DB3\u8A72 implicant \u7684 unique true point\uFF08\u4EFB\u9078\u5176\u4E00\u5373\u53EF\u6EFF\u8DB3\u6E96\u5247\uFF09\u3002",
+      description: L("For each implicant, list every unique true point that only satisfies that implicant (any one of them satisfies the criterion).", "\u5C0D\u6BCF\u500B implicant\uFF0C\u5217\u51FA\u6240\u6709\u53EA\u6EFF\u8DB3\u8A72 implicant \u7684 unique true point\uFF08\u4EFB\u9078\u5176\u4E00\u5373\u53EF\u6EFF\u8DB3\u6E96\u5247\uFF09\u3002"),
       tests,
       requirementCount: dnf.length,
       unsatisfied
@@ -4053,8 +4054,8 @@
       const utps = uniqueTruePointsForTerm(rows, term, dnf, index);
       if (!utps.length) {
         minorClauses.forEach((c) => {
-          unsatisfied.push(`MUTP {${termLabel(term)}} \u7F3A ${c}=T`);
-          unsatisfied.push(`MUTP {${termLabel(term)}} \u7F3A ${c}=F`);
+          unsatisfied.push(L(`MUTP {${termLabel(term)}} missing ${c}=T`, `MUTP {${termLabel(term)}} \u7F3A ${c}=T`));
+          unsatisfied.push(L(`MUTP {${termLabel(term)}} missing ${c}=F`, `MUTP {${termLabel(term)}} \u7F3A ${c}=F`));
         });
         return;
       }
@@ -4105,7 +4106,7 @@
       }
       if (remaining.size) {
         remaining.forEach((r) => {
-          unsatisfied.push(`MUTP {${termLabel(term)}} \u7F3A ${r}`);
+          unsatisfied.push(L(`MUTP {${termLabel(term)}} missing ${r}`, `MUTP {${termLabel(term)}} \u7F3A ${r}`));
         });
       }
       chosen.forEach((i) => {
@@ -4117,7 +4118,7 @@
         tests.push({
           id: key,
           row,
-          label: `MUTP {${termLabel(term)}}\uFF08${covered}\uFF09`,
+          label: `MUTP {${termLabel(term)}} (${covered})`,
           implicantIndex: index
         });
       });
@@ -4125,7 +4126,7 @@
     return {
       id: "mutpc",
       name: "Multiple Unique True Point Coverage",
-      description: "\u5C0D\u6BCF\u500B implicant\uFF0C\u6311\u9078\u4E00\u7D44 UTPs\uFF0C\u4F7F\u6BCF\u500B\u6B21\u5B50\u53E5\uFF08\u4E0D\u5728 implicant \u4E2D\u7684 clause\uFF09\u90FD\u81F3\u5C11\u51FA\u73FE\u4E00\u6B21 T \u8207\u4E00\u6B21 F\u3002",
+      description: L("For each implicant, pick a set of UTPs so that every minor clause (clauses not in the implicant) takes both T and F at least once.", "\u5C0D\u6BCF\u500B implicant\uFF0C\u6311\u9078\u4E00\u7D44 UTPs\uFF0C\u4F7F\u6BCF\u500B\u6B21\u5B50\u53E5\uFF08\u4E0D\u5728 implicant \u4E2D\u7684 clause\uFF09\u90FD\u81F3\u5C11\u51FA\u73FE\u4E00\u6B21 T \u8207\u4E00\u6B21 F\u3002"),
       tests,
       requirementCount,
       unsatisfied
@@ -4168,7 +4169,7 @@
         tests.push({
           id: key,
           row,
-          label: `NFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`,
+          label: L(`NFP {${termLabel(term)}} flip ${literalKey(literal)}`, `NFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`),
           implicantIndex: index,
           literal,
           pairedTruePointIndex: pairedTruePoint ? pairedTruePoint.index : null
@@ -4178,7 +4179,7 @@
     return {
       id: "nfpc",
       name: "Near False Point Coverage",
-      description: "\u5C0D\u6BCF\u500B implicant \u7684\u6BCF\u500B literal\uFF0C\u627E\u4E00\u500B\u7FFB\u8F49\u8A72 literal \u5F8C\u4F7F implicant \u70BA\u5047\u4E14 P \u70BA\u5047\u7684 row\u3002",
+      description: L("For every literal in every implicant, find a row that flips that literal so the implicant becomes false and P is false.", "\u5C0D\u6BCF\u500B implicant \u7684\u6BCF\u500B literal\uFF0C\u627E\u4E00\u500B\u7FFB\u8F49\u8A72 literal \u5F8C\u4F7F implicant \u70BA\u5047\u4E14 P \u70BA\u5047\u7684 row\u3002"),
       tests,
       requirementCount,
       unsatisfied
@@ -4197,11 +4198,11 @@
         const nfps = nearFalsePointsFor(rows, term, literalIndex);
         if (!nfps.length) {
           if (!minorClauses.length) {
-            unsatisfied.push(`MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`);
+            unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)}`, `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`));
           } else {
             minorClauses.forEach((c) => {
-              unsatisfied.push(`MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)} \u7F3A ${c}=T`);
-              unsatisfied.push(`MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)} \u7F3A ${c}=F`);
+              unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} missing ${c}=T`, `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)} \u7F3A ${c}=T`));
+              unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} missing ${c}=F`, `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)} \u7F3A ${c}=F`));
             });
           }
           return;
@@ -4214,7 +4215,7 @@
             tests.push({
               id: key,
               row,
-              label: `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`,
+              label: L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)}`, `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`),
               implicantIndex: index,
               literal
             });
@@ -4254,7 +4255,7 @@
         }
         if (remaining.size) {
           remaining.forEach((r) => {
-            unsatisfied.push(`MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)} \u7F3A ${r}`);
+            unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} missing ${r}`, `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)} \u7F3A ${r}`));
           });
         }
         chosen.forEach((i) => {
@@ -4266,7 +4267,7 @@
           tests.push({
             id: key,
             row,
-            label: `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}\uFF08${covered}\uFF09`,
+            label: L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} (${covered})`, `MNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}\uFF08${covered}\uFF09`),
             implicantIndex: index,
             literal
           });
@@ -4276,7 +4277,7 @@
     return {
       id: "mnfpc",
       name: "Multiple Near False Point Coverage",
-      description: "\u5C0D\u6BCF\u500B implicant \u7684\u6BCF\u500B literal\uFF0C\u6311\u4E00\u7D44 NFPs\uFF0C\u4F7F\u6BCF\u500B\u6B21\u5B50\u53E5\u90FD\u81F3\u5C11\u51FA\u73FE\u4E00\u6B21 T \u8207\u4E00\u6B21 F\u3002",
+      description: L("For every literal in every implicant, pick a set of NFPs so that every minor clause takes both T and F at least once.", "\u5C0D\u6BCF\u500B implicant \u7684\u6BCF\u500B literal\uFF0C\u6311\u4E00\u7D44 NFPs\uFF0C\u4F7F\u6BCF\u500B\u6B21\u5B50\u53E5\u90FD\u81F3\u5C11\u51FA\u73FE\u4E00\u6B21 T \u8207\u4E00\u6B21 F\u3002"),
       tests,
       requirementCount,
       unsatisfied
@@ -4306,7 +4307,7 @@
           }
         }
         if (!pair) {
-          unsatisfied.push(`CUTPNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`);
+          unsatisfied.push(L(`CUTPNFP {${termLabel(term)}} flip ${literalKey(literal)}`, `CUTPNFP {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`));
           return;
         }
         pair.forEach((row, role) => {
@@ -4316,7 +4317,7 @@
           tests.push({
             id: key,
             row,
-            label: `${role === 0 ? "UTP" : "NFP"} pair {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`,
+            label: L(`${role === 0 ? "UTP" : "NFP"} pair {${termLabel(term)}} flip ${literalKey(literal)}`, `${role === 0 ? "UTP" : "NFP"} pair {${termLabel(term)}} \u7FFB\u8F49 ${literalKey(literal)}`),
             implicantIndex: index,
             literal,
             role: role === 0 ? "utp" : "nfp",
@@ -4328,7 +4329,7 @@
     return {
       id: "cutpnfp",
       name: "Corresponding UTP + NFP Pair Coverage",
-      description: "\u70BA\u6BCF\u500B implicant \u7684\u6BCF\u500B literal\uFF0C\u6311\u4E00\u5C0D\u50C5\u5728\u8A72 literal \u4E0D\u540C\u7684 UTP \u8207 NFP\u3002",
+      description: L("For every literal in every implicant, pick a UTP/NFP pair that differs only in that literal.", "\u70BA\u6BCF\u500B implicant \u7684\u6BCF\u500B literal\uFF0C\u6311\u4E00\u5C0D\u50C5\u5728\u8A72 literal \u4E0D\u540C\u7684 UTP \u8207 NFP\u3002"),
       tests,
       requirementCount,
       unsatisfied
@@ -4939,7 +4940,7 @@ Content-Type: ${file.type || "application/octet-stream"}\r
           class="logic-example-btn${state.expression === p.expression ? " active" : ""}"
           data-expression="${escapeHtml2(p.expression)}"
           data-testid="logic-example-${p.id}"
-          title="${escapeHtml2(p.description)}"
+          title="${escapeHtml2(pickField(p, "description") || "")}"
         >
           ${escapeHtml2(p.name)}
         </button>
@@ -4973,8 +4974,8 @@ Content-Type: ${file.type || "application/octet-stream"}\r
           data-criterion="${c.id}"
           data-testid="logic-criterion-${c.id}"
         >
-          <span class="logic-criterion-label">${escapeHtml2(c.label)}</span>
-          <span class="logic-criterion-zh">${escapeHtml2(getLocale() === "en" ? c.descriptionEn || c.description || "" : c.labelZh)}</span>
+          <span class="logic-criterion-label">${escapeHtml2(pickField(c, "label") || c.label)}</span>
+          <span class="logic-criterion-zh">${escapeHtml2(getLocale() === "en" ? c.descriptionEn || c.description || "" : c.labelZh || "")}</span>
         </button>
       `).join("");
       const truthTableMarkup = renderTruthTable();
@@ -5212,7 +5213,7 @@ Content-Type: ${file.type || "application/octet-stream"}\r
       })() : "";
       return `
       <h3 class="logic-summary-title">${escapeHtml2(set.name)}</h3>
-      <p class="logic-summary-desc">${escapeHtml2(set.description)}</p>
+      <p class="logic-summary-desc">${escapeHtml2(set.description || "")}</p>
       ${dnfMarkup}
       ${kmapMarkup}
       <p class="logic-summary-stats">

--- a/src/utils/logicCoverage.js
+++ b/src/utils/logicCoverage.js
@@ -13,6 +13,12 @@
 //   - CACC (Correlated Active Clause Coverage)
 //   - RACC (Restricted Active Clause Coverage)
 
+import { getLocale } from '../i18n/index.js';
+
+// Tiny locale helper for messages and dynamic labels emitted from this module.
+// English first because the module's identifiers / API are English by default.
+const L = (en, zh) => (getLocale() === 'en' ? en : zh);
+
 // Tokens：
 //   `(` `)` `&&` `||` `!`  以及識別字（單一英文字母可選跟數字，如 a、b、c1、x2）。
 //   為了支援教科書記號，額外接受：
@@ -31,7 +37,7 @@ function tokenize(expression) {
     if (!match) {
       const remainder = expression.slice(start).trim();
       if (!remainder) break;
-      throw new Error(`不支援的字元：「${remainder[0]}」於位置 ${start + 1}`);
+      throw new Error(L(`Unsupported character "${remainder[0]}" at position ${start + 1}`, `不支援的字元：「${remainder[0]}」於位置 ${start + 1}`));
     }
     const [, lparen, rparen, andOp, orOp, plusOp, notOp, ident] = match;
     if (lparen) tokens.push({ type: 'lparen' });
@@ -44,7 +50,7 @@ function tokenize(expression) {
   }
 
   if (lastIndex < expression.length && expression.slice(lastIndex).trim()) {
-    throw new Error(`無法解析剩餘字串：「${expression.slice(lastIndex).trim()}」`);
+    throw new Error(L(`Could not parse trailing input "${expression.slice(lastIndex).trim()}"`, `無法解析剩餘字串：「${expression.slice(lastIndex).trim()}」`));
   }
 
   return tokens;
@@ -60,7 +66,7 @@ function parseExpression(tokens) {
   function consume(type) {
     const token = tokens[pos];
     if (!token || token.type !== type) {
-      throw new Error(`語法錯誤：預期 ${type}，實際 ${token ? token.type : 'EOF'}`);
+      throw new Error(L(`Syntax error: expected ${type}, got ${token ? token.type : 'EOF'}`, `語法錯誤：預期 ${type}，實際 ${token ? token.type : 'EOF'}`));
     }
     pos += 1;
     return token;
@@ -103,7 +109,7 @@ function parseExpression(tokens) {
 
   function parseAtom() {
     const token = peek();
-    if (!token) throw new Error('語法錯誤：未預期的結尾。');
+    if (!token) throw new Error(L('Syntax error: unexpected end of input.', '語法錯誤：未預期的結尾。'));
     if (token.type === 'lparen') {
       consume('lparen');
       const node = parseOr();
@@ -114,12 +120,12 @@ function parseExpression(tokens) {
       consume('ident');
       return { type: 'clause', name: token.value };
     }
-    throw new Error(`語法錯誤：未預期的 ${token.type}`);
+    throw new Error(L(`Syntax error: unexpected ${token.type}`, `語法錯誤：未預期的 ${token.type}`));
   }
 
   const ast = parseOr();
   if (pos !== tokens.length) {
-    throw new Error('語法錯誤：剩餘 token 未解析。');
+    throw new Error(L('Syntax error: trailing tokens were not parsed.', '語法錯誤：剩餘 token 未解析。'));
   }
   return ast;
 }
@@ -128,7 +134,7 @@ function evaluateAst(ast, values) {
   switch (ast.type) {
     case 'clause': {
       if (!(ast.name in values)) {
-        throw new Error(`缺少子句值：${ast.name}`);
+        throw new Error(L(`Missing clause value: ${ast.name}`, `缺少子句值：${ast.name}`));
       }
       return Boolean(values[ast.name]);
     }
@@ -139,7 +145,7 @@ function evaluateAst(ast, values) {
     case 'or':
       return evaluateAst(ast.left, values) || evaluateAst(ast.right, values);
     default:
-      throw new Error(`未知 AST 節點：${ast.type}`);
+      throw new Error(L(`Unknown AST node: ${ast.type}`, `未知 AST 節點：${ast.type}`));
   }
 }
 
@@ -158,11 +164,11 @@ function collectClauses(ast, accumulator = []) {
 export function parsePredicate(expression) {
   const trimmed = String(expression || '').trim();
   if (!trimmed) {
-    throw new Error('Predicate 不能為空。');
+    throw new Error(L('Predicate must not be empty.', 'Predicate 不能為空。'));
   }
   const tokens = tokenize(trimmed);
   if (!tokens.length) {
-    throw new Error('Predicate 不含任何 token。');
+    throw new Error(L('Predicate did not yield any token.', 'Predicate 不含任何 token。'));
   }
   const ast = parseExpression(tokens);
   const clauses = collectClauses(ast);
@@ -207,7 +213,7 @@ export function buildPredicateCoverageSet(rows) {
   return {
     id: 'pc',
     name: 'Predicate Coverage',
-    description: '讓整個 predicate 至少評估為 true 與 false 各一次。',
+    description: L('Make the predicate evaluate to true and false at least once each.', '讓整個 predicate 至少評估為 true 與 false 各一次。'),
     tests,
     requirementCount: 2,
   };
@@ -232,7 +238,7 @@ export function buildClauseCoverageSet(rows, clauses) {
   return {
     id: 'cc',
     name: 'Clause Coverage',
-    description: '每個子句都必須各取 true 與 false 一次。',
+    description: L('Each clause must take both true and false at least once.', '每個子句都必須各取 true 與 false 一次。'),
     tests,
     requirementCount: clauses.length * 2,
   };
@@ -242,7 +248,7 @@ export function buildCombinatorialCoverageSet(rows) {
   return {
     id: 'coc',
     name: 'Combinatorial Coverage',
-    description: '列舉所有子句真假組合（共 2^n 列）。',
+    description: L('Enumerate all clause T/F combinations (2^n rows).', '列舉所有子句真假組合（共 2^n 列）。'),
     tests: rows.map((row) => ({ id: rowKey(row), row, label: `Row ${row.index}` })),
     requirementCount: rows.length,
   };
@@ -305,7 +311,7 @@ function buildActiveClauseSet(id, name, description, rows, clauses, mode) {
       tests.push({
         id: testId,
         row,
-        label: `${clause}=${row.values[clause] ? 'T' : 'F'} (主導 ${clause})`,
+        label: `${clause}=${row.values[clause] ? 'T' : 'F'} ${L(`(major ${clause})`, `(主導 ${clause})`)}`,
         majorClause: clause,
       });
     });
@@ -325,7 +331,7 @@ export function buildGACCSet(rows, clauses) {
   return buildActiveClauseSet(
     'gacc',
     'General Active Clause Coverage',
-    '對每個主子句，找一對列使其決定 predicate 的值，次子句可任意。',
+    L('For each major clause, find a row pair such that the major clause determines the predicate while minor clauses are unconstrained.', '對每個主子句，找一對列使其決定 predicate 的值，次子句可任意。'),
     rows,
     clauses,
     'gacc',
@@ -336,7 +342,7 @@ export function buildCACCSet(rows, clauses) {
   return buildActiveClauseSet(
     'cacc',
     'Correlated Active Clause Coverage',
-    '主子句決定 predicate 結果，且兩列產生不同的 predicate 值。',
+    L('The major clause determines the predicate, and the two rows produce different predicate values.', '主子句決定 predicate 結果，且兩列產生不同的 predicate 值。'),
     rows,
     clauses,
     'cacc',
@@ -347,7 +353,7 @@ export function buildRACCSet(rows, clauses) {
   return buildActiveClauseSet(
     'racc',
     'Restricted Active Clause Coverage',
-    '主子句決定 predicate 結果，且兩列的次子句值完全相同。',
+    L('The major clause determines the predicate, and the two rows have identical minor-clause values.', '主子句決定 predicate 結果，且兩列的次子句值完全相同。'),
     rows,
     clauses,
     'racc',
@@ -375,7 +381,7 @@ function buildInactiveClauseSet(id, name, description, rows, clauses, mode) {
       tests.push({
         id: testId,
         row,
-        label: `${clause}=${row.values[clause] ? 'T' : 'F'}, P=${row.predicate ? 'T' : 'F'} (非主導 ${clause})`,
+        label: `${clause}=${row.values[clause] ? 'T' : 'F'}, P=${row.predicate ? 'T' : 'F'} ${L(`(minor ${clause})`, `(非主導 ${clause})`)}`,
         majorClause: clause,
       });
     }
@@ -433,7 +439,7 @@ export function buildGICCSet(rows, clauses) {
   return buildInactiveClauseSet(
     'gicc',
     'General Inactive Clause Coverage',
-    '對每個主子句，於不決定 predicate 的列中，覆蓋 (c=T/F)×(P=T/F) 共 4 種組合。',
+    L('For each major clause, in rows where it does not determine the predicate, cover all (c=T/F) × (P=T/F) combinations.', '對每個主子句，於不決定 predicate 的列中，覆蓋 (c=T/F)×(P=T/F) 共 4 種組合。'),
     rows,
     clauses,
     'gicc',
@@ -444,7 +450,7 @@ export function buildRICCSet(rows, clauses) {
   return buildInactiveClauseSet(
     'ricc',
     'Restricted Inactive Clause Coverage',
-    '同 GICC，但成對列（同 P 值）需所有次子句完全相同，僅主子句翻轉。',
+    L('Same as GICC, but paired rows (same P) must agree on every minor clause; only the major clause flips.', '同 GICC，但成對列（同 P 值）需所有次子句完全相同，僅主子句翻轉。'),
     rows,
     clauses,
     'ricc',
@@ -540,7 +546,7 @@ function dnfFromAst(ast) {
     case 'or':
       return dedupeTerms([...dnfFromAst(ast.left), ...dnfFromAst(ast.right)]);
     default:
-      throw new Error(`未知 AST 節點：${ast.type}`);
+      throw new Error(L(`Unknown AST node: ${ast.type}`, `未知 AST 節點：${ast.type}`));
   }
 }
 
@@ -563,7 +569,7 @@ function dnfNegate(ast) {
       return dedupeTerms(terms);
     }
     default:
-      throw new Error(`未知 AST 節點：${ast.type}`);
+      throw new Error(L(`Unknown AST node: ${ast.type}`, `未知 AST 節點：${ast.type}`));
   }
 }
 
@@ -755,7 +761,7 @@ export function buildImplicantCoverageSet(rows, dnf, negDnf = []) {
   return {
     id: 'ic',
     name: 'Implicant Coverage',
-    description: '對 f 與 ¬f 的最小 DNF 中每個 prime implicant，至少找到一個使其為真的 row（已最小化測試列數）。',
+    description: L('For every prime implicant in the minimal DNF of f and ¬f, find at least one row that satisfies it (test rows are minimised).', '對 f 與 ¬f 的最小 DNF 中每個 prime implicant，至少找到一個使其為真的 row（已最小化測試列數）。'),
     tests,
     requirementCount: dnf.length + negDnf.length,
     unsatisfied,
@@ -789,7 +795,7 @@ export function buildUTPCSet(rows, dnf) {
   return {
     id: 'utpc',
     name: 'Unique True Point Coverage',
-    description: '對每個 implicant，列出所有只滿足該 implicant 的 unique true point（任選其一即可滿足準則）。',
+    description: L('For each implicant, list every unique true point that only satisfies that implicant (any one of them satisfies the criterion).', '對每個 implicant，列出所有只滿足該 implicant 的 unique true point（任選其一即可滿足準則）。'),
     tests,
     requirementCount: dnf.length,
     unsatisfied,
@@ -813,8 +819,8 @@ export function buildMUTPCSet(rows, clauses, dnf) {
     const utps = uniqueTruePointsForTerm(rows, term, dnf, index);
     if (!utps.length) {
       minorClauses.forEach((c) => {
-        unsatisfied.push(`MUTP {${termLabel(term)}} 缺 ${c}=T`);
-        unsatisfied.push(`MUTP {${termLabel(term)}} 缺 ${c}=F`);
+        unsatisfied.push(L(`MUTP {${termLabel(term)}} missing ${c}=T`, `MUTP {${termLabel(term)}} 缺 ${c}=T`));
+        unsatisfied.push(L(`MUTP {${termLabel(term)}} missing ${c}=F`, `MUTP {${termLabel(term)}} 缺 ${c}=F`));
       });
       return;
     }
@@ -867,7 +873,7 @@ export function buildMUTPCSet(rows, clauses, dnf) {
 
     if (remaining.size) {
       remaining.forEach((r) => {
-        unsatisfied.push(`MUTP {${termLabel(term)}} 缺 ${r}`);
+        unsatisfied.push(L(`MUTP {${termLabel(term)}} missing ${r}`, `MUTP {${termLabel(term)}} 缺 ${r}`));
       });
     }
 
@@ -880,7 +886,7 @@ export function buildMUTPCSet(rows, clauses, dnf) {
       tests.push({
         id: key,
         row,
-        label: `MUTP {${termLabel(term)}}（${covered}）`,
+        label: `MUTP {${termLabel(term)}} (${covered})`,
         implicantIndex: index,
       });
     });
@@ -890,7 +896,7 @@ export function buildMUTPCSet(rows, clauses, dnf) {
     id: 'mutpc',
     name: 'Multiple Unique True Point Coverage',
     description:
-      '對每個 implicant，挑選一組 UTPs，使每個次子句（不在 implicant 中的 clause）都至少出現一次 T 與一次 F。',
+      L('For each implicant, pick a set of UTPs so that every minor clause (clauses not in the implicant) takes both T and F at least once.', '對每個 implicant，挑選一組 UTPs，使每個次子句（不在 implicant 中的 clause）都至少出現一次 T 與一次 F。'),
     tests,
     requirementCount,
     unsatisfied,
@@ -938,7 +944,7 @@ export function buildNFPCSet(rows, dnf) {
       tests.push({
         id: key,
         row,
-        label: `NFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`,
+        label: L(`NFP {${termLabel(term)}} flip ${literalKey(literal)}`, `NFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`),
         implicantIndex: index,
         literal,
         pairedTruePointIndex: pairedTruePoint ? pairedTruePoint.index : null,
@@ -949,7 +955,7 @@ export function buildNFPCSet(rows, dnf) {
   return {
     id: 'nfpc',
     name: 'Near False Point Coverage',
-    description: '對每個 implicant 的每個 literal，找一個翻轉該 literal 後使 implicant 為假且 P 為假的 row。',
+    description: L('For every literal in every implicant, find a row that flips that literal so the implicant becomes false and P is false.', '對每個 implicant 的每個 literal，找一個翻轉該 literal 後使 implicant 為假且 P 為假的 row。'),
     tests,
     requirementCount,
     unsatisfied,
@@ -974,11 +980,11 @@ export function buildMNFPCSet(rows, clauses, dnf) {
       const nfps = nearFalsePointsFor(rows, term, literalIndex);
       if (!nfps.length) {
         if (!minorClauses.length) {
-          unsatisfied.push(`MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`);
+          unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)}`, `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`));
         } else {
           minorClauses.forEach((c) => {
-            unsatisfied.push(`MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)} 缺 ${c}=T`);
-            unsatisfied.push(`MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)} 缺 ${c}=F`);
+            unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} missing ${c}=T`, `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)} 缺 ${c}=T`));
+            unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} missing ${c}=F`, `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)} 缺 ${c}=F`));
           });
         }
         return;
@@ -992,7 +998,7 @@ export function buildMNFPCSet(rows, clauses, dnf) {
           tests.push({
             id: key,
             row,
-            label: `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`,
+            label: L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)}`, `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`),
             implicantIndex: index,
             literal,
           });
@@ -1031,7 +1037,7 @@ export function buildMNFPCSet(rows, clauses, dnf) {
 
       if (remaining.size) {
         remaining.forEach((r) => {
-          unsatisfied.push(`MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)} 缺 ${r}`);
+          unsatisfied.push(L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} missing ${r}`, `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)} 缺 ${r}`));
         });
       }
 
@@ -1044,7 +1050,7 @@ export function buildMNFPCSet(rows, clauses, dnf) {
         tests.push({
           id: key,
           row,
-          label: `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}（${covered}）`,
+          label: L(`MNFP {${termLabel(term)}} flip ${literalKey(literal)} (${covered})`, `MNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}（${covered}）`),
           implicantIndex: index,
           literal,
         });
@@ -1056,7 +1062,7 @@ export function buildMNFPCSet(rows, clauses, dnf) {
     id: 'mnfpc',
     name: 'Multiple Near False Point Coverage',
     description:
-      '對每個 implicant 的每個 literal，挑一組 NFPs，使每個次子句都至少出現一次 T 與一次 F。',
+      L('For every literal in every implicant, pick a set of NFPs so that every minor clause takes both T and F at least once.', '對每個 implicant 的每個 literal，挑一組 NFPs，使每個次子句都至少出現一次 T 與一次 F。'),
     tests,
     requirementCount,
     unsatisfied,
@@ -1088,7 +1094,7 @@ export function buildCUTPNFPSet(rows, dnf) {
         }
       }
       if (!pair) {
-        unsatisfied.push(`CUTPNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`);
+        unsatisfied.push(L(`CUTPNFP {${termLabel(term)}} flip ${literalKey(literal)}`, `CUTPNFP {${termLabel(term)}} 翻轉 ${literalKey(literal)}`));
         return;
       }
       pair.forEach((row, role) => {
@@ -1098,7 +1104,7 @@ export function buildCUTPNFPSet(rows, dnf) {
         tests.push({
           id: key,
           row,
-          label: `${role === 0 ? 'UTP' : 'NFP'} pair {${termLabel(term)}} 翻轉 ${literalKey(literal)}`,
+          label: L(`${role === 0 ? 'UTP' : 'NFP'} pair {${termLabel(term)}} flip ${literalKey(literal)}`, `${role === 0 ? 'UTP' : 'NFP'} pair {${termLabel(term)}} 翻轉 ${literalKey(literal)}`),
           implicantIndex: index,
           literal,
           role: role === 0 ? 'utp' : 'nfp',
@@ -1111,7 +1117,7 @@ export function buildCUTPNFPSet(rows, dnf) {
   return {
     id: 'cutpnfp',
     name: 'Corresponding UTP + NFP Pair Coverage',
-    description: '為每個 implicant 的每個 literal，挑一對僅在該 literal 不同的 UTP 與 NFP。',
+    description: L('For every literal in every implicant, pick a UTP/NFP pair that differs only in that literal.', '為每個 implicant 的每個 literal，挑一對僅在該 literal 不同的 UTP 與 NFP。'),
     tests,
     requirementCount,
     unsatisfied,


### PR DESCRIPTION
Closes #58.

## What

Localize the remaining hardcoded Chinese strings inside the Logic Coverage Explorer so the UI follows the active locale.

### `src/utils/logicCoverage.js`
- Add a tiny `L(en, zh)` helper that reads `getLocale()` from `../i18n/index.js`.
- Wrap every parser `Error(...)` and `Predicate ...` validation in `L(...)`.
- Wrap every coverage-set `description` (PC, CC, CoC, GACC, CACC, RACC, GICC, RICC, IC, UTPC, MUTPC, NFPC, MNFPC, CUTPNFP) in `L(...)`.
- Localize the dynamic test labels and `unsatisfied[]` entries:
  - `(主導 c)` ↔ `(major c)`
  - `(非主導 c)` ↔ `(minor c)`
  - `NFP {…} 翻轉 lit` ↔ `NFP {…} flip lit`
  - `MNFP {…} 翻轉 lit 缺 c=T` ↔ `MNFP {…} flip lit missing c=T`
  - `MUTP {…} 缺 r` ↔ `MUTP {…} missing r`
  - `CUTPNFP {…} 翻轉 lit` ↔ `CUTPNFP {…} flip lit`
- Replace full-width `（…）` parens with neutral ASCII `(…)` so the covered-pair annotation reads cleanly in both locales.

### `src/components/LogicCoverageExplorer.js`
- Predicate-example button `title` → `pickField(p, 'description')`.
- Criterion button main label → `pickField(c, 'label')`.
- Coverage-set summary description renders the locale-correct `set.description` produced upstream.

## Verify

- `npm run test:run` → 187 passed (no behaviour change).
- `node scripts/build-standalone.mjs` → bundle rebuilt.