### PR TITLE
feat(quiz): self-test mode for Syntax, Metamorphic, and Test Doubles explorers

### DIFF
--- a/src/components/MetamorphicTestingExplorer.js
+++ b/src/components/MetamorphicTestingExplorer.js
@@ -19,6 +19,50 @@ export function createMetamorphicTestingExplorer() {
     results: null,
   };
 
+  const mtQuiz = { active: false, phase: 'question', answer: '', autoResults: null };
+
+  function renderMtQuizPanel() {
+    if (!mtQuiz.active) return '';
+    const isZh = getLocale() === 'zh';
+    const rel = getRelation();
+    const relName = isZh ? rel.nameZh : rel.name;
+    if (mtQuiz.phase === 'graded') {
+      const correct = mtQuiz.autoResults ? mtQuiz.autoResults.filter((r) => r.holds).length : 0;
+      const userAns = parseInt(mtQuiz.answer, 10);
+      const ok = userAns === correct;
+      return `
+        <div class="quiz-panel" data-testid="mt-quiz-panel">
+          <div class="quiz-header">
+            <span>${t('quiz.mt.title')}</span>
+            <button type="button" class="quiz-close-btn" data-testid="mt-quiz-close">✕</button>
+          </div>
+          <p class="quiz-prompt">${t('quiz.mt.prompt', { rel: escapeHtml(relName) })}</p>
+          <p class="quiz-score ${ok ? 'quiz-score--perfect' : 'quiz-score--wrong'}">
+            ${ok ? t('quiz.graph.perfect') : ''}
+            ${t('quiz.mt.answer', { count: correct })}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="mt-quiz-reset">${t('quiz.retry')}</button>
+        </div>
+      `;
+    }
+    return `
+      <div class="quiz-panel" data-testid="mt-quiz-panel">
+        <div class="quiz-header">
+          <span>${t('quiz.mt.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="mt-quiz-close">✕</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.mt.prompt', { rel: escapeHtml(relName) })}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            ${t('quiz.mt.label')}
+            <input type="number" min="0" max="8" class="quiz-input" data-testid="mt-quiz-input" value="${escapeHtml(mtQuiz.answer)}" />
+          </label>
+        </div>
+        <button type="button" class="quiz-start-btn" data-testid="mt-quiz-check">${t('quiz.check')}</button>
+      </div>
+    `;
+  }
+
   function getExample() {
     return metamorphicExamples.find((e) => e.id === state.exampleId) ?? metamorphicExamples[0];
   }
@@ -76,12 +120,15 @@ export function createMetamorphicTestingExplorer() {
             <div class="mt-mr-header">
               <span class="mt-mr-name">${isZh ? rel.nameZh : rel.name}</span>
               <code class="mt-mr-formula">${escapeHtml(rel.formula)}</code>
+              ${!mtQuiz.active ? `<button type="button" class="quiz-start-btn" data-testid="mt-quiz-start">${t('quiz.start')}</button>` : ''}
             </div>
             <p class="mt-mr-desc">${isZh ? rel.descZh : rel.desc}</p>
             <button type="button" class="mt-generate-btn" data-testid="mt-generate">
               ${t('mt.generate')}
             </button>
           </div>
+
+          ${renderMtQuizPanel()}
 
           <div class="mt-results" data-testid="mt-results">
             ${state.results ? renderResults(state.results) : `<p class="mt-hint">${t('mt.hint')}</p>`}
@@ -141,6 +188,7 @@ export function createMetamorphicTestingExplorer() {
         const ex = getExample();
         state.relationId = ex.relations[0].id;
         state.results = null;
+        mtQuiz.active = false;
         render();
       });
     });
@@ -149,6 +197,7 @@ export function createMetamorphicTestingExplorer() {
       btn.addEventListener('click', () => {
         state.relationId = btn.dataset.rel;
         state.results = null;
+        mtQuiz.active = false;
         render();
       });
     });
@@ -161,6 +210,43 @@ export function createMetamorphicTestingExplorer() {
         state.results = generateMrTests(ex, rel, 8);
         const resultsEl = root.querySelector('[data-testid="mt-results"]');
         if (resultsEl) resultsEl.innerHTML = renderResults(state.results);
+      });
+    }
+
+    const mqStart = root.querySelector('[data-testid="mt-quiz-start"]');
+    if (mqStart) {
+      mqStart.addEventListener('click', () => {
+        const ex = getExample();
+        const rel = getRelation();
+        mtQuiz.autoResults = generateMrTests(ex, rel, 8);
+        mtQuiz.active = true;
+        mtQuiz.phase = 'question';
+        mtQuiz.answer = '';
+        render();
+      });
+    }
+    const mqClose = root.querySelector('[data-testid="mt-quiz-close"]');
+    if (mqClose) {
+      mqClose.addEventListener('click', () => { mtQuiz.active = false; render(); });
+    }
+    const mqCheck = root.querySelector('[data-testid="mt-quiz-check"]');
+    if (mqCheck) {
+      mqCheck.addEventListener('click', () => {
+        const inp = root.querySelector('[data-testid="mt-quiz-input"]');
+        mtQuiz.answer = inp ? inp.value : '';
+        mtQuiz.phase = 'graded';
+        render();
+      });
+    }
+    const mqReset = root.querySelector('[data-testid="mt-quiz-reset"]');
+    if (mqReset) {
+      mqReset.addEventListener('click', () => {
+        const ex = getExample();
+        const rel = getRelation();
+        mtQuiz.autoResults = generateMrTests(ex, rel, 8);
+        mtQuiz.phase = 'question';
+        mtQuiz.answer = '';
+        render();
       });
     }
   }

--- a/src/components/SyntaxCoverageExplorer.js
+++ b/src/components/SyntaxCoverageExplorer.js
@@ -152,6 +152,47 @@ export function createSyntaxCoverageExplorer() {
     pushToCloud();
   }
 
+  const syntaxQuiz = { active: false, phase: 'question', answer: '', result: null };
+
+  function renderSyntaxQuizPanel() {
+    if (!syntaxQuiz.active) return '';
+    if (syntaxQuiz.phase === 'graded') {
+      const correct = state.score.killed;
+      const userAns = parseInt(syntaxQuiz.answer, 10);
+      const ok = userAns === correct;
+      return `
+        <div class="quiz-panel" data-testid="syntax-quiz-panel">
+          <div class="quiz-header">
+            <span>${t('quiz.syntax.title')}</span>
+            <button type="button" class="quiz-close-btn" data-testid="syntax-quiz-close">✕</button>
+          </div>
+          <p class="quiz-prompt">${t('quiz.syntax.prompt', { program: escapeHtml(state.exampleId) })}</p>
+          <p class="quiz-score ${ok ? 'quiz-score--perfect' : 'quiz-score--wrong'}">
+            ${ok ? t('quiz.graph.perfect') : ''}
+            ${t('quiz.syntax.answer', { killed: correct, total: state.score.total })}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="syntax-quiz-reset">${t('quiz.retry')}</button>
+        </div>
+      `;
+    }
+    return `
+      <div class="quiz-panel" data-testid="syntax-quiz-panel">
+        <div class="quiz-header">
+          <span>${t('quiz.syntax.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="syntax-quiz-close">✕</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.syntax.prompt', { program: escapeHtml(state.exampleId) })}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            ${t('quiz.syntax.label')}
+            <input type="number" min="0" class="quiz-input" data-testid="syntax-quiz-input" value="${escapeHtml(syntaxQuiz.answer)}" />
+          </label>
+        </div>
+        <button type="button" class="quiz-start-btn" data-testid="syntax-quiz-check">${t('quiz.check')}</button>
+      </div>
+    `;
+  }
+
   let saveTimer = null;
   let pendingSave = null;
   function pushToCloud() {
@@ -495,7 +536,10 @@ export function createSyntaxCoverageExplorer() {
           live <strong>${state.score.live}</strong>
           <span class="syntax-divider">·</span>
           equivalent <strong>${state.score.equivalent}</strong>
+          <span class="syntax-divider">·</span>
+          ${!syntaxQuiz.active ? `<button type="button" class="quiz-start-btn" data-testid="syntax-quiz-start">${t('quiz.start')}</button>` : ''}
         </p>
+        ${renderSyntaxQuizPanel()}
       </section>
 
       <section class="syntax-mutant-section">
@@ -619,6 +663,39 @@ export function createSyntaxCoverageExplorer() {
         render();
       });
     });
+
+    const sqStart = root.querySelector('[data-testid="syntax-quiz-start"]');
+    if (sqStart) {
+      sqStart.addEventListener('click', () => {
+        syntaxQuiz.active = true;
+        syntaxQuiz.phase = 'question';
+        syntaxQuiz.answer = '';
+        syntaxQuiz.result = null;
+        render();
+      });
+    }
+    const sqClose = root.querySelector('[data-testid="syntax-quiz-close"]');
+    if (sqClose) {
+      sqClose.addEventListener('click', () => { syntaxQuiz.active = false; render(); });
+    }
+    const sqCheck = root.querySelector('[data-testid="syntax-quiz-check"]');
+    if (sqCheck) {
+      sqCheck.addEventListener('click', () => {
+        const inp = root.querySelector('[data-testid="syntax-quiz-input"]');
+        syntaxQuiz.answer = inp ? inp.value : '';
+        syntaxQuiz.phase = 'graded';
+        render();
+      });
+    }
+    const sqReset = root.querySelector('[data-testid="syntax-quiz-reset"]');
+    if (sqReset) {
+      sqReset.addEventListener('click', () => {
+        syntaxQuiz.phase = 'question';
+        syntaxQuiz.answer = '';
+        syntaxQuiz.result = null;
+        render();
+      });
+    }
   }
 
   render();

--- a/src/components/TestDoublesExplorer.js
+++ b/src/components/TestDoublesExplorer.js
@@ -536,6 +536,43 @@ assert(callLog.filter(c => c.method === 'warn').length === 1);`,
 };
 
 // ---------------------------------------------------------------------------
+// Quiz scenarios — ask user to pick the right double type
+// ---------------------------------------------------------------------------
+
+const TD_QUIZ_SCENARIOS = [
+  {
+    id: 'qs1',
+    correct: 'stub',
+    descEn: 'Your SUT calls a remote weather API to get current temperature. You want to test the SUT with a fixed return value without hitting the network.',
+    descZh: '您的 SUT 呼叫遠端天氣 API 取得目前溫度。您想在不連網的情況下，以固定回傳值測試 SUT。',
+  },
+  {
+    id: 'qs2',
+    correct: 'mock',
+    descEn: 'You want to verify that when a user is deleted, an audit log service is called exactly once with the correct user ID.',
+    descZh: '您要驗證當使用者被刪除時，稽核日誌服務必須被呼叫恰好一次，且帶有正確的使用者 ID。',
+  },
+  {
+    id: 'qs3',
+    correct: 'fake',
+    descEn: 'Your SUT requires a database-backed user repository. You want a full working implementation that avoids hitting a real database during unit tests.',
+    descZh: '您的 SUT 需要資料庫支持的使用者儲存庫。您需要一個功能完整、但不連接真實資料庫的替代實作。',
+  },
+  {
+    id: 'qs4',
+    correct: 'spy',
+    descEn: 'You want to use the real email service implementation in your test, but also record every call so you can assert on call counts afterward.',
+    descZh: '您想在測試中使用真正的 Email 服務實作，同時記錄每次呼叫，以便事後斷言呼叫次數。',
+  },
+  {
+    id: 'qs5',
+    correct: 'dummy',
+    descEn: 'Your SUT requires a logger object in its constructor but never actually calls it during the code path you are testing.',
+    descZh: '您的 SUT 建構式需要一個 logger 物件，但在您測試的程式路徑中從不呼叫它。',
+  },
+];
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -548,6 +585,58 @@ export function createTestDoublesExplorer() {
     scenarioId: 'order',
     result: null,
   };
+
+  let tdQuizScenarioIdx = 0;
+  const tdQuiz = { active: false, phase: 'question', selected: '', result: null };
+
+  function renderTdQuizPanel() {
+    if (!tdQuiz.active) return '';
+    const isZh = getLocale() === 'zh';
+    const qs = TD_QUIZ_SCENARIOS[tdQuizScenarioIdx];
+    const desc = isZh ? qs.descZh : qs.descEn;
+
+    if (tdQuiz.phase === 'graded') {
+      const ok = tdQuiz.selected === qs.correct;
+      return `
+        <div class="quiz-panel" data-testid="td-quiz-panel">
+          <div class="quiz-header">
+            <span>${t('quiz.td.title')}</span>
+            <button type="button" class="quiz-close-btn" data-testid="td-quiz-close">✕</button>
+          </div>
+          <p class="quiz-prompt">${escapeHtml(desc)}</p>
+          <p class="quiz-score ${ok ? 'quiz-score--perfect' : 'quiz-score--wrong'}">
+            ${ok ? t('quiz.graph.perfect') : ''}
+            ${t('quiz.td.answer', { correct: qs.correct })}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="td-quiz-reset">${t('quiz.retry')}</button>
+        </div>
+      `;
+    }
+
+    const typeButtons = DOUBLE_TYPES.map((d) => `
+      <button type="button"
+        class="td-type-btn${tdQuiz.selected === d.id ? ' active' : ''}"
+        data-testid="td-quiz-choice-${d.id}"
+        data-quiz-choice="${d.id}"
+        style="--td-color:${d.color}"
+      >
+        <span class="td-type-dot"></span>
+        <span class="td-type-name">${t(`td.type.${d.id}`)}</span>
+      </button>
+    `).join('');
+
+    return `
+      <div class="quiz-panel" data-testid="td-quiz-panel">
+        <div class="quiz-header">
+          <span>${t('quiz.td.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="td-quiz-close">✕</button>
+        </div>
+        <p class="quiz-prompt">${escapeHtml(desc)}</p>
+        <div class="td-type-list" style="margin:0.5rem 0">${typeButtons}</div>
+        <button type="button" class="quiz-start-btn" data-testid="td-quiz-check" ${!tdQuiz.selected ? 'disabled' : ''}>${t('quiz.check')}</button>
+      </div>
+    `;
+  }
 
   function getType() {
     return DOUBLE_TYPES.find((d) => d.id === state.typeId) ?? DOUBLE_TYPES[0];
@@ -698,7 +787,10 @@ export function createTestDoublesExplorer() {
             <button type="button" class="td-run-btn" data-testid="td-run">
               ▶ ${t('td.run')}
             </button>
+            ${!tdQuiz.active ? `<button type="button" class="quiz-start-btn" data-testid="td-quiz-start">${t('quiz.start')}</button>` : ''}
           </div>
+
+          ${renderTdQuizPanel()}
 
           <!-- Results -->
           <div class="td-result-panel" data-testid="td-result">
@@ -743,6 +835,50 @@ export function createTestDoublesExplorer() {
         }
         const panel = root.querySelector('[data-testid="td-result"]');
         if (panel) panel.innerHTML = renderResult(state.result);
+      });
+    }
+
+    const tqStart = root.querySelector('[data-testid="td-quiz-start"]');
+    if (tqStart) {
+      tqStart.addEventListener('click', () => {
+        tdQuizScenarioIdx = Math.floor(Math.random() * TD_QUIZ_SCENARIOS.length);
+        tdQuiz.active = true;
+        tdQuiz.phase = 'question';
+        tdQuiz.selected = '';
+        tdQuiz.result = null;
+        render();
+      });
+    }
+    const tqClose = root.querySelector('[data-testid="td-quiz-close"]');
+    if (tqClose) {
+      tqClose.addEventListener('click', () => { tdQuiz.active = false; render(); });
+    }
+    root.querySelectorAll('[data-quiz-choice]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        tdQuiz.selected = btn.dataset.quizChoice;
+        const panel = root.querySelector('[data-testid="td-quiz-panel"]');
+        if (panel) {
+          root.querySelectorAll('[data-quiz-choice]').forEach((b) => b.classList.toggle('active', b.dataset.quizChoice === tdQuiz.selected));
+          const checkBtn = root.querySelector('[data-testid="td-quiz-check"]');
+          if (checkBtn) checkBtn.disabled = false;
+        }
+      });
+    });
+    const tqCheck = root.querySelector('[data-testid="td-quiz-check"]');
+    if (tqCheck) {
+      tqCheck.addEventListener('click', () => {
+        tdQuiz.phase = 'graded';
+        render();
+      });
+    }
+    const tqReset = root.querySelector('[data-testid="td-quiz-reset"]');
+    if (tqReset) {
+      tqReset.addEventListener('click', () => {
+        tdQuizScenarioIdx = (tdQuizScenarioIdx + 1) % TD_QUIZ_SCENARIOS.length;
+        tdQuiz.phase = 'question';
+        tdQuiz.selected = '';
+        tdQuiz.result = null;
+        render();
       });
     }
   }

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -248,6 +248,22 @@ export const messages = {
     'quiz.st.prompt': 'Using "{mode}", how many test cases does the current state machine require?',
     'quiz.st.label': 'Number of test cases',
 
+    // Quiz — Syntax / Mutation
+    'quiz.syntax.title': 'Mutation Testing Self-Test',
+    'quiz.syntax.prompt': 'Program: "{program}". How many mutants does the current test suite kill?',
+    'quiz.syntax.label': 'Killed mutants',
+    'quiz.syntax.answer': 'Answer: {killed} killed out of {total} mutants.',
+
+    // Quiz — Metamorphic Testing
+    'quiz.mt.title': 'Metamorphic Testing Self-Test',
+    'quiz.mt.prompt': 'For relation "{rel}", how many of the 8 generated test pairs hold?',
+    'quiz.mt.label': 'Test pairs that hold (out of 8)',
+    'quiz.mt.answer': 'Answer: {count} out of 8 pairs hold.',
+
+    // Quiz — Test Doubles
+    'quiz.td.title': 'Test Doubles Self-Test',
+    'quiz.td.answer': 'The best fit is: {correct}.',
+
     'section.flow': 'Testing Flow',
     'section.types': 'Testing Types',
     'section.methods.title': 'Testing Method Categories',
@@ -977,6 +993,19 @@ export const messages = {
     'quiz.st.title': '狀態轉移 自我測驗',
     'quiz.st.prompt': '使用「{mode}」模式，目前的狀態機需要幾個測試案例？',
     'quiz.st.label': '測試案例數',
+
+    'quiz.syntax.title': 'Mutation Testing 自我測驗',
+    'quiz.syntax.prompt': '程式："{program}"。目前測試套件可以殺死幾個突變體？',
+    'quiz.syntax.label': '被殺死的突變體數',
+    'quiz.syntax.answer': '答案：共 {total} 個突變體，{killed} 個被殺死。',
+
+    'quiz.mt.title': '變形測試 自我測驗',
+    'quiz.mt.prompt': '對於變形關係「{rel}」，8 對生成的測試案例中有幾對成立？',
+    'quiz.mt.label': '成立的測試對數（共 8 對）',
+    'quiz.mt.answer': '答案：8 對中有 {count} 對成立。',
+
+    'quiz.td.title': '測試替身 自我測驗',
+    'quiz.td.answer': '最適合的替身類型是：{correct}。',
 
     'section.flow': '測試流程',
     'section.types': '測試類型',


### PR DESCRIPTION
## Summary

- Quiz panels for the three medium-priority explorers in Plan.md D1
- All 346 unit tests pass

| Explorer | Quiz |
|---|---|
| SyntaxCoverageExplorer | Killed-mutant count for current test suite |
| MetamorphicTestingExplorer | Hold-count from auto-generated 8 test pairs |
| TestDoublesExplorer | Multiple-choice double-type selection (5 curated scenarios) |

## i18n

ZH-TW and EN keys added for `quiz.syntax.*`, `quiz.mt.*`, `quiz.td.*`.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)