### PR TITLE
test: add JSDOM smoke tests for Fuzz/TestGen/Symbolic/Concolic + binding panel

### DIFF
--- a/src/tests/ConcolicExecutionExplorer.test.jsx
+++ b/src/tests/ConcolicExecutionExplorer.test.jsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { createConcolicExecutionExplorer } from '../components/ConcolicExecutionExplorer.js';
+
+function mount() {
+  document.body.innerHTML = '';
+  const el = createConcolicExecutionExplorer();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('ConcolicExecutionExplorer smoke', () => {
+  it('renders root element with correct testid', () => {
+    mount();
+    expect(document.querySelector('[data-testid="concolic-explorer"]')).toBeInTheDocument();
+  });
+
+  it('renders example buttons and source editor', () => {
+    mount();
+    expect(document.querySelector('[data-testid="concolic-examples"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="concolic-source"]')).toBeInTheDocument();
+    const btns = document.querySelectorAll('[data-testid^="concolic-example-"]');
+    expect(btns.length).toBeGreaterThan(0);
+  });
+
+  it('renders seed input and max-iter input', () => {
+    mount();
+    expect(document.querySelector('[data-testid="concolic-seed"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="concolic-max-iter"]')).toBeInTheDocument();
+  });
+
+  it('clicking an example does not throw', () => {
+    mount();
+    const btn = document.querySelector('[data-testid^="concolic-example-"]');
+    expect(() => btn.click()).not.toThrow();
+  });
+
+  it('shows iteration list and summary after selecting an example', () => {
+    mount();
+    document.querySelector('[data-testid^="concolic-example-"]').click();
+    expect(document.querySelector('[data-testid="concolic-iters"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="concolic-summary"]')).toBeInTheDocument();
+  });
+
+  it('shows at least one iteration after selecting an example', () => {
+    mount();
+    document.querySelector('[data-testid^="concolic-example-"]').click();
+    const iters = document.querySelector('[data-testid="concolic-iters"]');
+    expect(iters.children.length).toBeGreaterThan(0);
+  });
+
+  it('shows CFG area', () => {
+    mount();
+    document.querySelector('[data-testid^="concolic-example-"]').click();
+    expect(document.querySelector('[data-testid="concolic-cfg"]')).toBeInTheDocument();
+  });
+
+  it('clicking an iteration does not throw', () => {
+    mount();
+    document.querySelector('[data-testid^="concolic-example-"]').click();
+    const firstIter = document.querySelector('[data-concolic-iter]');
+    if (firstIter) expect(() => firstIter.click()).not.toThrow();
+  });
+});

--- a/src/tests/FuzzTestingExplorer.test.jsx
+++ b/src/tests/FuzzTestingExplorer.test.jsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { createFuzzTestingExplorer } from '../components/FuzzTestingExplorer.js';
+
+function mount() {
+  document.body.innerHTML = '';
+  const el = createFuzzTestingExplorer();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('FuzzTestingExplorer smoke', () => {
+  it('renders root element with correct testid', () => {
+    mount();
+    expect(document.querySelector('[data-testid="fuzz-explorer"]')).toBeInTheDocument();
+  });
+
+  it('renders example buttons', () => {
+    mount();
+    expect(document.querySelector('[data-testid="fuzz-examples"]')).toBeInTheDocument();
+    const btns = document.querySelectorAll('[data-testid^="fuzz-example-"]');
+    expect(btns.length).toBeGreaterThan(0);
+  });
+
+  it('renders run button and source editor', () => {
+    mount();
+    expect(document.querySelector('[data-testid="fuzz-run-btn"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="fuzz-source"]')).toBeInTheDocument();
+  });
+
+  it('clicking an example does not throw', () => {
+    mount();
+    const btn = document.querySelector('[data-testid^="fuzz-example-"]');
+    expect(() => btn.click()).not.toThrow();
+  });
+
+  it('clicking run button after selecting an example does not throw', () => {
+    mount();
+    const exampleBtn = document.querySelector('[data-testid^="fuzz-example-"]');
+    exampleBtn.click();
+    const runBtn = document.querySelector('[data-testid="fuzz-run-btn"]');
+    expect(() => runBtn.click()).not.toThrow();
+    expect(document.querySelector('[data-testid="fuzz-summary"]')).toBeInTheDocument();
+  });
+
+  it('shows CFG area after a run', () => {
+    mount();
+    document.querySelector('[data-testid^="fuzz-example-"]').click();
+    document.querySelector('[data-testid="fuzz-run-btn"]').click();
+    expect(document.querySelector('[data-testid="fuzz-cfg"]')).toBeInTheDocument();
+  });
+});

--- a/src/tests/LogicCoverageExplorer.test.jsx
+++ b/src/tests/LogicCoverageExplorer.test.jsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createLogicCoverageExplorer } from '../components/LogicCoverageExplorer.js';
-import { logicCoverageCriteria } from '../data/testingData.js';
+import { logicCoverageCriteria, logicCoveragePredicates } from '../data/testingData.js';
 
 function mount() {
   document.body.innerHTML = '';
@@ -24,5 +24,61 @@ describe('LogicCoverageExplorer smoke', () => {
       // shadowing bugs) would surface here.
       expect(() => btn.click()).not.toThrow();
     }
+  });
+});
+
+describe('LogicCoverageExplorer binding panel', () => {
+  it('renders the clause binding panel', () => {
+    mount();
+    expect(document.querySelector('[data-testid="logic-binding"]')).toBeInTheDocument();
+  });
+
+  it('auto-fills bindings when a predicate example with defaultBindings is clicked', () => {
+    mount();
+    const exampleWithBindings = logicCoveragePredicates.find((p) => p.defaultBindings);
+    if (!exampleWithBindings) return;
+    const btn = document.querySelector(`[data-expression="${exampleWithBindings.expression}"]`);
+    if (!btn) return;
+    btn.click();
+    const inputs = document.querySelectorAll('[data-testid^="logic-binding-input-"]');
+    expect(inputs.length).toBeGreaterThan(0);
+    const filled = [...inputs].some((inp) => inp.value.trim() !== '');
+    expect(filled).toBe(true);
+  });
+
+  it('shows source code block when an example with sourceCode is selected', () => {
+    mount();
+    const exampleWithSource = logicCoveragePredicates.find((p) => p.sourceCode);
+    if (!exampleWithSource) return;
+    const btn = document.querySelector(`[data-expression="${exampleWithSource.expression}"]`);
+    if (!btn) return;
+    btn.click();
+    expect(document.querySelector('[data-testid="logic-binding-source"]')).toBeInTheDocument();
+  });
+
+  it('shows restore button when a predicate example with defaultBindings is selected', () => {
+    mount();
+    const exampleWithBindings = logicCoveragePredicates.find((p) => p.defaultBindings);
+    if (!exampleWithBindings) return;
+    const btn = document.querySelector(`[data-expression="${exampleWithBindings.expression}"]`);
+    if (!btn) return;
+    btn.click();
+    expect(document.querySelector('[data-testid="logic-binding-restore"]')).toBeInTheDocument();
+  });
+
+  it('renders binding results table after bindings are set', () => {
+    mount();
+    const exampleWithBindings = logicCoveragePredicates.find((p) => p.defaultBindings);
+    if (!exampleWithBindings) return;
+    const btn = document.querySelector(`[data-expression="${exampleWithBindings.expression}"]`);
+    if (!btn) return;
+    btn.click();
+    expect(document.querySelector('[data-testid="logic-binding-results"]')).toBeInTheDocument();
+  });
+
+  it('renders range inputs', () => {
+    mount();
+    expect(document.querySelector('[data-testid="logic-binding-range-min"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="logic-binding-range-max"]')).toBeInTheDocument();
   });
 });

--- a/src/tests/SymbolicExecutionExplorer.test.jsx
+++ b/src/tests/SymbolicExecutionExplorer.test.jsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { createSymbolicExecutionExplorer } from '../components/SymbolicExecutionExplorer.js';
+
+function mount() {
+  document.body.innerHTML = '';
+  const el = createSymbolicExecutionExplorer();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('SymbolicExecutionExplorer smoke', () => {
+  it('renders root element with correct testid', () => {
+    mount();
+    expect(document.querySelector('[data-testid="symbex-explorer"]')).toBeInTheDocument();
+  });
+
+  it('renders example buttons and source editor', () => {
+    mount();
+    expect(document.querySelector('[data-testid="symbex-examples"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="symbex-source"]')).toBeInTheDocument();
+    const btns = document.querySelectorAll('[data-testid^="symbex-example-"]');
+    expect(btns.length).toBeGreaterThan(0);
+  });
+
+  it('clicking an example does not throw', () => {
+    mount();
+    const btn = document.querySelector('[data-testid^="symbex-example-"]');
+    expect(() => btn.click()).not.toThrow();
+  });
+
+  it('shows path list and summary after selecting an example', () => {
+    mount();
+    document.querySelector('[data-testid^="symbex-example-"]').click();
+    expect(document.querySelector('[data-testid="symbex-paths"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="symbex-summary"]')).toBeInTheDocument();
+  });
+
+  it('shows at least one path after selecting an example', () => {
+    mount();
+    document.querySelector('[data-testid^="symbex-example-"]').click();
+    const paths = document.querySelector('[data-testid="symbex-paths"]');
+    expect(paths.children.length).toBeGreaterThan(0);
+  });
+
+  it('shows CFG area', () => {
+    mount();
+    document.querySelector('[data-testid^="symbex-example-"]').click();
+    expect(document.querySelector('[data-testid="symbex-cfg"]')).toBeInTheDocument();
+  });
+
+  it('clicking a path does not throw', () => {
+    mount();
+    document.querySelector('[data-testid^="symbex-example-"]').click();
+    const firstPath = document.querySelector('[data-symbex-path]');
+    if (firstPath) expect(() => firstPath.click()).not.toThrow();
+  });
+});

--- a/src/tests/TestGenerationExplorer.test.jsx
+++ b/src/tests/TestGenerationExplorer.test.jsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { createTestGenerationExplorer } from '../components/TestGenerationExplorer.js';
+
+function mount() {
+  document.body.innerHTML = '';
+  const el = createTestGenerationExplorer();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('TestGenerationExplorer smoke', () => {
+  it('renders root element with correct testid', () => {
+    mount();
+    expect(document.querySelector('[data-testid="testgen-explorer"]')).toBeInTheDocument();
+  });
+
+  it('renders example buttons and criterion selector', () => {
+    mount();
+    expect(document.querySelector('[data-testid="testgen-examples"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="testgen-criterion"]')).toBeInTheDocument();
+    const btns = document.querySelectorAll('[data-testid^="testgen-example-"]');
+    expect(btns.length).toBeGreaterThan(0);
+  });
+
+  it('renders source editor', () => {
+    mount();
+    expect(document.querySelector('[data-testid="testgen-source"]')).toBeInTheDocument();
+  });
+
+  it('clicking an example does not throw', () => {
+    mount();
+    const btn = document.querySelector('[data-testid^="testgen-example-"]');
+    expect(() => btn.click()).not.toThrow();
+  });
+
+  it('shows requirements and tests cards after selecting an example', () => {
+    mount();
+    document.querySelector('[data-testid^="testgen-example-"]').click();
+    expect(document.querySelector('[data-testid="testgen-requirements-card"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="testgen-tests-card"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="testgen-summary"]')).toBeInTheDocument();
+  });
+
+  it('shows at least one requirement after selecting an example', () => {
+    mount();
+    document.querySelector('[data-testid^="testgen-example-"]').click();
+    const reqList = document.querySelector('[data-testid="testgen-req-list"]');
+    expect(reqList).toBeInTheDocument();
+    expect(reqList.children.length).toBeGreaterThan(0);
+  });
+
+  it('switching criterion does not throw', () => {
+    mount();
+    document.querySelector('[data-testid^="testgen-example-"]').click();
+    const sel = document.querySelector('[data-testid="testgen-criterion"]');
+    sel.value = sel.options[1]?.value ?? sel.value;
+    expect(() => sel.dispatchEvent(new Event('change', { bubbles: true }))).not.toThrow();
+  });
+
+  it('shows CFG area', () => {
+    mount();
+    document.querySelector('[data-testid^="testgen-example-"]').click();
+    expect(document.querySelector('[data-testid="testgen-cfg"]')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes the issue above.

## Changes

- `src/tests/FuzzTestingExplorer.test.jsx` (new, 6 tests)
- `src/tests/TestGenerationExplorer.test.jsx` (new, 7 tests)
- `src/tests/SymbolicExecutionExplorer.test.jsx` (new, 7 tests)
- `src/tests/ConcolicExecutionExplorer.test.jsx` (new, 8 tests)
- `src/tests/LogicCoverageExplorer.test.jsx` (extended, +6 binding panel tests)

Total: 229 → 264 tests.

## Test plan

- [ ] `npx vitest run` → 264 passed
- [ ] No existing snapshots broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)