### PR TITLE
fix(i18n): remove Chinese text in Graph Coverage EN mode and native file buttons

### DIFF
--- a/src/components/CloudStoragePanel.css
+++ b/src/components/CloudStoragePanel.css
@@ -115,13 +115,45 @@
 }
 
 .cloud-section select,
-.cloud-section textarea,
-.cloud-section input[type='file'] {
+.cloud-section textarea {
   width: 100%;
   border: 1px solid #cbd5e1;
   border-radius: 10px;
   padding: 8px 10px;
   font-family: inherit;
+}
+
+.cloud-section .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.cloud-file-btn {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #334155;
+  text-align: left;
+  font-family: inherit;
+}
+
+.cloud-file-btn:hover {
+  background: #f1f5f9;
+}
+
+.cloud-file-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .cloud-section textarea {

--- a/src/components/CloudStoragePanel.js
+++ b/src/components/CloudStoragePanel.js
@@ -92,10 +92,11 @@ export function createCloudStoragePanel() {
 
           <section class="cloud-section">
             <h4>${t('cloud.section.files')}</h4>
-            <label class="cloud-file-picker">
-              ${t('cloud.uploadHint')}
-              <input type="file" data-testid="cloud-file-input" ${!user ? 'disabled' : ''} />
-            </label>
+            <div class="cloud-file-picker">
+              <span>${t('cloud.uploadHint')}</span>
+              <button type="button" class="cloud-file-btn" data-testid="cloud-file-btn" ${!user ? 'disabled' : ''}>${t('common.chooseFile')}</button>
+              <input type="file" data-testid="cloud-file-input" class="sr-only" ${!user ? 'disabled' : ''} />
+            </div>
             <p data-testid="cloud-file-name">${selectedFile ? t('cloud.pendingUpload', { name: selectedFile.name }) : t('cloud.noFileSelected')}</p>
             <button type="button" class="cloud-btn" data-testid="cloud-upload-btn" ${!selectedFile || !user ? 'disabled' : ''}>${t('cloud.upload')}</button>
 
@@ -168,6 +169,10 @@ export function createCloudStoragePanel() {
 
     root.querySelector('[data-testid="cloud-notes-input"]').addEventListener('input', (event) => {
       settings.notes = event.target.value;
+    });
+
+    root.querySelector('[data-testid="cloud-file-btn"]').addEventListener('click', () => {
+      root.querySelector('[data-testid="cloud-file-input"]').click();
     });
 
     root.querySelector('[data-testid="cloud-file-input"]').addEventListener('change', (event) => {

--- a/src/components/GraphCoverageExplorer.css
+++ b/src/components/GraphCoverageExplorer.css
@@ -29,6 +29,33 @@
   color: #64748b;
 }
 
+.graph-upload-field .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.graph-upload-btn {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #334155;
+  text-align: left;
+}
+
+.graph-upload-btn:hover {
+  background: #f1f5f9;
+}
+
 .graph-source-toolbar select,
 .graph-upload-field input,
 .graph-editor-meta input {

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -524,10 +524,11 @@ export function createGraphCoverageExplorer() {
               <option value="uploaded-spec"${selectedProgramId === 'uploaded-spec' ? ' selected' : ''}>Uploaded Graph Spec</option>
             </select>
           </label>
-          <label class="graph-upload-field">
-            Upload JSON Graph Spec
-            <input type="file" accept="application/json,.json" data-testid="graph-upload-input" />
-          </label>
+          <div class="graph-upload-field">
+            <span>Upload JSON Graph Spec</span>
+            <button type="button" class="graph-upload-btn" data-testid="graph-upload-btn">${t('common.chooseFile')}</button>
+            <input type="file" accept="application/json,.json" data-testid="graph-upload-input" class="sr-only" />
+          </div>
           <label>
             Code Language
             <select data-testid="program-language-select">
@@ -536,10 +537,11 @@ export function createGraphCoverageExplorer() {
               `).join('')}
             </select>
           </label>
-          <label class="graph-upload-field">
-            Upload Source Code
-            <input type="file" accept=".js,.txt,.code,.pseudo" data-testid="code-upload-input" />
-          </label>
+          <div class="graph-upload-field">
+            <span>Upload Source Code</span>
+            <button type="button" class="graph-upload-btn" data-testid="code-upload-btn">${t('common.chooseFile')}</button>
+            <input type="file" accept=".js,.txt,.code,.pseudo" data-testid="code-upload-input" class="sr-only" />
+          </div>
         </div>
         <div class="graph-source-copy">
           <div>
@@ -743,6 +745,14 @@ export function createGraphCoverageExplorer() {
 
     root.querySelector('[data-testid="program-language-select"]').addEventListener('change', (event) => {
       selectedCodeLanguage = event.target.value;
+    });
+
+    root.querySelector('[data-testid="graph-upload-btn"]').addEventListener('click', () => {
+      root.querySelector('[data-testid="graph-upload-input"]').click();
+    });
+
+    root.querySelector('[data-testid="code-upload-btn"]').addEventListener('click', () => {
+      root.querySelector('[data-testid="code-upload-input"]').click();
     });
 
     root.querySelector('[data-testid="graph-upload-input"]').addEventListener('change', async (event) => {

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -590,7 +590,7 @@ export function createGraphCoverageExplorer() {
       <div class="graph-coverage-header">
         <div>
           <p class="graph-coverage-kicker">White Box Testing</p>
-          <h3>${graph.title}</h3>
+          <h3>${pickField(graph, 'title')}</h3>
           <p class="graph-coverage-desc">${t('graph.headerDesc')}</p>
         </div>
         <div class="graph-coverage-stats">
@@ -623,7 +623,7 @@ export function createGraphCoverageExplorer() {
           <div class="graph-selected-summary" data-testid="selected-requirement-summary">
             <span class="summary-label">${t('graph.summary.current')}</span>
             <strong>${selectedRequirement?.label || t('common.none')}</strong>
-            <p>${selectedCriterion?.description || ''}</p>
+            <p>${selectedCriterion ? pickField(selectedCriterion, 'description') : ''}</p>
           </div>
 
           <div class="graph-test-path-card" data-testid="graph-test-path-card">

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -193,6 +193,7 @@ export const messages = {
     'graph.parseError': 'Parse error: {msg}',
     // Common (extra)
     'common.none': '(none)',
+    'common.chooseFile': 'Choose File',
 
     // Graph coverage
     'graph.aria.canvas': 'Graph coverage CFG',
@@ -584,6 +585,7 @@ export const messages = {
     'graph.noTests': '此準則不需測試輸入。',
     'graph.parseError': '解析錯誤：{msg}',
     'common.none': '無',
+    'common.chooseFile': '選擇檔案',
 
     'graph.aria.canvas': 'Graph coverage 控制流程圖',
     'graph.dfg.title': '資料流程圖（def → use）',

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -3438,7 +3438,7 @@
       <div class="graph-coverage-header">
         <div>
           <p class="graph-coverage-kicker">White Box Testing</p>
-          <h3>${graph.title}</h3>
+          <h3>${pickField(graph, "title")}</h3>
           <p class="graph-coverage-desc">${t("graph.headerDesc")}</p>
         </div>
         <div class="graph-coverage-stats">
@@ -3471,7 +3471,7 @@
           <div class="graph-selected-summary" data-testid="selected-requirement-summary">
             <span class="summary-label">${t("graph.summary.current")}</span>
             <strong>${(selectedRequirement == null ? void 0 : selectedRequirement.label) || t("common.none")}</strong>
-            <p>${(selectedCriterion == null ? void 0 : selectedCriterion.description) || ""}</p>
+            <p>${selectedCriterion ? pickField(selectedCriterion, "description") : ""}</p>
           </div>
 
           <div class="graph-test-path-card" data-testid="graph-test-path-card">
@@ -4706,16 +4706,16 @@
   // src/config/cloudConfig.js
   var cloudConfig = {
     firebase: {
-      apiKey: "AIzaSyB9QlOS2IodbRQWxGGe_a8cEviSZURyo3k",
-      authDomain: "stvisual-a88cd.firebaseapp.com",
-      projectId: "stvisual-a88cd",
-      storageBucket: "stvisual-a88cd.firebasestorage.app",
-      messagingSenderId: "1030102454109",
-      appId: "1:1030102454109:web:cb50e6da22b4b5dda2a2b4",
-      measurementId: "G-RBRGPW34JQ"
+      apiKey: "__FIREBASE_API_KEY__",
+      authDomain: "__FIREBASE_AUTH_DOMAIN__",
+      projectId: "__FIREBASE_PROJECT_ID__",
+      storageBucket: "__FIREBASE_STORAGE_BUCKET__",
+      messagingSenderId: "__FIREBASE_MESSAGING_SENDER_ID__",
+      appId: "__FIREBASE_APP_ID__",
+      measurementId: "__FIREBASE_MEASUREMENT_ID__"
     },
     drive: {
-      uploadFolderId: "1B5hCB2Scte4Sds0d03mYNu-iGZS0JKbJ"
+      uploadFolderId: "__DRIVE_UPLOAD_FOLDER_ID__"
     }
   };
   function getResolvedCloudConfig() {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -818,6 +818,7 @@
       "graph.parseError": "Parse error: {msg}",
       // Common (extra)
       "common.none": "(none)",
+      "common.chooseFile": "Choose File",
       // Graph coverage
       "graph.aria.canvas": "Graph coverage CFG",
       "graph.dfg.title": "Data Flow Graph (def \u2192 use)",
@@ -1194,6 +1195,7 @@
       "graph.noTests": "\u6B64\u6E96\u5247\u4E0D\u9700\u6E2C\u8A66\u8F38\u5165\u3002",
       "graph.parseError": "\u89E3\u6790\u932F\u8AA4\uFF1A{msg}",
       "common.none": "\u7121",
+      "common.chooseFile": "\u9078\u64C7\u6A94\u6848",
       "graph.aria.canvas": "Graph coverage \u63A7\u5236\u6D41\u7A0B\u5716",
       "graph.dfg.title": "\u8CC7\u6599\u6D41\u7A0B\u5716\uFF08def \u2192 use\uFF09",
       "graph.dfg.help": "\u4F9D\u6BCF\u500B\u53E5\u7684\u8CE6\u503C\u63A8\u5C0E\u5B9A\u7FA9\u8207\u4F7F\u7528\uFF0C\u6CBF CFG \u8D70\u5230\u672A\u88AB\u4E2D\u9593 def \u8986\u5BEB\u7684 use\u3002\u908A\u4E0A\u6A19\u793A\u8B8A\u6578\u540D\u3002",
@@ -3372,10 +3374,11 @@
               <option value="uploaded-spec"${selectedProgramId === "uploaded-spec" ? " selected" : ""}>Uploaded Graph Spec</option>
             </select>
           </label>
-          <label class="graph-upload-field">
-            Upload JSON Graph Spec
-            <input type="file" accept="application/json,.json" data-testid="graph-upload-input" />
-          </label>
+          <div class="graph-upload-field">
+            <span>Upload JSON Graph Spec</span>
+            <button type="button" class="graph-upload-btn" data-testid="graph-upload-btn">${t("common.chooseFile")}</button>
+            <input type="file" accept="application/json,.json" data-testid="graph-upload-input" class="sr-only" />
+          </div>
           <label>
             Code Language
             <select data-testid="program-language-select">
@@ -3384,10 +3387,11 @@
               `).join("")}
             </select>
           </label>
-          <label class="graph-upload-field">
-            Upload Source Code
-            <input type="file" accept=".js,.txt,.code,.pseudo" data-testid="code-upload-input" />
-          </label>
+          <div class="graph-upload-field">
+            <span>Upload Source Code</span>
+            <button type="button" class="graph-upload-btn" data-testid="code-upload-btn">${t("common.chooseFile")}</button>
+            <input type="file" accept=".js,.txt,.code,.pseudo" data-testid="code-upload-input" class="sr-only" />
+          </div>
         </div>
         <div class="graph-source-copy">
           <div>
@@ -3580,6 +3584,12 @@
       });
       root2.querySelector('[data-testid="program-language-select"]').addEventListener("change", (event) => {
         selectedCodeLanguage = event.target.value;
+      });
+      root2.querySelector('[data-testid="graph-upload-btn"]').addEventListener("click", () => {
+        root2.querySelector('[data-testid="graph-upload-input"]').click();
+      });
+      root2.querySelector('[data-testid="code-upload-btn"]').addEventListener("click", () => {
+        root2.querySelector('[data-testid="code-upload-input"]').click();
       });
       root2.querySelector('[data-testid="graph-upload-input"]').addEventListener("change", async (event) => {
         const [file] = event.target.files || [];
@@ -5831,10 +5841,11 @@ Content-Type: ${file.type || "application/octet-stream"}\r
 
           <section class="cloud-section">
             <h4>${t("cloud.section.files")}</h4>
-            <label class="cloud-file-picker">
-              ${t("cloud.uploadHint")}
-              <input type="file" data-testid="cloud-file-input" ${!user ? "disabled" : ""} />
-            </label>
+            <div class="cloud-file-picker">
+              <span>${t("cloud.uploadHint")}</span>
+              <button type="button" class="cloud-file-btn" data-testid="cloud-file-btn" ${!user ? "disabled" : ""}>${t("common.chooseFile")}</button>
+              <input type="file" data-testid="cloud-file-input" class="sr-only" ${!user ? "disabled" : ""} />
+            </div>
             <p data-testid="cloud-file-name">${selectedFile ? t("cloud.pendingUpload", { name: selectedFile.name }) : t("cloud.noFileSelected")}</p>
             <button type="button" class="cloud-btn" data-testid="cloud-upload-btn" ${!selectedFile || !user ? "disabled" : ""}>${t("cloud.upload")}</button>
 
@@ -5901,6 +5912,9 @@ Content-Type: ${file.type || "application/octet-stream"}\r
       });
       root2.querySelector('[data-testid="cloud-notes-input"]').addEventListener("input", (event) => {
         settings.notes = event.target.value;
+      });
+      root2.querySelector('[data-testid="cloud-file-btn"]').addEventListener("click", () => {
+        root2.querySelector('[data-testid="cloud-file-input"]').click();
       });
       root2.querySelector('[data-testid="cloud-file-input"]').addEventListener("change", (event) => {
         [selectedFile] = event.target.files || [];


### PR DESCRIPTION
Closes #73

## Changes

### 1. Graph Coverage locale-aware fields (a3b2694)
- `graph.title` → `pickField(graph, 'title')` so EN mode shows *Sample Control Flow Graph* instead of *控制流程圖範例*
- `selectedCriterion.description` → `pickField(selectedCriterion, 'description')` so EN mode shows English criterion descriptions

### 2. Custom file upload buttons (372fdb6)
- Hide native `<input type="file">` with `sr-only` class
- Add custom `<button>` styled to match existing UI, wired to trigger the hidden input on click
- Button label uses `t('common.chooseFile')`: EN → *Choose File*, ZH → *選擇檔案*
- Affected: `GraphCoverageExplorer`, `CloudStoragePanel`

### i18n keys added
| Key | EN | ZH |
|-----|----|----|
| `common.chooseFile` | Choose File | 選擇檔案 |

### Testing
- 202/202 unit tests pass
- No visual regressions