### PR TITLE
chore: remove hardcoded API keys and inject via CI secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in the real values.
+# These values are injected into src/config/cloudConfig.js at build time.
+
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+FIREBASE_MEASUREMENT_ID=
+DRIVE_UPLOAD_FOLDER_ID=

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,6 +35,15 @@ jobs:
         run: npm run test:run
 
       - name: Prepare static site
+        env:
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
+          DRIVE_UPLOAD_FOLDER_ID: ${{ secrets.DRIVE_UPLOAD_FOLDER_ID }}
         run: npm run pages:prepare
 
       - name: Upload pages artifact

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ site/
 coverage/
 playwright-report/
 test-results/
+.env

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "serve": "python3 -m http.server 4173",
+    "inject-env": "node scripts/inject-env.mjs",
     "build:standalone": "node scripts/build-standalone.mjs",
-    "pages:prepare": "npm run build:standalone && node scripts/prepare-pages.mjs",
+    "pages:prepare": "npm run inject-env && npm run build:standalone && node scripts/prepare-pages.mjs",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/scripts/inject-env.mjs
+++ b/scripts/inject-env.mjs
@@ -1,0 +1,60 @@
+// Reads environment variables (from process.env or a local .env file)
+// and replaces the __PLACEHOLDER__ tokens in src/config/cloudConfig.js.
+//
+// Usage:
+//   node scripts/inject-env.mjs          # reads .env if present
+//   FIREBASE_API_KEY=xxx node scripts/inject-env.mjs  # uses shell env
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const configPath = path.join(projectRoot, 'src', 'config', 'cloudConfig.js');
+
+// Load .env file if it exists (does NOT override existing process.env).
+const dotenvPath = path.join(projectRoot, '.env');
+try {
+  const dotenv = await readFile(dotenvPath, 'utf8');
+  for (const line of dotenv.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+} catch {
+  // No .env file — rely on process.env (CI secrets).
+}
+
+const PLACEHOLDERS = {
+  __FIREBASE_API_KEY__: 'FIREBASE_API_KEY',
+  __FIREBASE_AUTH_DOMAIN__: 'FIREBASE_AUTH_DOMAIN',
+  __FIREBASE_PROJECT_ID__: 'FIREBASE_PROJECT_ID',
+  __FIREBASE_STORAGE_BUCKET__: 'FIREBASE_STORAGE_BUCKET',
+  __FIREBASE_MESSAGING_SENDER_ID__: 'FIREBASE_MESSAGING_SENDER_ID',
+  __FIREBASE_APP_ID__: 'FIREBASE_APP_ID',
+  __FIREBASE_MEASUREMENT_ID__: 'FIREBASE_MEASUREMENT_ID',
+  __DRIVE_UPLOAD_FOLDER_ID__: 'DRIVE_UPLOAD_FOLDER_ID',
+};
+
+let source = await readFile(configPath, 'utf8');
+let replaced = 0;
+
+for (const [placeholder, envKey] of Object.entries(PLACEHOLDERS)) {
+  const value = process.env[envKey] || '';
+  if (source.includes(placeholder)) {
+    source = source.replaceAll(placeholder, value);
+    replaced += 1;
+    if (!value) {
+      console.warn(`  ⚠  ${envKey} is empty — placeholder ${placeholder} replaced with blank.`);
+    }
+  }
+}
+
+await writeFile(configPath, source, 'utf8');
+console.log(`inject-env: replaced ${replaced} placeholder(s) in cloudConfig.js`);

--- a/src/config/cloudConfig.js
+++ b/src/config/cloudConfig.js
@@ -1,15 +1,15 @@
 export const cloudConfig = {
   firebase: {
-    apiKey: "AIzaSyB9QlOS2IodbRQWxGGe_a8cEviSZURyo3k",
-    authDomain: "stvisual-a88cd.firebaseapp.com",
-    projectId: "stvisual-a88cd",
-    storageBucket: "stvisual-a88cd.firebasestorage.app",
-    messagingSenderId: "1030102454109",
-    appId: "1:1030102454109:web:cb50e6da22b4b5dda2a2b4",
-    measurementId: "G-RBRGPW34JQ",
+    apiKey: "__FIREBASE_API_KEY__",
+    authDomain: "__FIREBASE_AUTH_DOMAIN__",
+    projectId: "__FIREBASE_PROJECT_ID__",
+    storageBucket: "__FIREBASE_STORAGE_BUCKET__",
+    messagingSenderId: "__FIREBASE_MESSAGING_SENDER_ID__",
+    appId: "__FIREBASE_APP_ID__",
+    measurementId: "__FIREBASE_MEASUREMENT_ID__",
   },
   drive: {
-    uploadFolderId: '1B5hCB2Scte4Sds0d03mYNu-iGZS0JKbJ',
+    uploadFolderId: '__DRIVE_UPLOAD_FOLDER_ID__',
   },
 };
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -4672,16 +4672,16 @@
   // src/config/cloudConfig.js
   var cloudConfig = {
     firebase: {
-      apiKey: "AIzaSyB9QlOS2IodbRQWxGGe_a8cEviSZURyo3k",
-      authDomain: "stvisual-a88cd.firebaseapp.com",
-      projectId: "stvisual-a88cd",
-      storageBucket: "stvisual-a88cd.firebasestorage.app",
-      messagingSenderId: "1030102454109",
-      appId: "1:1030102454109:web:cb50e6da22b4b5dda2a2b4",
-      measurementId: "G-RBRGPW34JQ"
+      apiKey: "__FIREBASE_API_KEY__",
+      authDomain: "__FIREBASE_AUTH_DOMAIN__",
+      projectId: "__FIREBASE_PROJECT_ID__",
+      storageBucket: "__FIREBASE_STORAGE_BUCKET__",
+      messagingSenderId: "__FIREBASE_MESSAGING_SENDER_ID__",
+      appId: "__FIREBASE_APP_ID__",
+      measurementId: "__FIREBASE_MEASUREMENT_ID__"
     },
     drive: {
-      uploadFolderId: "1B5hCB2Scte4Sds0d03mYNu-iGZS0JKbJ"
+      uploadFolderId: "__DRIVE_UPLOAD_FOLDER_ID__"
     }
   };
   function getResolvedCloudConfig() {


### PR DESCRIPTION
Closes #70.

## Summary

Removes all hardcoded Firebase and Drive API keys from the source
code and replaces them with `__PLACEHOLDER__` tokens that are
substituted at build time by `scripts/inject-env.mjs`.

### Changes

- **`src/config/cloudConfig.js`**: all 8 credential values replaced
  with `__FIREBASE_*__` / `__DRIVE_*__` placeholders.
- **`scripts/inject-env.mjs`** (new): reads a local `.env` file if
  present (without overriding existing env vars), then replaces each
  placeholder in `cloudConfig.js`. Reports warnings for empty values.
- **`.env.example`** (new): documents required environment variables.
- **`.gitignore`**: added `.env`.
- **`package.json`**: new `inject-env` script; `pages:prepare` now
  runs `inject-env → build:standalone → prepare-pages`.
- **`.github/workflows/deploy-pages.yml`**: passes all 8 secrets as
  env vars to the build step.
- **`src/standalone.js`**: rebuilt with placeholder tokens.

### Setup for deployment

Add the following secrets in the repo's
**Settings → Secrets and variables → Actions**:

| Secret | Example |
|--------|---------|
| `FIREBASE_API_KEY` | `AIzaSy...` |
| `FIREBASE_AUTH_DOMAIN` | `stvisual-a88cd.firebaseapp.com` |
| `FIREBASE_PROJECT_ID` | `stvisual-a88cd` |
| `FIREBASE_STORAGE_BUCKET` | `stvisual-a88cd.firebasestorage.app` |
| `FIREBASE_MESSAGING_SENDER_ID` | `1030102454109` |
| `FIREBASE_APP_ID` | `1:1030102...` |
| `FIREBASE_MEASUREMENT_ID` | `G-RBRGPW34JQ` |
| `DRIVE_UPLOAD_FOLDER_ID` | `1B5hCB2S...` |

For local development, copy `.env.example` to `.env` and fill in
the values, then run `npm run inject-env` before `npm run build:standalone`.

## Tests

- `npm run test:run`: **202 / 202** across 21 files.
- `scripts/inject-env.mjs` verified: 8/8 placeholders replaced.