### PR TITLE
fix(flow): stop stepAppear animation replaying on every timer tick

### DIFF
--- a/src/components/TestingFlow.js
+++ b/src/components/TestingFlow.js
@@ -13,15 +13,84 @@ export function createTestingFlow() {
       clearInterval(timerId);
       timerId = null;
     }
-
     if (isPlaying) {
       timerId = window.setInterval(() => {
         activeStep = (activeStep + 1) % testingFlow.length;
-        render();
+        updateState();
       }, 1800);
     }
   }
 
+  // Lightweight update — patches classes/text without touching the DOM structure.
+  // Called by the timer and by mouse/click handlers so the stepAppear animation
+  // never replays unintentionally.
+  function updateState() {
+    const playBtn = root.querySelector('[data-testid="flow-play-btn"]');
+    if (playBtn) {
+      playBtn.className = `flow-play-btn${isPlaying ? ' playing' : ''}`;
+      playBtn.setAttribute('aria-label', isPlaying ? t('flow.pause') : t('flow.play'));
+      playBtn.innerHTML = isPlaying ? `⏸ ${t('flow.pause')}` : `▶ ${t('flow.play')}`;
+    }
+
+    root.querySelectorAll('[data-step-index]').forEach((el) => {
+      const idx = Number(el.dataset.stepIndex);
+      const step = testingFlow[idx];
+      const isActive = idx === activeStep;
+      const isHovered = idx === hoveredStep;
+
+      el.className = [
+        'flow-step',
+        isActive ? 'flow-step--active' : '',
+        isHovered ? 'flow-step--hovered' : '',
+      ].filter(Boolean).join(' ');
+      el.setAttribute('aria-label', t('flow.step', { n: idx + 1, label: pickField(step, 'label') }));
+
+      const labelEl = el.querySelector('.flow-step-label');
+      if (labelEl) labelEl.textContent = pickField(step, 'label');
+      const labelEnEl = el.querySelector('.flow-step-label-en');
+      if (labelEnEl) labelEnEl.textContent = getLocale() === 'zh' ? step.labelEn : '';
+
+      // Add / remove tooltip without replacing the surrounding step element
+      const tooltipId = `flow-tooltip-${step.id}`;
+      let tooltip = el.querySelector(`[data-testid="${tooltipId}"]`);
+      const showTooltip = isActive || isHovered;
+      if (showTooltip && !tooltip) {
+        tooltip = document.createElement('div');
+        tooltip.className = 'flow-step-tooltip';
+        tooltip.dataset.testid = tooltipId;
+        tooltip.textContent = pickField(step, 'description');
+        el.appendChild(tooltip);
+      } else if (!showTooltip && tooltip) {
+        tooltip.remove();
+      } else if (showTooltip && tooltip) {
+        tooltip.textContent = pickField(step, 'description');
+      }
+    });
+
+    root.querySelectorAll('[data-testid^="flow-arrow-"]').forEach((arrow) => {
+      const idx = Number(arrow.dataset.testid.replace('flow-arrow-', ''));
+      arrow.className = [
+        'flow-arrow',
+        activeStep > idx ? 'flow-arrow--passed' : '',
+        activeStep === idx ? 'flow-arrow--active' : '',
+      ].filter(Boolean).join(' ');
+    });
+
+    const fill = root.querySelector('[data-testid="flow-progress-fill"]');
+    if (fill) fill.style.width = `${((activeStep + 1) / testingFlow.length) * 100}%`;
+    const progressLabel = root.querySelector('.flow-progress-label');
+    if (progressLabel) {
+      progressLabel.textContent = t('flow.progress', {
+        current: activeStep + 1,
+        total: testingFlow.length,
+        label: pickField(testingFlow[activeStep], 'label'),
+      });
+    }
+  }
+
+  // Full DOM build — called once on initialization.
+  // Recreating innerHTML would retrigger the stepAppear CSS animation on every tick,
+  // so subsequent state changes use updateState() instead.
   function render() {
     root.className = 'testing-flow';
     root.dataset.testid = 'testing-flow';
@@ -81,7 +150,7 @@ export function createTestingFlow() {
     root.querySelector('[data-testid="flow-play-btn"]').addEventListener('click', () => {
       isPlaying = !isPlaying;
       restartTimer();
-      render();
+      updateState();
     });
 
     root.querySelectorAll('[data-step-index]').forEach((element) => {
@@ -90,17 +159,17 @@ export function createTestingFlow() {
         hoveredStep = stepIndex;
         isPlaying = false;
         restartTimer();
-        render();
+        updateState();
       });
       element.addEventListener('mouseleave', () => {
         hoveredStep = null;
         isPlaying = true;
         restartTimer();
-        render();
+        updateState();
       });
       element.addEventListener('click', () => {
         activeStep = stepIndex;
-        render();
+        updateState();
       });
     });
   }


### PR DESCRIPTION
## Root Cause

`render()` called `root.innerHTML = …` on **every** 1800 ms timer tick,
recreating all step DOM elements from scratch. Because the CSS declares:

```css
.flow-step { animation: stepAppear 0.5s ease forwards; }
```

every newly-created element plays the fade-in/scale-up animation, so
the entire flow track visually flashed and "reset" each cycle — the
"整個亂掉" reported by the user.

## Fix

Split into two functions:

| Function | When called | DOM effect |
|---|---|---|
| `render()` | Once on init | Rebuilds full `root.innerHTML`; attaches event listeners |
| `updateState()` | Timer tick, mouse hover, click | Patches `.className`, text, tooltip presence **in place** |

The `stepAppear` animation now fires only on the initial load, not on
every playback tick. Mouse handlers (mouseenter / mouseleave / click)
also call `updateState()` instead of `render()`, so hovering no longer
rebuilds the DOM either.

## Test plan
- [ ] Play mode: steps advance every 1.8 s without any flash or reset
- [ ] Hover over a step: tooltip appears, playback pauses; leave: resumes
- [ ] Click a step: jumps to that step
- [ ] Pause / Play button toggles correctly
- [ ] 346 unit tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)