### PR TITLE
Adjust Symbolic/Concolic layout and full-height CFG pane

### DIFF
--- a/src/components/ConcolicExecutionExplorer.css
+++ b/src/components/ConcolicExecutionExplorer.css
@@ -1,4 +1,36 @@
 .concolic-explorer { display: flex; flex-direction: column; gap: 1rem; }
+.concolic-split-body {
+  display: grid;
+  grid-template-columns: minmax(320px, 1.1fr) minmax(340px, 1.5fr);
+  gap: 1.2rem;
+  min-height: 64rem;
+}
+@media (max-width: 900px) {
+  .concolic-split-body { grid-template-columns: 1fr; }
+  .concolic-cfg-pane { min-height: 36rem; }
+}
+.concolic-cfg-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 48rem;
+}
+.concolic-right-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+.concolic-results-pane {
+  flex: 1 1 0;
+  min-height: 24rem;
+  max-height: 44rem;
+  overflow-y: auto;
+}
+.concolic-editor-pane {
+  flex: 1 1 0;
+  min-height: 20rem;
+}
 
 .concolic-toolbar {
   display: flex;
@@ -42,6 +74,7 @@
   display: grid;
   grid-template-columns: minmax(280px, 1fr) minmax(320px, 1.2fr);
   gap: 1rem;
+  min-height: 64rem;
 }
 @media (max-width: 900px) { .concolic-body { grid-template-columns: 1fr; } }
 
@@ -175,11 +208,26 @@
 .concolic-iter { cursor: pointer; transition: background 0.15s, border-color 0.15s; }
 .concolic-iter:hover { background: #eef2f7; }
 .concolic-iter.selected { border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124,58,237,0.18); }
-.concolic-cfg { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.5rem; }
+.concolic-cfg {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  flex: 1 1 auto;
+  min-height: 0;
+}
 .concolic-cfg-header { display: flex; align-items: baseline; gap: 0.6rem; }
 .concolic-cfg-header h3 { margin: 0; font-size: 1rem; }
 .concolic-cfg-selected { font-family: 'SF Mono', monospace; color: #7c3aed; font-size: 0.85rem; }
-.concolic-cfg-canvas { width: 100%; max-height: 28rem; overflow: auto; border: 1px solid #e2e8f0; border-radius: 6px; background: #fff; }
+.concolic-cfg-canvas {
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+}
 .concolic-cfg-canvas svg { width: 100%; height: auto; }
 .concolic-cfg-error { color: #b45309; font-size: 0.85rem; }
 

--- a/src/components/ConcolicExecutionExplorer.js
+++ b/src/components/ConcolicExecutionExplorer.js
@@ -156,23 +156,26 @@ export function createConcolicExecutionExplorer() {
         </div>
       </div>
 
-      <div class="concolic-body">
-        <div class="concolic-editor-pane">
-          <label class="concolic-editor-label" for="concolic-source">${t('concolic.source')}</label>
-          <textarea id="concolic-source"
-            class="concolic-editor"
-            data-testid="concolic-source"
-            spellcheck="false"
-            autocomplete="off"
-            rows="14">${escapeHtml(state.sourceCode)}</textarea>
+      <div class="concolic-split-body">
+        <div class="concolic-cfg-pane">
+          ${renderCfgPane()}
         </div>
-        <div class="concolic-results-pane">
-          <p class="concolic-summary" data-testid="concolic-summary">${summary}</p>
-          ${body}
+        <div class="concolic-right-pane">
+          <div class="concolic-results-pane">
+            <p class="concolic-summary" data-testid="concolic-summary">${summary}</p>
+            ${body}
+          </div>
+          <div class="concolic-editor-pane">
+            <label class="concolic-editor-label" for="concolic-source">${t('concolic.source')}</label>
+            <textarea id="concolic-source"
+              class="concolic-editor"
+              data-testid="concolic-source"
+              spellcheck="false"
+              autocomplete="off"
+              rows="14">${escapeHtml(state.sourceCode)}</textarea>
+          </div>
         </div>
       </div>
-
-      ${renderCfgPane()}
 
       <p class="concolic-hint">${t('concolic.hint')}</p>
     `;

--- a/src/components/SymbolicExecutionExplorer.css
+++ b/src/components/SymbolicExecutionExplorer.css
@@ -1,4 +1,38 @@
+
 .symbex-explorer { display: flex; flex-direction: column; gap: 1rem; }
+
+.symbex-split-body {
+  display: grid;
+  grid-template-columns: minmax(320px, 1.1fr) minmax(340px, 1.5fr);
+  gap: 1.2rem;
+  min-height: 64rem;
+}
+@media (max-width: 900px) {
+  .symbex-split-body { grid-template-columns: 1fr; }
+  .symbex-cfg-pane { min-height: 36rem; }
+}
+.symbex-cfg-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 48rem;
+}
+.symbex-right-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+.symbex-results-pane {
+  flex: 1 1 0;
+  min-height: 24rem;
+  max-height: 44rem;
+  overflow-y: auto;
+}
+.symbex-editor-pane {
+  flex: 1 1 0;
+  min-height: 20rem;
+}
 
 .symbex-toolbar {
   display: flex;
@@ -18,6 +52,10 @@
   cursor: pointer;
   font-size: 0.875rem;
 }
+
+.symbex-editor-pane,
+.symbex-results-pane { gap: 0.5rem; }
+
 .symbex-example-btn.active { background: #1f6feb; color: #fff; border-color: #1f6feb; }
 .symbex-example-btn:hover { background: #eef2f7; }
 .symbex-example-btn.active:hover { background: #1f6feb; opacity: 0.9; }
@@ -35,6 +73,7 @@
   display: grid;
   grid-template-columns: minmax(280px, 1fr) minmax(320px, 1.2fr);
   gap: 1rem;
+  min-height: 64rem;
 }
 
 @media (max-width: 900px) {
@@ -154,11 +193,26 @@
 .symbex-path { cursor: pointer; transition: background 0.15s, border-color 0.15s; }
 .symbex-path:hover { background: #f1f5f9; }
 .symbex-path.selected { border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124,58,237,0.18); }
-.symbex-cfg { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.5rem; }
+.symbex-cfg {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  flex: 1 1 auto;
+  min-height: 0;
+}
 .symbex-cfg-header { display: flex; align-items: baseline; gap: 0.6rem; }
 .symbex-cfg-header h3 { margin: 0; font-size: 1rem; }
 .symbex-cfg-selected { font-family: 'SF Mono', monospace; color: #7c3aed; font-size: 0.85rem; }
-.symbex-cfg-canvas { width: 100%; max-height: 28rem; overflow: auto; border: 1px solid #e2e8f0; border-radius: 6px; background: #fff; }
+.symbex-cfg-canvas {
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+}
 .symbex-cfg-canvas svg { width: 100%; height: auto; }
 .symbex-cfg-error { color: #b45309; font-size: 0.85rem; }
 

--- a/src/components/SymbolicExecutionExplorer.js
+++ b/src/components/SymbolicExecutionExplorer.js
@@ -117,6 +117,7 @@ export function createSymbolicExecutionExplorer() {
            : ''}`
       : '';
 
+
     root.innerHTML = `
       <div class="symbex-toolbar">
         <div class="symbex-examples" data-testid="symbex-examples">${exampleButtons}</div>
@@ -130,24 +131,26 @@ export function createSymbolicExecutionExplorer() {
         </div>
       </div>
 
-      <div class="symbex-body">
-        <div class="symbex-editor-pane">
-          <label class="symbex-editor-label" for="symbex-source">${t('symbex.source')}</label>
-          <textarea id="symbex-source"
-            class="symbex-editor"
-            data-testid="symbex-source"
-            spellcheck="false"
-            autocomplete="off"
-            rows="14">${escapeHtml(state.sourceCode)}</textarea>
+      <div class="symbex-split-body">
+        <div class="symbex-cfg-pane">
+          ${renderCfgPane()}
         </div>
-
-        <div class="symbex-results-pane">
-          <p class="symbex-summary" data-testid="symbex-summary">${summary}</p>
-          ${pathsMarkup}
+        <div class="symbex-right-pane">
+          <div class="symbex-results-pane">
+            <p class="symbex-summary" data-testid="symbex-summary">${summary}</p>
+            ${pathsMarkup}
+          </div>
+          <div class="symbex-editor-pane">
+            <label class="symbex-editor-label" for="symbex-source">${t('symbex.source')}</label>
+            <textarea id="symbex-source"
+              class="symbex-editor"
+              data-testid="symbex-source"
+              spellcheck="false"
+              autocomplete="off"
+              rows="14">${escapeHtml(state.sourceCode)}</textarea>
+          </div>
         </div>
       </div>
-
-      ${renderCfgPane()}
 
       <p class="symbex-hint">${t('symbex.hint')}</p>
     `;


### PR DESCRIPTION
## Summary\n- apply split layout for Symbolic Execution and Concolic Execution\n- place CFG panel on the left, Paths on the right-top, Program Source on the right-bottom\n- increase section vertical length to 2x\n- make CFG canvas stretch to fill the full left column height\n\n## Files\n- src/components/SymbolicExecutionExplorer.js\n- src/components/SymbolicExecutionExplorer.css\n- src/components/ConcolicExecutionExplorer.js\n- src/components/ConcolicExecutionExplorer.css\n\n## Tracking\nCloses #78\n