### PR TITLE
fix: add missing sourceCode for concolic Middle value example

### DIFF
--- a/src/data/testingData.js
+++ b/src/data/testingData.js
@@ -618,6 +618,28 @@ export const concolicExecutionExamples = [
     description: '經典 DART 測試對象（Khurshid et al.）：回傳三數的中位數。',
     descriptionEn: 'A classic DART benchmark (Khurshid et al.): returns the median of three integers.',
     seed: 'a=0, b=0, c=0',
+    sourceCode: `function middle(a, b, c) {
+  let m = b;
+  if (a < b) {
+    if (b > c) {
+      if (a < c) {
+        m = c;
+      } else {
+        m = a;
+      }
+    }
+  } else {
+    if (b < c) {
+      if (a < c) {
+        m = a;
+      } else {
+        m = c;
+      }
+    }
+  }
+  return m;
+}
+`,
   },
 ];
 


### PR DESCRIPTION
## What

Add the missing `sourceCode` field to the **Middle value** entry in `concolicExecutionExamples`.

Fixes #82

## Root Cause

`middle` had no `sourceCode` field. Selecting it set the editor to `undefined` and caused the concolic engine to crash.

## Change

Added the classic DART median-of-three implementation (Khurshid et al.) — the same benchmark used in the original DART paper to demonstrate concolic testing.

| File | Change |
|------|--------|
| `src/data/testingData.js` | Add `sourceCode` to the `middle` concolic example |