### PR TITLE
feat(quiz): self-test mode for Symbolic, Concolic, and Fuzz Testing explorers

### DIFF
--- a/src/components/ConcolicExecutionExplorer.js
+++ b/src/components/ConcolicExecutionExplorer.js
@@ -75,6 +75,47 @@ export function createConcolicExecutionExplorer() {
     error: null,
   };
 
+  const concolicQuiz = { active: false, phase: 'question', answer: '', result: null };
+
+  function renderConcolicQuizPanel() {
+    if (!concolicQuiz.active) return '';
+    if (concolicQuiz.phase === 'graded') {
+      const correct = state.result ? state.result.uniquePathCount : 0;
+      const userAns = parseInt(concolicQuiz.answer, 10);
+      const ok = userAns === correct;
+      return `
+        <div class="quiz-panel" data-testid="concolic-quiz-panel">
+          <div class="quiz-header">
+            <span>${t('quiz.concolic.title')}</span>
+            <button type="button" class="quiz-close-btn" data-testid="concolic-quiz-close">✕</button>
+          </div>
+          <p class="quiz-prompt">${t('quiz.concolic.prompt')}</p>
+          <p class="quiz-score ${ok ? 'quiz-score--perfect' : 'quiz-score--wrong'}">
+            ${ok ? t('quiz.graph.perfect') : ''}
+            ${t('quiz.concolic.answer', { count: correct })}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="concolic-quiz-reset">${t('quiz.retry')}</button>
+        </div>
+      `;
+    }
+    return `
+      <div class="quiz-panel" data-testid="concolic-quiz-panel">
+        <div class="quiz-header">
+          <span>${t('quiz.concolic.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="concolic-quiz-close">✕</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.concolic.prompt')}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            ${t('quiz.concolic.label')}
+            <input type="number" min="0" class="quiz-input" data-testid="concolic-quiz-input" value="${escapeHtml(concolicQuiz.answer)}" />
+          </label>
+        </div>
+        <button type="button" class="quiz-start-btn" data-testid="concolic-quiz-check">${t('quiz.check')}</button>
+      </div>
+    `;
+  }
+
   function recompute() {
     state.result = null;
     state.error = null;
@@ -187,7 +228,11 @@ export function createConcolicExecutionExplorer() {
           <header class="concolic-panel-header">
             <h3>${t('explorer.panel.results')}</h3>
           </header>
-          <p class="concolic-summary" data-testid="concolic-summary">${summary}</p>
+          <p class="concolic-summary" data-testid="concolic-summary">
+            ${summary}
+            ${!concolicQuiz.active ? `<button type="button" class="quiz-start-btn" data-testid="concolic-quiz-start" style="margin-left:0.5rem">${t('quiz.start')}</button>` : ''}
+          </p>
+          ${renderConcolicQuizPanel()}
           ${body}
         </section>
       </div>
@@ -309,6 +354,7 @@ export function createConcolicExecutionExplorer() {
         state.sourceCode = ex.sourceCode;
         state.seedText = ex.seed || '';
         state.selectedIterId = null;
+        concolicQuiz.active = false;
         render();
       });
     });
@@ -367,6 +413,35 @@ export function createConcolicExecutionExplorer() {
         render();
       });
     });
+
+    const cqStart = root.querySelector('[data-testid="concolic-quiz-start"]');
+    if (cqStart) {
+      cqStart.addEventListener('click', () => {
+        concolicQuiz.active = true;
+        concolicQuiz.phase = 'question';
+        concolicQuiz.answer = '';
+        render();
+      });
+    }
+    const cqClose = root.querySelector('[data-testid="concolic-quiz-close"]');
+    if (cqClose) { cqClose.addEventListener('click', () => { concolicQuiz.active = false; render(); }); }
+    const cqCheck = root.querySelector('[data-testid="concolic-quiz-check"]');
+    if (cqCheck) {
+      cqCheck.addEventListener('click', () => {
+        const inp = root.querySelector('[data-testid="concolic-quiz-input"]');
+        concolicQuiz.answer = inp ? inp.value : '';
+        concolicQuiz.phase = 'graded';
+        render();
+      });
+    }
+    const cqReset = root.querySelector('[data-testid="concolic-quiz-reset"]');
+    if (cqReset) {
+      cqReset.addEventListener('click', () => {
+        concolicQuiz.phase = 'question';
+        concolicQuiz.answer = '';
+        render();
+      });
+    }
   }
 
   function renderPreservingFocus(testid) {

--- a/src/components/FuzzTestingExplorer.js
+++ b/src/components/FuzzTestingExplorer.js
@@ -65,6 +65,49 @@ export function createFuzzTestingExplorer() {
     totalEdges: 0,
   };
 
+  const fuzzQuiz = { active: false, phase: 'question', answer: '', result: null };
+
+  function renderFuzzQuizPanel() {
+    if (!fuzzQuiz.active) return '';
+    const nodeCov = state.totalNodes > 0
+      ? Math.round((state.coveredNodes.length / state.totalNodes) * 100)
+      : 0;
+    if (fuzzQuiz.phase === 'graded') {
+      const userAns = parseInt(fuzzQuiz.answer, 10);
+      const ok = userAns === nodeCov;
+      return `
+        <div class="quiz-panel" data-testid="fuzz-quiz-panel">
+          <div class="quiz-header">
+            <span>${t('quiz.fuzz.title')}</span>
+            <button type="button" class="quiz-close-btn" data-testid="fuzz-quiz-close">✕</button>
+          </div>
+          <p class="quiz-prompt">${t('quiz.fuzz.prompt')}</p>
+          <p class="quiz-score ${ok ? 'quiz-score--perfect' : 'quiz-score--wrong'}">
+            ${ok ? t('quiz.graph.perfect') : ''}
+            ${t('quiz.fuzz.answer', { pct: nodeCov })}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="fuzz-quiz-reset">${t('quiz.retry')}</button>
+        </div>
+      `;
+    }
+    return `
+      <div class="quiz-panel" data-testid="fuzz-quiz-panel">
+        <div class="quiz-header">
+          <span>${t('quiz.fuzz.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="fuzz-quiz-close">✕</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.fuzz.prompt')}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            ${t('quiz.fuzz.label')}
+            <input type="number" min="0" max="100" class="quiz-input" data-testid="fuzz-quiz-input" value="${escapeHtml(fuzzQuiz.answer)}" />
+          </label>
+        </div>
+        <button type="button" class="quiz-start-btn" data-testid="fuzz-quiz-check">${t('quiz.check')}</button>
+      </div>
+    `;
+  }
+
   function recompute() {
     state.result = null;
     state.cfg = null;
@@ -213,7 +256,11 @@ export function createFuzzTestingExplorer() {
           <header class="fuzz-panel-header">
             <h3>${t('explorer.panel.results')}</h3>
           </header>
-          <p class="fuzz-summary" data-testid="fuzz-summary">${summary}</p>
+          <p class="fuzz-summary" data-testid="fuzz-summary">
+            ${summary}
+            ${!fuzzQuiz.active && state.result ? `<button type="button" class="quiz-start-btn" data-testid="fuzz-quiz-start" style="margin-left:0.5rem">${t('quiz.start')}</button>` : ''}
+          </p>
+          ${renderFuzzQuizPanel()}
           ${testCasesMarkup}
         </section>
       </div>
@@ -340,6 +387,7 @@ export function createFuzzTestingExplorer() {
         state.exampleId = ex.id;
         state.sourceCode = ex.sourceCode;
         state.selectedCaseId = null;
+        fuzzQuiz.active = false;
         render();
       });
     });
@@ -402,6 +450,35 @@ export function createFuzzTestingExplorer() {
         render();
       });
     });
+
+    const fqStart = root.querySelector('[data-testid="fuzz-quiz-start"]');
+    if (fqStart) {
+      fqStart.addEventListener('click', () => {
+        fuzzQuiz.active = true;
+        fuzzQuiz.phase = 'question';
+        fuzzQuiz.answer = '';
+        render();
+      });
+    }
+    const fqClose = root.querySelector('[data-testid="fuzz-quiz-close"]');
+    if (fqClose) { fqClose.addEventListener('click', () => { fuzzQuiz.active = false; render(); }); }
+    const fqCheck = root.querySelector('[data-testid="fuzz-quiz-check"]');
+    if (fqCheck) {
+      fqCheck.addEventListener('click', () => {
+        const inp = root.querySelector('[data-testid="fuzz-quiz-input"]');
+        fuzzQuiz.answer = inp ? inp.value : '';
+        fuzzQuiz.phase = 'graded';
+        render();
+      });
+    }
+    const fqReset = root.querySelector('[data-testid="fuzz-quiz-reset"]');
+    if (fqReset) {
+      fqReset.addEventListener('click', () => {
+        fuzzQuiz.phase = 'question';
+        fuzzQuiz.answer = '';
+        render();
+      });
+    }
   }
 
   function renderPreservingFocus(testid) {

--- a/src/components/SymbolicExecutionExplorer.js
+++ b/src/components/SymbolicExecutionExplorer.js
@@ -58,6 +58,47 @@ export function createSymbolicExecutionExplorer() {
     error: null,
   };
 
+  const symbexQuiz = { active: false, phase: 'question', answer: '', result: null };
+
+  function renderSymbexQuizPanel() {
+    if (!symbexQuiz.active) return '';
+    if (symbexQuiz.phase === 'graded') {
+      const correct = state.result ? state.result.paths.filter((p) => p.feasible).length : 0;
+      const userAns = parseInt(symbexQuiz.answer, 10);
+      const ok = userAns === correct;
+      return `
+        <div class="quiz-panel" data-testid="symbex-quiz-panel">
+          <div class="quiz-header">
+            <span>${t('quiz.symbex.title')}</span>
+            <button type="button" class="quiz-close-btn" data-testid="symbex-quiz-close">✕</button>
+          </div>
+          <p class="quiz-prompt">${t('quiz.symbex.prompt')}</p>
+          <p class="quiz-score ${ok ? 'quiz-score--perfect' : 'quiz-score--wrong'}">
+            ${ok ? t('quiz.graph.perfect') : ''}
+            ${t('quiz.symbex.answer', { count: correct })}
+          </p>
+          <button type="button" class="quiz-start-btn" data-testid="symbex-quiz-reset">${t('quiz.retry')}</button>
+        </div>
+      `;
+    }
+    return `
+      <div class="quiz-panel" data-testid="symbex-quiz-panel">
+        <div class="quiz-header">
+          <span>${t('quiz.symbex.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="symbex-quiz-close">✕</button>
+        </div>
+        <p class="quiz-prompt">${t('quiz.symbex.prompt')}</p>
+        <div class="quiz-bva-inputs">
+          <label class="quiz-bva-field">
+            ${t('quiz.symbex.label')}
+            <input type="number" min="0" class="quiz-input" data-testid="symbex-quiz-input" value="${escapeHtml(symbexQuiz.answer)}" />
+          </label>
+        </div>
+        <button type="button" class="quiz-start-btn" data-testid="symbex-quiz-check">${t('quiz.check')}</button>
+      </div>
+    `;
+  }
+
   function recompute() {
     state.result = null;
     state.error = null;
@@ -162,7 +203,11 @@ export function createSymbolicExecutionExplorer() {
           <header class="symbex-panel-header">
             <h3>${t('explorer.panel.results')}</h3>
           </header>
-          <p class="symbex-summary" data-testid="symbex-summary">${summary}</p>
+          <p class="symbex-summary" data-testid="symbex-summary">
+            ${summary}
+            ${!symbexQuiz.active ? `<button type="button" class="quiz-start-btn" data-testid="symbex-quiz-start" style="margin-left:0.5rem">${t('quiz.start')}</button>` : ''}
+          </p>
+          ${renderSymbexQuizPanel()}
           ${pathsMarkup}
         </section>
       </div>
@@ -262,6 +307,7 @@ export function createSymbolicExecutionExplorer() {
         state.exampleId = ex.id;
         state.sourceCode = ex.sourceCode;
         state.selectedPathId = null;
+        symbexQuiz.active = false;
         render();
       });
     });
@@ -312,6 +358,35 @@ export function createSymbolicExecutionExplorer() {
         render();
       });
     });
+
+    const sqStart = root.querySelector('[data-testid="symbex-quiz-start"]');
+    if (sqStart) {
+      sqStart.addEventListener('click', () => {
+        symbexQuiz.active = true;
+        symbexQuiz.phase = 'question';
+        symbexQuiz.answer = '';
+        render();
+      });
+    }
+    const sqClose = root.querySelector('[data-testid="symbex-quiz-close"]');
+    if (sqClose) { sqClose.addEventListener('click', () => { symbexQuiz.active = false; render(); }); }
+    const sqCheck = root.querySelector('[data-testid="symbex-quiz-check"]');
+    if (sqCheck) {
+      sqCheck.addEventListener('click', () => {
+        const inp = root.querySelector('[data-testid="symbex-quiz-input"]');
+        symbexQuiz.answer = inp ? inp.value : '';
+        symbexQuiz.phase = 'graded';
+        render();
+      });
+    }
+    const sqReset = root.querySelector('[data-testid="symbex-quiz-reset"]');
+    if (sqReset) {
+      sqReset.addEventListener('click', () => {
+        symbexQuiz.phase = 'question';
+        symbexQuiz.answer = '';
+        render();
+      });
+    }
   }
 
   function renderPreservingFocus(testid) {

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -264,6 +264,24 @@ export const messages = {
     'quiz.td.title': 'Test Doubles Self-Test',
     'quiz.td.answer': 'The best fit is: {correct}.',
 
+    // Quiz — Symbolic Execution
+    'quiz.symbex.title': 'Symbolic Execution Self-Test',
+    'quiz.symbex.prompt': 'How many feasible paths does symbolic execution find for the current program?',
+    'quiz.symbex.label': 'Feasible paths',
+    'quiz.symbex.answer': 'Answer: {count} feasible path(s).',
+
+    // Quiz — Concolic Execution
+    'quiz.concolic.title': 'Concolic Execution Self-Test',
+    'quiz.concolic.prompt': 'How many unique paths does concolic execution discover for the current program?',
+    'quiz.concolic.label': 'Unique paths',
+    'quiz.concolic.answer': 'Answer: {count} unique path(s).',
+
+    // Quiz — Fuzz Testing
+    'quiz.fuzz.title': 'Fuzz Testing Self-Test',
+    'quiz.fuzz.prompt': 'After running the fuzzer, what is the node coverage percentage?',
+    'quiz.fuzz.label': 'Node coverage (%)',
+    'quiz.fuzz.answer': 'Answer: {pct}% node coverage.',
+
     'section.flow': 'Testing Flow',
     'section.types': 'Testing Types',
     'section.methods.title': 'Testing Method Categories',
@@ -1006,6 +1024,21 @@ export const messages = {
 
     'quiz.td.title': '測試替身 自我測驗',
     'quiz.td.answer': '最適合的替身類型是：{correct}。',
+
+    'quiz.symbex.title': '符號執行 自我測驗',
+    'quiz.symbex.prompt': '對於目前的程式，符號執行找到幾條可行路徑？',
+    'quiz.symbex.label': '可行路徑數',
+    'quiz.symbex.answer': '答案：{count} 條可行路徑。',
+
+    'quiz.concolic.title': 'Concolic 執行 自我測驗',
+    'quiz.concolic.prompt': '對於目前的程式，Concolic 執行共發現幾條不重複路徑？',
+    'quiz.concolic.label': '不重複路徑數',
+    'quiz.concolic.answer': '答案：{count} 條不重複路徑。',
+
+    'quiz.fuzz.title': 'Fuzz Testing 自我測驗',
+    'quiz.fuzz.prompt': '執行模糊測試後，節點覆蓋率為幾 %？',
+    'quiz.fuzz.label': '節點覆蓋率（%）',
+    'quiz.fuzz.answer': '答案：節點覆蓋率 {pct}%。',
 
     'section.flow': '測試流程',
     'section.types': '測試類型',


### PR DESCRIPTION
## Summary

- Quiz panels for the three low-priority explorers in Plan.md D1
- All 346 unit tests pass

| Explorer | Quiz |
|---|---|
| SymbolicExecutionExplorer | Feasible path count |
| ConcolicExecutionExplorer | Unique path count |
| FuzzTestingExplorer | Node coverage % (available after first fuzz run) |

## i18n

ZH-TW and EN keys added for `quiz.symbex.*`, `quiz.concolic.*`, `quiz.fuzz.*`.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)