### PR TITLE
feat(quiz): self-test mode for Logic, Decision Table, State Transition explorers

### DIFF
--- a/src/components/DecisionTableExplorer.js
+++ b/src/components/DecisionTableExplorer.js
@@ -106,6 +106,52 @@ export function createDecisionTableExplorer() {
   let nextActId  = 10;
   let nextRuleId = 10;
 
+  const dtQuiz = { active: false, phase: 'question', ansCovered: '', ansDup: '', result: null };
+
+  function renderDtQuizPanel() {
+    if (!dtQuiz.active) return '';
+    const validation = validateDecisionTable(state.conditions, state.rules);
+    const isGraded = dtQuiz.phase === 'graded';
+    const covCorrect = isGraded && parseInt(dtQuiz.ansCovered, 10) === validation.covered;
+    const dupCorrect = isGraded && parseInt(dtQuiz.ansDup, 10) === validation.duplicate.length;
+    const allCorrect = covCorrect && dupCorrect;
+    return `
+      <div class="quiz-panel" data-testid="dt-quiz">
+        <div class="quiz-header">
+          <h4>${t('quiz.dt.title')}</h4>
+          <button type="button" class="quiz-close-btn" data-testid="dt-quiz-close">${t('quiz.close')}</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.dt.prompt')}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            <span>${t('quiz.dt.label.covered')}</span>
+            <input type="number" min="0"
+              class="quiz-bva-input${isGraded ? (covCorrect ? ' quiz-input-correct' : ' quiz-input-wrong') : ''}"
+              data-testid="dt-quiz-covered" value="${esc(dtQuiz.ansCovered)}" ${isGraded ? 'readonly' : ''}>
+          </label>
+          <label class="quiz-bva-field">
+            <span>${t('quiz.dt.label.dup')}</span>
+            <input type="number" min="0"
+              class="quiz-bva-input${isGraded ? (dupCorrect ? ' quiz-input-correct' : ' quiz-input-wrong') : ''}"
+              data-testid="dt-quiz-dup" value="${esc(dtQuiz.ansDup)}" ${isGraded ? 'readonly' : ''}>
+          </label>
+        </div>
+        ${isGraded ? `
+          <p class="quiz-score" data-testid="dt-quiz-score">
+            ${allCorrect
+              ? `<strong>${t('quiz.bva.perfect')}</strong>`
+              : `${t('quiz.ec.wrong')} ${t('quiz.dt.answer')
+                  .replace('{covered}', validation.covered)
+                  .replace('{dup}', validation.duplicate.length)}`}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="dt-quiz-reset">${t('quiz.reset')}</button>
+        ` : `
+          <button type="button" class="quiz-start-btn" data-testid="dt-quiz-check">${t('quiz.check')}</button>
+        `}
+      </div>
+    `;
+  }
+
   function renderTable() {
     const tests = generateDecisionTableTests(state.conditions, state.actions, state.rules);
     const validation = validateDecisionTable(state.conditions, state.rules);
@@ -159,6 +205,7 @@ export function createDecisionTableExplorer() {
         <span class="dt-coverage-badge" data-testid="dt-coverage">${t('dt.coverage')}: ${validation.covered}/${validation.total}</span>
         ${dupMsg}
         <button class="dt-add-rule-btn" data-testid="dt-add-rule">+ ${t('dt.rule.add')}</button>
+        <button class="quiz-start-btn dt-quiz-trigger" data-testid="dt-quiz-start">${t('quiz.start')}</button>
       </div>
     </div>`;
   }
@@ -223,6 +270,7 @@ export function createDecisionTableExplorer() {
               <span class="dt-count">${state.rules.length} ${t('dt.results.count')}</span>
             </h3>
             ${renderTable()}
+            ${renderDtQuizPanel()}
           </div>
         </div>
       </div>
@@ -353,6 +401,24 @@ export function createDecisionTableExplorer() {
       else r.actions.push(aid);
       refreshResults();
       persist(state);
+    });
+
+    root.querySelector('[data-testid="dt-quiz-start"]')?.addEventListener('click', () => {
+      dtQuiz.active = true; dtQuiz.phase = 'question';
+      dtQuiz.ansCovered = ''; dtQuiz.ansDup = '';
+      render();
+    });
+    root.querySelector('[data-testid="dt-quiz-close"]')?.addEventListener('click', () => {
+      dtQuiz.active = false; render();
+    });
+    root.querySelector('[data-testid="dt-quiz-check"]')?.addEventListener('click', () => {
+      dtQuiz.ansCovered = root.querySelector('[data-testid="dt-quiz-covered"]')?.value ?? '';
+      dtQuiz.ansDup     = root.querySelector('[data-testid="dt-quiz-dup"]')?.value ?? '';
+      dtQuiz.phase = 'graded';
+      render();
+    });
+    root.querySelector('[data-testid="dt-quiz-reset"]')?.addEventListener('click', () => {
+      dtQuiz.phase = 'question'; dtQuiz.ansCovered = ''; dtQuiz.ansDup = ''; render();
     });
   }
 

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -204,6 +204,59 @@ export function createLogicCoverageExplorer() {
     cloudUser: null,
   };
 
+  const logicQuiz = { active: false, phase: 'question', answer: '', result: null };
+
+  function getQuizUniqueCount() {
+    const set = getActiveSet();
+    if (!set) return null;
+    const seen = new Set();
+    for (const test of set.tests) {
+      seen.add(`r${test.row.index}`);
+    }
+    return seen.size;
+  }
+
+  function renderLogicQuizPanel() {
+    if (!logicQuiz.active) return '';
+    const criterion = logicCoverageCriteria.find((c) => c.id === state.selectedCriterion);
+    const criterionLabel = pickField(criterion, 'label') || criterion?.id || state.selectedCriterion;
+    const uniqueCount = getQuizUniqueCount();
+    if (uniqueCount === null) return '';
+    const isGraded = logicQuiz.phase === 'graded';
+    const correct = isGraded && parseInt(logicQuiz.answer, 10) === uniqueCount;
+    return `
+      <div class="quiz-panel" data-testid="logic-quiz">
+        <div class="quiz-header">
+          <h4>${t('quiz.logic.title')}</h4>
+          <button type="button" class="quiz-close-btn" data-testid="logic-quiz-close">${t('quiz.close')}</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.logic.prompt')
+          .replace('{expr}', escapeHtml(state.expression))
+          .replace('{criterion}', escapeHtml(criterionLabel))}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            <span>${t('quiz.logic.label')}</span>
+            <input type="number" min="0"
+              class="quiz-bva-input${isGraded ? (correct ? ' quiz-input-correct' : ' quiz-input-wrong') : ''}"
+              data-testid="logic-quiz-answer"
+              value="${escapeHtml(logicQuiz.answer)}"
+              ${isGraded ? 'readonly' : ''}>
+          </label>
+        </div>
+        ${isGraded ? `
+          <p class="quiz-score" data-testid="logic-quiz-score">
+            ${correct
+              ? `<strong>${t('quiz.bva.perfect')}</strong>`
+              : `${t('quiz.ec.wrong')} ${t('quiz.ec.answer').replace('{count}', uniqueCount)}`}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="logic-quiz-reset">${t('quiz.reset')}</button>
+        ` : `
+          <button type="button" class="quiz-start-btn" data-testid="logic-quiz-check">${t('quiz.check')}</button>
+        `}
+      </div>
+    `;
+  }
+
   let cloudClient = null;
   try {
     cloudClient = createCloudIntegrationClient();
@@ -354,8 +407,16 @@ export function createLogicCoverageExplorer() {
       ${state.error ? `<div class="logic-error" data-testid="logic-error">${escapeHtml(state.error)}</div>` : ''}
 
       <div class="logic-criteria" role="tablist" aria-label="${t('logic.aria.criteria')}">
-        ${criteriaMarkup}
+        <div class="graph-criterion-row">
+          ${criteriaMarkup}
+          ${!state.error && state.analysis ? `
+            <button type="button" class="quiz-start-btn" data-testid="logic-quiz-start">
+              ${t('quiz.start')}
+            </button>` : ''}
+        </div>
       </div>
+
+      ${renderLogicQuizPanel()}
 
       <div class="logic-summary" data-testid="logic-summary">${summaryMarkup}</div>
 
@@ -819,8 +880,44 @@ export function createLogicCoverageExplorer() {
     root.querySelectorAll('[data-criterion]').forEach((btn) => {
       btn.addEventListener('click', () => {
         state.selectedCriterion = btn.dataset.criterion;
+        logicQuiz.active = false;
+        logicQuiz.phase = 'question';
+        logicQuiz.answer = '';
+        logicQuiz.result = null;
         render();
       });
+    });
+
+    root.querySelector('[data-testid="logic-quiz-start"]')?.addEventListener('click', () => {
+      logicQuiz.active = true;
+      logicQuiz.phase = 'question';
+      logicQuiz.answer = '';
+      logicQuiz.result = null;
+      const quizEl = root.querySelector('[data-testid="logic-quiz"]');
+      if (!quizEl) { render(); return; }
+      quizEl.outerHTML = renderLogicQuizPanel();
+      // Re-insert by full render since outerHTML swap loses binding
+      render();
+    });
+
+    root.querySelector('[data-testid="logic-quiz-close"]')?.addEventListener('click', () => {
+      logicQuiz.active = false;
+      render();
+    });
+
+    root.querySelector('[data-testid="logic-quiz-check"]')?.addEventListener('click', () => {
+      const inp = root.querySelector('[data-testid="logic-quiz-answer"]');
+      logicQuiz.answer = inp?.value ?? '';
+      logicQuiz.phase = 'graded';
+      const panel = root.querySelector('[data-testid="logic-quiz"]');
+      if (panel) panel.outerHTML = renderLogicQuizPanel();
+      render();
+    });
+
+    root.querySelector('[data-testid="logic-quiz-reset"]')?.addEventListener('click', () => {
+      logicQuiz.phase = 'question';
+      logicQuiz.answer = '';
+      render();
     });
 
     // Binding inputs — update results section only (no full re-render → no focus loss).

--- a/src/components/StateTransitionExplorer.js
+++ b/src/components/StateTransitionExplorer.js
@@ -84,6 +84,44 @@ export function createStateTransitionExplorer() {
   let nextSId = 20;
   let nextTId = 20;
 
+  const stQuiz = { active: false, phase: 'question', answer: '', result: null };
+
+  function renderStQuizPanel() {
+    if (!stQuiz.active) return '';
+    const tests = getTests();
+    const count = tests.length;
+    const modeLabel = state.mode === 'sequence' ? t('st.mode.sequence') : t('st.mode.transition');
+    const isGraded = stQuiz.phase === 'graded';
+    const correct = isGraded && parseInt(stQuiz.answer, 10) === count;
+    return `
+      <div class="quiz-panel" data-testid="st-quiz">
+        <div class="quiz-header">
+          <h4>${t('quiz.st.title')}</h4>
+          <button type="button" class="quiz-close-btn" data-testid="st-quiz-close">${t('quiz.close')}</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.st.prompt').replace('{mode}', esc(modeLabel))}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            <span>${t('quiz.st.label')}</span>
+            <input type="number" min="0"
+              class="quiz-bva-input${isGraded ? (correct ? ' quiz-input-correct' : ' quiz-input-wrong') : ''}"
+              data-testid="st-quiz-answer" value="${esc(stQuiz.answer)}" ${isGraded ? 'readonly' : ''}>
+          </label>
+        </div>
+        ${isGraded ? `
+          <p class="quiz-score" data-testid="st-quiz-score">
+            ${correct
+              ? `<strong>${t('quiz.bva.perfect')}</strong>`
+              : `${t('quiz.ec.wrong')} ${t('quiz.ec.answer').replace('{count}', count)}`}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="st-quiz-reset">${t('quiz.reset')}</button>
+        ` : `
+          <button type="button" class="quiz-start-btn" data-testid="st-quiz-check">${t('quiz.check')}</button>
+        `}
+      </div>
+    `;
+  }
+
   function getTests() {
     if (!state.states.length || !state.transitions.length) return [];
     return state.mode === 'sequence'
@@ -235,6 +273,7 @@ export function createStateTransitionExplorer() {
               data-mode="transition" data-testid="st-mode-transition">${t('st.mode.transition')}</button>
             <button type="button" class="st-mode-btn${state.mode === 'sequence' ? ' active' : ''}"
               data-mode="sequence" data-testid="st-mode-sequence">${t('st.mode.sequence')}</button>
+            <button type="button" class="quiz-start-btn" data-testid="st-quiz-start">${t('quiz.start')}</button>
           </div>
         </div>
 
@@ -268,6 +307,7 @@ export function createStateTransitionExplorer() {
               <span class="st-count">${tests.length} ${t('st.results.count')}</span>
             </h3>
             ${renderTestTable(tests)}
+            ${renderStQuizPanel()}
           </div>
         </div>
       </div>
@@ -365,6 +405,20 @@ export function createStateTransitionExplorer() {
       const to   = state.states[1]?.id ?? from;
       state.transitions.push({ id: `t${nextTId++}`, from, to, event: 'event', action: '' });
       render();
+    });
+
+    root.querySelector('[data-testid="st-quiz-start"]')?.addEventListener('click', () => {
+      stQuiz.active = true; stQuiz.phase = 'question'; stQuiz.answer = ''; render();
+    });
+    root.querySelector('[data-testid="st-quiz-close"]')?.addEventListener('click', () => {
+      stQuiz.active = false; render();
+    });
+    root.querySelector('[data-testid="st-quiz-check"]')?.addEventListener('click', () => {
+      stQuiz.answer = root.querySelector('[data-testid="st-quiz-answer"]')?.value ?? '';
+      stQuiz.phase = 'graded'; render();
+    });
+    root.querySelector('[data-testid="st-quiz-reset"]')?.addEventListener('click', () => {
+      stQuiz.phase = 'question'; stQuiz.answer = ''; render();
     });
   }
 

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -231,6 +231,23 @@ export const messages = {
     'quiz.graph.perfect': 'Optimal!',
     'quiz.graph.incomplete': 'Incomplete — some requirements are not covered.',
 
+    // Quiz — Logic Coverage
+    'quiz.logic.title': 'Logic Coverage Self-Test',
+    'quiz.logic.prompt': 'Predicate: "{expr}" — Criterion: {criterion}. How many unique test cases are required?',
+    'quiz.logic.label': 'Unique test cases',
+
+    // Quiz — Decision Table
+    'quiz.dt.title': 'Decision Table Self-Test',
+    'quiz.dt.prompt': 'For the current decision table, answer the two questions below.',
+    'quiz.dt.label.covered': 'Unique rule combinations covered',
+    'quiz.dt.label.dup': 'Duplicate rules',
+    'quiz.dt.answer': 'Answer: {covered} unique, {dup} duplicate',
+
+    // Quiz — State Transition
+    'quiz.st.title': 'State Transition Self-Test',
+    'quiz.st.prompt': 'Using "{mode}", how many test cases does the current state machine require?',
+    'quiz.st.label': 'Number of test cases',
+
     'section.flow': 'Testing Flow',
     'section.types': 'Testing Types',
     'section.methods.title': 'Testing Method Categories',
@@ -946,6 +963,20 @@ export const messages = {
     'quiz.graph.score': '您的選擇覆蓋了 {covered}/{total} 項需求。最優最小集：{optimal} 條路徑。',
     'quiz.graph.perfect': '最優！',
     'quiz.graph.incomplete': '未完整 — 仍有部分需求未被覆蓋。',
+
+    'quiz.logic.title': 'Logic Coverage 自我測驗',
+    'quiz.logic.prompt': '謂詞："{expr}" — 準則：{criterion}。需要幾個不重複的測試案例？',
+    'quiz.logic.label': '不重複測試案例數',
+
+    'quiz.dt.title': '決策表 自我測驗',
+    'quiz.dt.prompt': '針對目前的決策表，回答下列兩個問題。',
+    'quiz.dt.label.covered': '已覆蓋的不重複規則組合數',
+    'quiz.dt.label.dup': '重複規則數',
+    'quiz.dt.answer': '答案：{covered} 個不重複，{dup} 個重複',
+
+    'quiz.st.title': '狀態轉移 自我測驗',
+    'quiz.st.prompt': '使用「{mode}」模式，目前的狀態機需要幾個測試案例？',
+    'quiz.st.label': '測試案例數',
 
     'section.flow': '測試流程',
     'section.types': '測試類型',


### PR DESCRIPTION
## Summary

- Adds interactive Self-Test quiz panels to the three high-priority explorers in Plan.md D1
- All 346 unit tests pass

| Explorer | Quiz |
|---|---|
| LogicCoverageExplorer | Unique test case count for active predicate + criterion |
| DecisionTableExplorer | Covered rule count + duplicate rule count |
| StateTransitionExplorer | Test case count for current coverage mode |

## i18n

ZH-TW and EN keys added for `quiz.logic.*`, `quiz.dt.*`, `quiz.st.*`.

## Test plan

- [x] `npx vitest run` — 346/346 pass
- [ ] Logic quiz: correct / wrong answer paths
- [ ] DT quiz: both fields correct / one wrong
- [ ] ST quiz: transition mode and sequence mode
- [ ] ZH/EN language toggle shows correct labels

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)