### PR TITLE
feat(logic): clause binding panel — map clauses to program expressions, auto-solve concrete witnesses

### DIFF
--- a/src/components/LogicCoverageExplorer.css
+++ b/src/components/LogicCoverageExplorer.css
@@ -462,3 +462,126 @@
 }
 .logic-cell-result.is-true { color: #27ae60; font-weight: 700; }
 .logic-cell-result.is-false { color: #c0392b; font-weight: 700; }
+
+/* ---- Clause Binding panel ---- */
+.logic-binding {
+  border: 1px solid var(--app-border, #d0d7e2);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+}
+.logic-binding-summary {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f2a44;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+.logic-binding-summary::-webkit-details-marker { display: none; }
+.logic-binding-summary::before { content: '▶ '; font-size: 0.75rem; }
+details.logic-binding[open] .logic-binding-summary::before { content: '▼ '; }
+
+.logic-binding-desc {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.logic-binding-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.logic-binding-clause-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.logic-binding-clause-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f3a8a;
+  min-width: 1.4rem;
+  text-align: center;
+}
+.logic-binding-arrow {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+.logic-binding-expr-input {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--app-border, #d0d7e2);
+  border-radius: 6px;
+  background: #fff;
+  width: 14rem;
+  transition: border-color 0.15s;
+}
+.logic-binding-expr-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59,130,246,0.18);
+}
+
+.logic-binding-results {
+  margin-top: 0.25rem;
+}
+
+.logic-binding-vars {
+  display: block;
+  font-size: 0.82rem;
+  color: #4b5563;
+  margin-bottom: 0.5rem;
+}
+
+.logic-binding-hint-noentry {
+  font-size: 0.85rem;
+  color: #9ca3af;
+  font-style: italic;
+  margin: 0;
+}
+
+.logic-binding-table {
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  width: 100%;
+  max-width: 42rem;
+}
+.logic-binding-table th {
+  text-align: left;
+  padding: 0.3rem 0.6rem;
+  border-bottom: 2px solid #e5e7eb;
+  font-weight: 600;
+  color: #374151;
+}
+.logic-binding-table td {
+  padding: 0.25rem 0.6rem;
+  border-bottom: 1px solid #f3f4f6;
+  vertical-align: middle;
+}
+.logic-binding-td-index { color: #6b7280; font-size: 0.78rem; white-space: nowrap; }
+.logic-binding-td-vals {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  color: #374151;
+}
+.logic-binding-td-witness { min-width: 8rem; }
+
+.logic-binding-witness {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.82rem;
+  background: #ecfdf5;
+  color: #047857;
+  padding: 0.1rem 0.45rem;
+  border-radius: 5px;
+}
+.logic-binding-infeasible {
+  font-size: 0.8rem;
+  color: #b91c1c;
+  font-style: italic;
+}

--- a/src/components/LogicCoverageExplorer.css
+++ b/src/components/LogicCoverageExplorer.css
@@ -528,6 +528,30 @@ details.logic-binding[open] .logic-binding-summary::before { content: '▼ '; }
   box-shadow: 0 0 0 2px rgba(59,130,246,0.18);
 }
 
+.logic-binding-range-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.82rem;
+  color: #4b5563;
+}
+.logic-binding-range-label { white-space: nowrap; }
+.logic-binding-range-sep { color: #9ca3af; }
+.logic-binding-range-input {
+  width: 5rem;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.82rem;
+  border: 1px solid var(--app-border, #d0d7e2);
+  border-radius: 5px;
+  background: #fff;
+  text-align: center;
+}
+.logic-binding-range-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
 .logic-binding-results {
   margin-top: 0.25rem;
 }
@@ -550,7 +574,6 @@ details.logic-binding[open] .logic-binding-summary::before { content: '▼ '; }
   border-collapse: collapse;
   font-size: 0.85rem;
   width: 100%;
-  max-width: 42rem;
 }
 .logic-binding-table th {
   text-align: left;
@@ -569,8 +592,20 @@ details.logic-binding[open] .logic-binding-summary::before { content: '▼ '; }
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.8rem;
   color: #374151;
+  white-space: nowrap;
 }
-.logic-binding-td-witness { min-width: 8rem; }
+.logic-binding-td-constraint {
+  font-size: 0.78rem;
+  color: #4b5563;
+}
+.logic-binding-td-constraint code {
+  background: #f1f5f9;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-all;
+}
+.logic-binding-td-witness { min-width: 8rem; white-space: nowrap; }
 
 .logic-binding-witness {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -10,6 +10,7 @@ import {
 import { buildKMap } from '../utils/karnaughMap.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
 import { createCloudIntegrationClient } from '../utils/cloudIntegration.js';
+import { solveBinding, formatWitnessStr, extractVarsFromBindings } from '../utils/logicBinding.js';
 
 const RECENT_KEY = 'stvisual.logic.recentPredicates';
 const RECENT_LIMIT = 8;
@@ -197,6 +198,7 @@ export function createLogicCoverageExplorer() {
     error: null,
     parsed: null,
     analysis: null,
+    bindings: {},  // clauseName → JS expression string
     recent: loadRecent(),
     cloudUser: null,
   };
@@ -249,6 +251,11 @@ export function createLogicCoverageExplorer() {
       }
       state.analysis = buildAllCoverageSets(state.parsed);
       state.error = null;
+      // Drop bindings for clauses no longer in the predicate.
+      const clauseSet = new Set(state.parsed.clauses);
+      for (const k of Object.keys(state.bindings)) {
+        if (!clauseSet.has(k)) delete state.bindings[k];
+      }
     } catch (err) {
       state.parsed = null;
       state.analysis = null;
@@ -350,6 +357,8 @@ export function createLogicCoverageExplorer() {
       </div>
 
       <div class="logic-summary" data-testid="logic-summary">${summaryMarkup}</div>
+
+      ${renderBindingPanel()}
 
       <div class="logic-truth-table-wrap">${truthTableMarkup}</div>
     `;
@@ -619,6 +628,109 @@ export function createLogicCoverageExplorer() {
     `;
   }
 
+  // ---- Clause Binding panel ----
+
+  function buildBindingResultsHTML() {
+    if (!state.analysis) return '';
+    const { clauses } = state.analysis;
+    const hasAnyBinding = clauses.some((c) => state.bindings[c]?.trim());
+    if (!hasAnyBinding) {
+      return `<p class="logic-binding-hint-noentry" data-testid="logic-binding-no-entry">${t('logic.binding.noBinding')}</p>`;
+    }
+
+    const vars = extractVarsFromBindings(state.bindings);
+    const activeSet = getActiveSet();
+    if (!activeSet) return '';
+
+    const seenRows = new Set();
+    const uniqueTests = activeSet.tests.filter((test) => {
+      const key = `r${test.row.index}`;
+      if (seenRows.has(key)) return false;
+      seenRows.add(key);
+      return true;
+    });
+
+    const rows = uniqueTests.map((test) => {
+      const valStr = clauses.map((c) => `${c}=${test.row.values[c] ? 'T' : 'F'}`).join(', ');
+      // Only include clauses that have a binding expression.
+      const boundClauseValues = {};
+      for (const c of clauses) {
+        if (state.bindings[c]?.trim()) boundClauseValues[c] = test.row.values[c];
+      }
+      const result = solveBinding({
+        clauseValues: boundClauseValues,
+        bindings: state.bindings,
+      });
+      const witnessCell = result.witness
+        ? `<code class="logic-binding-witness" data-testid="logic-binding-witness-${test.row.index}">${escapeHtml(formatWitnessStr(result.witness))}</code>`
+        : `<span class="logic-binding-infeasible" data-testid="logic-binding-infeasible-${test.row.index}">${t('logic.binding.infeasible')}</span>`;
+      return `
+        <tr data-testid="logic-binding-row-${test.row.index}">
+          <td class="logic-binding-td-index">#${test.row.index}</td>
+          <td class="logic-binding-td-vals">${escapeHtml(valStr)}</td>
+          <td class="logic-binding-td-witness">${witnessCell}</td>
+        </tr>
+      `;
+    }).join('');
+
+    const varList = vars.length ? `<span class="logic-binding-vars">${t('logic.binding.vars')} <code>${escapeHtml(vars.join(', '))}</code></span>` : '';
+    return `
+      ${varList}
+      <table class="logic-binding-table" data-testid="logic-binding-table">
+        <thead>
+          <tr>
+            <th>${t('logic.binding.col.row')}</th>
+            <th>${t('logic.binding.col.vals')}</th>
+            <th>${t('logic.binding.col.witness')}</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    `;
+  }
+
+  function renderBindingPanel() {
+    if (!state.analysis || state.error) return '';
+    const { clauses } = state.analysis;
+    const inputRows = clauses.map((c) => `
+      <label class="logic-binding-clause-row">
+        <span class="logic-binding-clause-name" aria-label="${t('logic.binding.clause')} ${escapeHtml(c)}">${escapeHtml(c)}</span>
+        <span class="logic-binding-arrow" aria-hidden="true">↦</span>
+        <input
+          type="text"
+          class="logic-binding-expr-input"
+          data-testid="logic-binding-input-${escapeHtml(c)}"
+          data-binding-clause="${escapeHtml(c)}"
+          value="${escapeHtml(state.bindings[c] || '')}"
+          placeholder="${t('logic.binding.placeholder')}"
+          spellcheck="false"
+          autocomplete="off"
+          aria-label="${t('logic.binding.clause')} ${escapeHtml(c)}"
+        />
+      </label>
+    `).join('');
+
+    return `
+      <details class="logic-binding" data-testid="logic-binding" open>
+        <summary class="logic-binding-summary">${t('logic.binding.title')}</summary>
+        <p class="logic-binding-desc">${t('logic.binding.hint')}</p>
+        <div class="logic-binding-inputs" data-testid="logic-binding-inputs">
+          ${inputRows}
+        </div>
+        <div class="logic-binding-results" data-testid="logic-binding-results">
+          ${buildBindingResultsHTML()}
+        </div>
+      </details>
+    `;
+  }
+
+  function refreshBindingResults() {
+    const el = root.querySelector('[data-testid="logic-binding-results"]');
+    if (el) el.innerHTML = buildBindingResultsHTML();
+  }
+
+  // ---- end Clause Binding panel ----
+
   function bindEvents() {
     const input = root.querySelector('[data-testid="logic-expression-input"]');
     if (input) {
@@ -665,6 +777,17 @@ export function createLogicCoverageExplorer() {
       btn.addEventListener('click', () => {
         state.selectedCriterion = btn.dataset.criterion;
         render();
+      });
+    });
+
+    // Binding inputs — update results section only (no full re-render → no focus loss).
+    let bindingTimer = null;
+    root.querySelectorAll('[data-binding-clause]').forEach((input) => {
+      input.addEventListener('input', () => {
+        const clause = input.dataset.bindingClause;
+        state.bindings[clause] = input.value;
+        if (bindingTimer) clearTimeout(bindingTimer);
+        bindingTimer = setTimeout(() => refreshBindingResults(), 200);
       });
     });
   }

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -10,7 +10,7 @@ import {
 import { buildKMap } from '../utils/karnaughMap.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
 import { createCloudIntegrationClient } from '../utils/cloudIntegration.js';
-import { solveBinding, formatWitnessStr, extractVarsFromBindings } from '../utils/logicBinding.js';
+import { solveBinding, formatWitnessStr, extractVarsFromBindings, buildConstraintStr } from '../utils/logicBinding.js';
 
 const RECENT_KEY = 'stvisual.logic.recentPredicates';
 const RECENT_LIMIT = 8;
@@ -198,7 +198,8 @@ export function createLogicCoverageExplorer() {
     error: null,
     parsed: null,
     analysis: null,
-    bindings: {},  // clauseName → JS expression string
+    bindings: {},           // clauseName → JS expression string
+    bindingRange: [-10, 10], // [min, max] for brute-force search
     recent: loadRecent(),
     cloudUser: null,
   };
@@ -657,9 +658,11 @@ export function createLogicCoverageExplorer() {
       for (const c of clauses) {
         if (state.bindings[c]?.trim()) boundClauseValues[c] = test.row.values[c];
       }
+      const constraintStr = buildConstraintStr(boundClauseValues, state.bindings);
       const result = solveBinding({
         clauseValues: boundClauseValues,
         bindings: state.bindings,
+        searchRange: state.bindingRange,
       });
       const witnessCell = result.witness
         ? `<code class="logic-binding-witness" data-testid="logic-binding-witness-${test.row.index}">${escapeHtml(formatWitnessStr(result.witness))}</code>`
@@ -668,6 +671,7 @@ export function createLogicCoverageExplorer() {
         <tr data-testid="logic-binding-row-${test.row.index}">
           <td class="logic-binding-td-index">#${test.row.index}</td>
           <td class="logic-binding-td-vals">${escapeHtml(valStr)}</td>
+          <td class="logic-binding-td-constraint"><code>${escapeHtml(constraintStr)}</code></td>
           <td class="logic-binding-td-witness">${witnessCell}</td>
         </tr>
       `;
@@ -681,6 +685,7 @@ export function createLogicCoverageExplorer() {
           <tr>
             <th>${t('logic.binding.col.row')}</th>
             <th>${t('logic.binding.col.vals')}</th>
+            <th>${t('logic.binding.col.constraint')}</th>
             <th>${t('logic.binding.col.witness')}</th>
           </tr>
         </thead>
@@ -716,6 +721,14 @@ export function createLogicCoverageExplorer() {
         <p class="logic-binding-desc">${t('logic.binding.hint')}</p>
         <div class="logic-binding-inputs" data-testid="logic-binding-inputs">
           ${inputRows}
+        </div>
+        <div class="logic-binding-range-row">
+          <span class="logic-binding-range-label">${t('logic.binding.range')}</span>
+          <input type="number" class="logic-binding-range-input" data-testid="logic-binding-range-min"
+            data-binding-range="min" value="${state.bindingRange[0]}" min="-1000" max="0" step="1" />
+          <span class="logic-binding-range-sep">${t('logic.binding.rangeTo')}</span>
+          <input type="number" class="logic-binding-range-input" data-testid="logic-binding-range-max"
+            data-binding-range="max" value="${state.bindingRange[1]}" min="0" max="1000" step="1" />
         </div>
         <div class="logic-binding-results" data-testid="logic-binding-results">
           ${buildBindingResultsHTML()}
@@ -788,6 +801,20 @@ export function createLogicCoverageExplorer() {
         state.bindings[clause] = input.value;
         if (bindingTimer) clearTimeout(bindingTimer);
         bindingTimer = setTimeout(() => refreshBindingResults(), 200);
+      });
+    });
+
+    // Search range inputs.
+    root.querySelectorAll('[data-binding-range]').forEach((input) => {
+      input.addEventListener('change', () => {
+        const v = parseInt(input.value, 10);
+        if (Number.isNaN(v)) return;
+        if (input.dataset.bindingRange === 'min') {
+          state.bindingRange = [Math.min(v, state.bindingRange[1] - 1), state.bindingRange[1]];
+        } else {
+          state.bindingRange = [state.bindingRange[0], Math.max(v, state.bindingRange[0] + 1)];
+        }
+        refreshBindingResults();
       });
     });
   }

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -340,15 +340,18 @@ export const messages = {
 
     // Clause Binding
     'logic.binding.title': 'Clause Binding → Concrete Inputs',
-    'logic.binding.hint': 'Map each clause to a JS expression using program variables (e.g. x > 0, x + y > z). The solver searches integers in [−10, 10].',
+    'logic.binding.hint': 'Map each clause to a JS expression using program variables (e.g. x > 0, x + y > z). The solver searches integers in the range below.',
     'logic.binding.placeholder': 'e.g. x > 0',
     'logic.binding.clause': 'Clause',
     'logic.binding.vars': 'Variables detected:',
     'logic.binding.noBinding': 'Enter at least one binding expression above to see concrete witnesses.',
     'logic.binding.infeasible': 'infeasible',
+    'logic.binding.range': 'Search range:',
+    'logic.binding.rangeTo': 'to',
     'logic.binding.col.row': 'Test row',
     'logic.binding.col.vals': 'Clause values',
-    'logic.binding.col.witness': 'Concrete witness',
+    'logic.binding.col.constraint': 'Constraint',
+    'logic.binding.col.witness': 'Witness',
 
     // Syntax / mutation
     'syntax.title': 'Syntax-Based Testing: Program Mutation',
@@ -796,15 +799,18 @@ export const messages = {
 
     // Clause Binding（ZH）
     'logic.binding.title': 'Clause Binding → 具體輸入',
-    'logic.binding.hint': '把每個 clause 對應到程式裡的 JS 運算式（例如 x > 0, x + y > z）。求解器在整數範圍 [−10, 10] 內暴力搜尋。',
+    'logic.binding.hint': '把每個 clause 對應到程式裡的 JS 運算式（例如 x > 0, x + y > z）。求解器在下方設定的整數範圍內暴力搜尋。',
     'logic.binding.placeholder': '例：x > 0',
     'logic.binding.clause': 'Clause',
     'logic.binding.vars': '偵測到的變數：',
     'logic.binding.noBinding': '請至少輸入一個 binding 運算式，以查看具體的 witness。',
     'logic.binding.infeasible': '不可行',
+    'logic.binding.range': '搜索範圍：',
+    'logic.binding.rangeTo': '到',
     'logic.binding.col.row': '測試列',
     'logic.binding.col.vals': 'Clause 值',
-    'logic.binding.col.witness': '具體 witness',
+    'logic.binding.col.constraint': '求解條件',
+    'logic.binding.col.witness': 'Witness',
 
     'syntax.title': 'Syntax-Based Testing：Program Mutation',
     'syntax.subtitle': '挑選程式、選擇 mutation operators 與 test set，系統會產生 mutants 並計分。',

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -338,6 +338,17 @@ export const messages = {
     'logic.metric.duplicate': 'Duplicates: ',
     'logic.metric.requirements': 'Suggested requirements: ',
 
+    // Clause Binding
+    'logic.binding.title': 'Clause Binding → Concrete Inputs',
+    'logic.binding.hint': 'Map each clause to a JS expression using program variables (e.g. x > 0, x + y > z). The solver searches integers in [−10, 10].',
+    'logic.binding.placeholder': 'e.g. x > 0',
+    'logic.binding.clause': 'Clause',
+    'logic.binding.vars': 'Variables detected:',
+    'logic.binding.noBinding': 'Enter at least one binding expression above to see concrete witnesses.',
+    'logic.binding.infeasible': 'infeasible',
+    'logic.binding.col.row': 'Test row',
+    'logic.binding.col.vals': 'Clause values',
+    'logic.binding.col.witness': 'Concrete witness',
 
     // Syntax / mutation
     'syntax.title': 'Syntax-Based Testing: Program Mutation',
@@ -783,6 +794,17 @@ export const messages = {
     'logic.metric.duplicate': '重複數量：',
     'logic.metric.requirements': '建議測試需求：',
 
+    // Clause Binding（ZH）
+    'logic.binding.title': 'Clause Binding → 具體輸入',
+    'logic.binding.hint': '把每個 clause 對應到程式裡的 JS 運算式（例如 x > 0, x + y > z）。求解器在整數範圍 [−10, 10] 內暴力搜尋。',
+    'logic.binding.placeholder': '例：x > 0',
+    'logic.binding.clause': 'Clause',
+    'logic.binding.vars': '偵測到的變數：',
+    'logic.binding.noBinding': '請至少輸入一個 binding 運算式，以查看具體的 witness。',
+    'logic.binding.infeasible': '不可行',
+    'logic.binding.col.row': '測試列',
+    'logic.binding.col.vals': 'Clause 值',
+    'logic.binding.col.witness': '具體 witness',
 
     'syntax.title': 'Syntax-Based Testing：Program Mutation',
     'syntax.subtitle': '挑選程式、選擇 mutation operators 與 test set，系統會產生 mutants 並計分。',

--- a/src/tests/logicBinding.test.js
+++ b/src/tests/logicBinding.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractVarsFromBindings,
+  solveBinding,
+  formatWitnessStr,
+  validateBindingExpr,
+} from '../utils/logicBinding.js';
+
+describe('extractVarsFromBindings', () => {
+  it('extracts unique variable names from expressions', () => {
+    const bindings = { a: 'x > 0', b: 'y < 10', c: 'x === 0' };
+    expect(extractVarsFromBindings(bindings)).toEqual(['x', 'y']);
+  });
+
+  it('excludes JS keywords', () => {
+    // 'true' and 'false' are keywords; only 'x' is a program variable
+    const bindings = { a: 'x > 0 && true', b: 'false || x < 10' };
+    expect(extractVarsFromBindings(bindings)).toEqual(['x']);
+  });
+
+  it('returns empty for empty bindings', () => {
+    expect(extractVarsFromBindings({})).toEqual([]);
+  });
+
+  it('excludes clause names themselves', () => {
+    const bindings = { a: 'b > 0', b: 'a < 10' };
+    // 'a' and 'b' are clause names, not program vars
+    expect(extractVarsFromBindings(bindings)).toEqual([]);
+  });
+});
+
+describe('solveBinding', () => {
+  it('finds a witness for a satisfiable row', () => {
+    const result = solveBinding({
+      clauseValues: { a: true },
+      bindings: { a: 'x > 0' },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.witness.x).toBeGreaterThan(0);
+  });
+
+  it('returns infeasible for a contradictory row', () => {
+    // a=T requires x > 0; b=T requires x < 0 — impossible
+    const result = solveBinding({
+      clauseValues: { a: true, b: true },
+      bindings: { a: 'x > 0', b: 'x < 0' },
+    });
+    expect(result.error).toBe('infeasible');
+  });
+
+  it('correctly negates clause expressions for false values', () => {
+    // a=F means !(x > 0), i.e. x <= 0
+    const result = solveBinding({
+      clauseValues: { a: false },
+      bindings: { a: 'x > 0' },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.witness.x).toBeLessThanOrEqual(0);
+  });
+
+  it('handles two-variable expressions', () => {
+    // a=T: x > y  →  e.g. x=1, y=0
+    const result = solveBinding({
+      clauseValues: { a: true },
+      bindings: { a: 'x > y' },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.witness.x).toBeGreaterThan(result.witness.y);
+  });
+
+  it('solves a three-clause CACC-style row', () => {
+    // a=T, b=F, c=T  →  x>0 && !(y<10) && z===0
+    const result = solveBinding({
+      clauseValues: { a: true, b: false, c: true },
+      bindings: { a: 'x > 0', b: 'y < 10', c: 'z === 0' },
+    });
+    expect(result.error).toBeUndefined();
+    const { x, y, z } = result.witness;
+    expect(x).toBeGreaterThan(0);
+    expect(y).toBeGreaterThanOrEqual(10);
+    expect(z).toBe(0);
+  });
+
+  it('returns no-vars when bindings have no expressions', () => {
+    const result = solveBinding({
+      clauseValues: { a: true },
+      bindings: { a: '' },
+    });
+    expect(result.error).toBe('no-vars');
+  });
+
+  it('respects a custom search range', () => {
+    // x > 50 is only satisfiable with range [51, 100]
+    const infeasible = solveBinding({
+      clauseValues: { a: true },
+      bindings: { a: 'x > 50' },
+      searchRange: [-10, 10],
+    });
+    expect(infeasible.error).toBe('infeasible');
+
+    const feasible = solveBinding({
+      clauseValues: { a: true },
+      bindings: { a: 'x > 50' },
+      searchRange: [0, 100],
+    });
+    expect(feasible.error).toBeUndefined();
+    expect(feasible.witness.x).toBeGreaterThan(50);
+  });
+});
+
+describe('formatWitnessStr', () => {
+  it('produces readable key=value pairs', () => {
+    expect(formatWitnessStr({ x: 1, y: -3 })).toBe('x=1, y=-3');
+  });
+});
+
+describe('validateBindingExpr', () => {
+  it('returns null for valid expressions', () => {
+    expect(validateBindingExpr('x > 0')).toBeNull();
+    expect(validateBindingExpr('x + y > z')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(validateBindingExpr('')).toBeNull();
+    expect(validateBindingExpr(null)).toBeNull();
+  });
+
+  it('returns an error string for syntax errors', () => {
+    const err = validateBindingExpr('x >>>>> 0');
+    expect(typeof err).toBe('string');
+    expect(err.length).toBeGreaterThan(0);
+  });
+});

--- a/src/tests/logicBinding.test.js
+++ b/src/tests/logicBinding.test.js
@@ -4,6 +4,7 @@ import {
   solveBinding,
   formatWitnessStr,
   validateBindingExpr,
+  buildConstraintStr,
 } from '../utils/logicBinding.js';
 
 describe('extractVarsFromBindings', () => {
@@ -30,13 +31,14 @@ describe('extractVarsFromBindings', () => {
 });
 
 describe('solveBinding', () => {
-  it('finds a witness for a satisfiable row', () => {
+  it('finds the smallest satisfying witness', () => {
+    // x > 0: smallest positive integer is 1, not 10 or -10.
     const result = solveBinding({
       clauseValues: { a: true },
       bindings: { a: 'x > 0' },
     });
     expect(result.error).toBeUndefined();
-    expect(result.witness.x).toBeGreaterThan(0);
+    expect(result.witness.x).toBe(1);
   });
 
   it('returns infeasible for a contradictory row', () => {
@@ -49,13 +51,13 @@ describe('solveBinding', () => {
   });
 
   it('correctly negates clause expressions for false values', () => {
-    // a=F means !(x > 0), i.e. x <= 0
+    // a=F means !(x > 0), i.e. x <= 0; smallest abs value satisfying is 0.
     const result = solveBinding({
       clauseValues: { a: false },
       bindings: { a: 'x > 0' },
     });
     expect(result.error).toBeUndefined();
-    expect(result.witness.x).toBeLessThanOrEqual(0);
+    expect(result.witness.x).toBe(0);
   });
 
   it('handles two-variable expressions', () => {
@@ -68,16 +70,17 @@ describe('solveBinding', () => {
     expect(result.witness.x).toBeGreaterThan(result.witness.y);
   });
 
-  it('solves a three-clause CACC-style row', () => {
+  it('solves a three-clause CACC-style row with minimal values', () => {
     // a=T, b=F, c=T  →  x>0 && !(y<10) && z===0
+    // smallest: x=1, y=10, z=0
     const result = solveBinding({
       clauseValues: { a: true, b: false, c: true },
       bindings: { a: 'x > 0', b: 'y < 10', c: 'z === 0' },
     });
     expect(result.error).toBeUndefined();
     const { x, y, z } = result.witness;
-    expect(x).toBeGreaterThan(0);
-    expect(y).toBeGreaterThanOrEqual(10);
+    expect(x).toBe(1);
+    expect(y).toBe(10);
     expect(z).toBe(0);
   });
 
@@ -111,6 +114,32 @@ describe('solveBinding', () => {
 describe('formatWitnessStr', () => {
   it('produces readable key=value pairs', () => {
     expect(formatWitnessStr({ x: 1, y: -3 })).toBe('x=1, y=-3');
+  });
+});
+
+describe('buildConstraintStr', () => {
+  it('wraps true clauses without negation', () => {
+    expect(buildConstraintStr({ a: true }, { a: 'x > 0' })).toBe('(x > 0)');
+  });
+
+  it('negates false clauses', () => {
+    expect(buildConstraintStr({ a: false }, { a: 'x > 0' })).toBe('!(x > 0)');
+  });
+
+  it('joins multiple clauses with &&', () => {
+    const str = buildConstraintStr(
+      { a: true, b: false, c: true },
+      { a: 'x > 0', b: 'y < 10', c: 'z === 0' },
+    );
+    expect(str).toBe('(x > 0) && !(y < 10) && (z === 0)');
+  });
+
+  it('skips clauses with no binding expression', () => {
+    const str = buildConstraintStr(
+      { a: true, b: false },
+      { a: 'x > 0', b: '' },
+    );
+    expect(str).toBe('(x > 0)');
   });
 });
 

--- a/src/utils/logicBinding.js
+++ b/src/utils/logicBinding.js
@@ -55,14 +55,24 @@ function buildChecker(clauseValues, bindings, varNames) {
   }
 }
 
-// Cartesian product over integer range.
+// Yields integers in [min, max] ordered by ascending absolute value:
+// 0, 1, -1, 2, -2, … so witnesses prefer small, readable numbers.
+function* smallAbsFirst(min, max) {
+  const limit = Math.max(Math.abs(min), Math.abs(max));
+  for (let d = 0; d <= limit; d++) {
+    if (d >= min && d <= max) yield d;
+    if (d > 0 && -d >= min && -d <= max) yield -d;
+  }
+}
+
+// Cartesian product over integer range, smallest-abs-value first.
 function* cartesian(vars, range) {
   function* gen(depth, current) {
     if (depth === vars.length) {
       yield [...current];
       return;
     }
-    for (let v = range[0]; v <= range[1]; v++) {
+    for (const v of smallAbsFirst(range[0], range[1])) {
       current.push(v);
       yield* gen(depth + 1, current);
       current.pop();
@@ -107,6 +117,20 @@ export function solveBinding({ clauseValues, bindings, searchRange = [-10, 10] }
 // Pretty-print a witness as "x=1, y=11, z=0".
 export function formatWitnessStr(witness) {
   return Object.entries(witness).map(([k, v]) => `${k}=${v}`).join(', ');
+}
+
+// Build a human-readable constraint string for one test row.
+// clauseValues: { a: true, b: false, c: true }
+// bindings:     { a: 'x > 0', b: 'y < 10', c: 'z === 0' }
+// → '(x > 0) && !(y < 10) && (z === 0)'
+export function buildConstraintStr(clauseValues, bindings) {
+  const parts = [];
+  for (const [clause, val] of Object.entries(clauseValues)) {
+    const expr = bindings[clause]?.trim();
+    if (!expr) continue;
+    parts.push(val ? `(${expr})` : `!(${expr})`);
+  }
+  return parts.join(' && ') || '—';
 }
 
 // Validate a single binding expression for a given clause.

--- a/src/utils/logicBinding.js
+++ b/src/utils/logicBinding.js
@@ -1,0 +1,122 @@
+// Clause Binding — map abstract logic-coverage clauses to concrete program
+// expressions, then brute-force a witness for each test row.
+//
+// Example:
+//   predicate : (a && b) || c
+//   bindings  : { a: 'x > 0', b: 'y < 10', c: 'z === 0' }
+//   test row  : { a: true, b: false, c: true }
+//   → need: x > 0 && !(y < 10) && z === 0
+//   → search integers → witness: { x: 1, y: 10, z: 0 }
+
+const JS_KEYWORDS = new Set([
+  'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',
+  'default', 'delete', 'do', 'else', 'export', 'extends', 'false', 'finally',
+  'for', 'function', 'if', 'import', 'in', 'instanceof', 'let', 'new', 'null',
+  'return', 'static', 'super', 'switch', 'this', 'throw', 'true', 'try',
+  'typeof', 'undefined', 'var', 'void', 'while', 'with', 'yield',
+  'Math', 'Number', 'parseInt', 'parseFloat', 'Infinity', 'NaN',
+]);
+
+const IDENT_RE = /\b([A-Za-z_$][A-Za-z0-9_$]*)\b/g;
+
+// Returns unique program variable names appearing in binding expressions.
+// Excludes JS keywords, built-ins, and the clause names themselves.
+export function extractVarsFromBindings(bindings) {
+  const clauseNames = new Set(Object.keys(bindings));
+  const vars = new Set();
+  for (const expr of Object.values(bindings)) {
+    if (!expr || !expr.trim()) continue;
+    for (const [, name] of (expr.matchAll ? expr.matchAll(IDENT_RE) : [])) {
+      if (!JS_KEYWORDS.has(name) && !clauseNames.has(name)) {
+        vars.add(name);
+      }
+    }
+  }
+  return [...vars].sort();
+}
+
+// Build a JS checker function for one test row.
+// clauseValues: { a: true, b: false, c: true }
+// bindings:     { a: 'x > 0', b: 'y < 10', c: 'z === 0' }
+// varNames: ['x', 'y', 'z']
+// Returns a function (...values) => boolean, or null if any expression is empty/invalid.
+function buildChecker(clauseValues, bindings, varNames) {
+  const parts = [];
+  for (const [clause, val] of Object.entries(clauseValues)) {
+    const expr = bindings[clause]?.trim();
+    if (!expr) return null;
+    parts.push(val ? `(${expr})` : `!(${expr})`);
+  }
+  if (!parts.length) return null;
+  try {
+    return new Function(...varNames, `'use strict'; return ${parts.join(' && ')};`);
+  } catch {
+    return null;
+  }
+}
+
+// Cartesian product over integer range.
+function* cartesian(vars, range) {
+  function* gen(depth, current) {
+    if (depth === vars.length) {
+      yield [...current];
+      return;
+    }
+    for (let v = range[0]; v <= range[1]; v++) {
+      current.push(v);
+      yield* gen(depth + 1, current);
+      current.pop();
+    }
+  }
+  yield* gen(0, []);
+}
+
+// Main export.
+// clauseValues: { a: true, b: false, ... }
+// bindings:     { a: 'x > 0', b: 'y < 10', ... }
+// searchRange:  [min, max]  defaults to [-10, 10]
+// Returns { witness: {x: 1, y: 11, ...} } or { error: 'infeasible' | '<message>' }
+export function solveBinding({ clauseValues, bindings, searchRange = [-10, 10] }) {
+  const varNames = extractVarsFromBindings(bindings);
+  if (!varNames.length) return { error: 'no-vars' };
+
+  let checker;
+  try {
+    checker = buildChecker(clauseValues, bindings, varNames);
+  } catch (e) {
+    return { error: String(e.message || e) };
+  }
+  if (!checker) return { error: 'bad-expr' };
+
+  for (const combo of cartesian(varNames, searchRange)) {
+    let result;
+    try {
+      result = checker(...combo);
+    } catch {
+      continue;
+    }
+    if (result) {
+      const witness = {};
+      varNames.forEach((v, i) => { witness[v] = combo[i]; });
+      return { witness };
+    }
+  }
+  return { error: 'infeasible' };
+}
+
+// Pretty-print a witness as "x=1, y=11, z=0".
+export function formatWitnessStr(witness) {
+  return Object.entries(witness).map(([k, v]) => `${k}=${v}`).join(', ');
+}
+
+// Validate a single binding expression for a given clause.
+// Returns null if valid, or an error string.
+export function validateBindingExpr(expr) {
+  if (!expr || !expr.trim()) return null;
+  try {
+    new Function('__x__', `'use strict'; return (${expr.trim()});`);
+    return null;
+  } catch (e) {
+    return e.message || 'Invalid expression';
+  }
+}


### PR DESCRIPTION
Closes #87

## Summary

- **`src/utils/logicBinding.js`** (new, ~110 lines) — pure solver module:
  - `extractVarsFromBindings(bindings)` — collects program variable names from binding expressions, excluding JS keywords and clause names
  - `solveBinding({ clauseValues, bindings, searchRange })` — builds a JS checker via `new Function()`, then iterates the Cartesian product of integers in `searchRange` in `0, 1, −1, 2, −2, …` order (smallest-abs-value first)
  - `buildConstraintStr(clauseValues, bindings)` — produces `(x > 0) && !(y < 10) && (z === 0)`
  - `formatWitnessStr(witness)` — `x=1, y=0, z=1`
  - `validateBindingExpr(expr)` — syntax-checks without evaluating

- **`src/components/LogicCoverageExplorer.js`** — new Clause Binding `<details>` panel:
  - One text input per clause (`a ↦ x > 0`, `b ↦ y < 10`, …)
  - Adjustable search range inputs (default `[-10, 10]`)
  - Results table: **Test row | Clause values | Constraint | Witness**
  - Partial bindings supported — unbound clauses skipped from conjunction
  - `refreshBindingResults()` updates only the results div; inputs never lose focus

- **`src/components/LogicCoverageExplorer.css`** — new `.logic-binding-*` rules

- **`src/i18n/dict.js`** — 12 new `logic.binding.*` keys in both EN and ZH

- **`src/tests/logicBinding.test.js`** (new, 19 tests) — covers extraction, solving, negation, two-variable expressions, CACC three-clause rows, custom ranges, `buildConstraintStr`, `validateBindingExpr`

## Test plan

- [ ] Open Logic Coverage → pick `(a && b) || c` + CACC
- [ ] Fill `a ↦ x > 0`, `b ↦ y < 10`, `c ↦ z === 0`; confirm each row shows a constraint and a green witness with small integers (e.g. `x=1, y=0, z=1`)
- [ ] Confirm infeasible row (e.g. `a ↦ x > 0`, `b ↦ x < 0` for a row needing both true) shows "不可行 / infeasible"
- [ ] Change search range to `[0, 5]` — witnesses update, range-exceeding requirements go infeasible
- [ ] Switch criterion (e.g. PC → CACC → CUTPNFP) — table rows change, witnesses recompute
- [ ] Partial binding (fill only `a`) — solver runs for `a` only; `b` and `c` columns not included in constraint
- [ ] `npm run test:run` → 23 test files / 229 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)