### PR TITLE
feat(logic): auto-fill clause bindings from predicate examples

### DIFF
--- a/src/components/LogicCoverageExplorer.css
+++ b/src/components/LogicCoverageExplorer.css
@@ -528,6 +528,26 @@ details.logic-binding[open] .logic-binding-summary::before { content: '▼ '; }
   box-shadow: 0 0 0 2px rgba(59,130,246,0.18);
 }
 
+.logic-binding-restore-btn {
+  align-self: center;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.78rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #f9fafb;
+  color: #374151;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.logic-binding-restore-btn:hover { background: #f3f4f6; border-color: #9ca3af; }
+
+.logic-binding-params-hint {
+  display: block;
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin-bottom: 0.4rem;
+}
+
 .logic-binding-range-row {
   display: flex;
   align-items: center;

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -694,9 +694,17 @@ export function createLogicCoverageExplorer() {
     `;
   }
 
+  function activePredicateExample() {
+    return logicCoveragePredicates.find((p) => p.expression === state.expression) || null;
+  }
+
   function renderBindingPanel() {
     if (!state.analysis || state.error) return '';
     const { clauses } = state.analysis;
+    const example = activePredicateExample();
+    const hasDefaults = example?.defaultBindings &&
+      clauses.some((c) => example.defaultBindings[c]);
+
     const inputRows = clauses.map((c) => `
       <label class="logic-binding-clause-row">
         <span class="logic-binding-clause-name" aria-label="${t('logic.binding.clause')} ${escapeHtml(c)}">${escapeHtml(c)}</span>
@@ -715,13 +723,25 @@ export function createLogicCoverageExplorer() {
       </label>
     `).join('');
 
+    const restoreBtn = hasDefaults
+      ? `<button type="button" class="logic-binding-restore-btn"
+           data-testid="logic-binding-restore"
+           title="${t('logic.binding.restore')}">${t('logic.binding.restore')}</button>`
+      : '';
+
+    const paramsHint = example?.bindingParams
+      ? `<span class="logic-binding-params-hint">${t('logic.binding.params')} <code>${escapeHtml(example.bindingParams)}</code></span>`
+      : '';
+
     return `
       <details class="logic-binding" data-testid="logic-binding" open>
         <summary class="logic-binding-summary">${t('logic.binding.title')}</summary>
         <p class="logic-binding-desc">${t('logic.binding.hint')}</p>
         <div class="logic-binding-inputs" data-testid="logic-binding-inputs">
           ${inputRows}
+          ${restoreBtn}
         </div>
+        ${paramsHint}
         <div class="logic-binding-range-row">
           <span class="logic-binding-range-label">${t('logic.binding.range')}</span>
           <input type="number" class="logic-binding-range-input" data-testid="logic-binding-range-min"
@@ -767,6 +787,11 @@ export function createLogicCoverageExplorer() {
       btn.addEventListener('click', () => {
         state.expression = btn.dataset.expression;
         recompute();
+        // Auto-fill bindings from defaultBindings when available.
+        const example = activePredicateExample();
+        if (example?.defaultBindings) {
+          state.bindings = { ...example.defaultBindings };
+        }
         render();
       });
     });
@@ -803,6 +828,18 @@ export function createLogicCoverageExplorer() {
         bindingTimer = setTimeout(() => refreshBindingResults(), 200);
       });
     });
+
+    // Restore defaults button.
+    const restoreBtn = root.querySelector('[data-testid="logic-binding-restore"]');
+    if (restoreBtn) {
+      restoreBtn.addEventListener('click', () => {
+        const example = activePredicateExample();
+        if (example?.defaultBindings) {
+          state.bindings = { ...example.defaultBindings };
+          render();
+        }
+      });
+    }
 
     // Search range inputs.
     root.querySelectorAll('[data-binding-range]').forEach((input) => {

--- a/src/data/testingData.js
+++ b/src/data/testingData.js
@@ -461,6 +461,9 @@ export const logicCoveragePredicates = [
     expression: '(a && b) || c',
     description: '常見的混合 AND/OR predicate，三個子句。',
     descriptionEn: 'A common mixed AND/OR predicate with three clauses.',
+    // Binding: f(x,y,z) returns true when (x>0 && y>0) || z===0
+    defaultBindings: { a: 'x > 0', b: 'y > 0', c: 'z === 0' },
+    bindingParams: 'x, y, z',
   },
   {
     id: 'guarded-exit',
@@ -468,6 +471,9 @@ export const logicCoveragePredicates = [
     expression: 'a && (b || !c)',
     description: '帶有否定子句的守衛條件。',
     descriptionEn: 'A guarded condition that includes a negated clause.',
+    // Binding: guard — n must be positive and either even or not large
+    defaultBindings: { a: 'n > 0', b: 'n % 2 === 0', c: 'n > 100' },
+    bindingParams: 'n',
   },
   {
     id: 'four-clause',
@@ -475,6 +481,36 @@ export const logicCoveragePredicates = [
     expression: '(a || b) && (c || d)',
     description: '四個子句的乘積式 predicate，常見於範圍檢查。',
     descriptionEn: 'A four-clause product predicate, common in range checks.',
+    // Binding: x out-of-range OR y out-of-range — both axes must trigger
+    defaultBindings: { a: 'x < 0', b: 'x > 100', c: 'y < 0', d: 'y > 100' },
+    bindingParams: 'x, y',
+  },
+  {
+    id: 'triangle-valid',
+    name: 'Triangle valid',
+    expression: 'a && b && c',
+    description: '三角形合法性：三邊正數且任意兩邊之和大於第三邊。',
+    descriptionEn: 'Triangle validity: all sides positive and triangle inequality holds.',
+    defaultBindings: { a: 'p > 0 && q > 0 && r > 0', b: 'p + q > r', c: 'p + r > q' },
+    bindingParams: 'p, q, r',
+  },
+  {
+    id: 'abs-predicate',
+    name: 'abs(x) branch',
+    expression: 'a',
+    description: 'abs(x) 函式的單一分支條件：x < 0 → 回傳 -x。',
+    descriptionEn: 'The single branch condition inside abs(x): x < 0 returns -x.',
+    defaultBindings: { a: 'x < 0' },
+    bindingParams: 'x',
+  },
+  {
+    id: 'max3-predicate',
+    name: 'max3(a,b,c) branches',
+    expression: 'a && b',
+    description: 'max3 的雙層 if：a>b 且 a>c 時 a 為最大值。',
+    descriptionEn: 'Nested ifs in max3: a is maximum when a>b and a>c.',
+    defaultBindings: { a: 'x > y', b: 'x > z' },
+    bindingParams: 'x, y, z',
   },
 ];
 

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -352,6 +352,8 @@ export const messages = {
     'logic.binding.col.vals': 'Clause values',
     'logic.binding.col.constraint': 'Constraint',
     'logic.binding.col.witness': 'Witness',
+    'logic.binding.restore': 'Restore defaults',
+    'logic.binding.params': 'Suggested variables:',
 
     // Syntax / mutation
     'syntax.title': 'Syntax-Based Testing: Program Mutation',
@@ -811,6 +813,8 @@ export const messages = {
     'logic.binding.col.vals': 'Clause 值',
     'logic.binding.col.constraint': '求解條件',
     'logic.binding.col.witness': 'Witness',
+    'logic.binding.restore': '還原預設 binding',
+    'logic.binding.params': '建議變數名稱：',
 
     'syntax.title': 'Syntax-Based Testing：Program Mutation',
     'syntax.subtitle': '挑選程式、選擇 mutation operators 與 test set，系統會產生 mutants 並計分。',


### PR DESCRIPTION
Closes #89

## Summary

- `src/data/testingData.js` — each `logicCoveragePredicates` entry now carries:
  - `defaultBindings: { clauseName: jsExpression, … }` — pre-populated on example click
  - `bindingParams` — shown as a "建議變數名稱 / Suggested variables" hint
  - Three existing examples updated; three new program-grounded examples added (`triangle-valid`, `abs-predicate`, `max3-predicate`)

- `src/components/LogicCoverageExplorer.js`:
  - Clicking a predicate example chip auto-applies `defaultBindings` into `state.bindings` (no manual typing needed)
  - `renderBindingPanel()` shows the params hint and a "還原預設 binding / Restore defaults" button when `defaultBindings` exist
  - Restore button resets `state.bindings` to `defaultBindings` and re-renders

- `src/components/LogicCoverageExplorer.css` — `.logic-binding-restore-btn`, `.logic-binding-params-hint`

- `src/i18n/dict.js` — `logic.binding.restore` + `logic.binding.params` in EN + ZH

## Test plan

- [ ] Click `(a && b) || c` example → binding inputs immediately show `x > 0`, `y > 0`, `z === 0`; witness table populates without any manual input
- [ ] Click `abs(x) branch` → one clause `a ↦ x < 0`; PC shows `x=-1` and `x=0`
- [ ] Edit a binding manually, then click "還原預設 binding" → inputs reset to defaults
- [ ] Switch to a custom-typed predicate (no `defaultBindings`) → restore button is absent
- [ ] `npm run test:run` → 23 test files / 229 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)