### PR TITLE
feat(phase-a): quiz result share links + ResultViewer (F-A1/A2/A5)

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -79,6 +79,85 @@ ExploratoryTestingExplorer、CloudStoragePanel。
 
 ---
 
+### F. Google Classroom 整合 + Self-Test 強化（進行中）
+
+#### 背景與目標
+
+讓老師可以透過 Google Classroom 出作業，學生在工具中完成 **Quiz 模式**（有正確答案、自動批改）或 **Lab 模式**（互動探索 + 反思問題 / 量化指標），再將成績回報給老師。
+
+#### Self-Test 模式定義
+
+| 模式 | 說明 | 批改方式 |
+|------|------|---------|
+| **Quiz** | 給定場景，輸入正確答案（數字、選擇題） | 自動批改，有確定正解 |
+| **Lab — Reflection** | 探索互動後回答 2–3 個反思問題（開放式文字） | 榮譽制，老師閱覽 |
+| **Lab — Metric** | 達成量化指標（如覆蓋率 ≥ 80%、消滅突變體 ≥ N 個） | 自動判定通過/未通過 |
+
+---
+
+#### F-A — Phase A：純前端成績匯出（進行中）
+
+**目標**：不需後端，學生完成 quiz/lab → 產生可分享的結果連結 → 貼到 Classroom 作業留言 → 老師點連結驗證。
+
+**元件**
+
+- `src/utils/resultExporter.js` — 將答題記錄序列化為 Base64 URL 參數
+- `src/components/ResultViewer.js` + CSS — 讀取 URL `?result=` 參數，呈現唯讀成績單
+- 各 Explorer quiz panel 加「📋 分享成績」按鈕（複製連結到剪貼板）
+- Lab — Reflection：在數個 Explorer 加「反思問題」（open-ended 文字輸入），同樣可匯出
+- Lab — Metric：在支援量化指標的 Explorer（Graph/Syntax/Fuzz 等）加「達標紀錄」匯出
+
+**URL 格式**（無後端簽章，榮譽制）
+
+```
+https://site/?result=<base64(JSON)>
+JSON = { v:1, explorer, mode:"quiz"|"lab-reflect"|"lab-metric",
+         ts, lang, items:[{q,a,correct?,score?}], total, passed? }
+```
+
+**限制**：純榮譽制，學生可自行修改連結；Phase B 才加簽章與身份驗證。
+
+**子任務**
+
+- [ ] F-A1：`resultExporter.js` + `ResultViewer` 元件 + i18n + 測試
+- [ ] F-A2：所有現有 Quiz Explorer 加「分享成績」按鈕
+- [ ] F-A3：Lab — Reflection：為 Graph / Logic / Fuzz / Symbex 加反思問題 + 匯出
+- [ ] F-A4：Lab — Metric：Graph（覆蓋率）、Syntax（殺死突變體 %）、Fuzz（節點覆蓋 %）加達標匯出
+- [ ] F-A5：`ResultViewer` 整合進 app 首頁（URL 有 `?result=` 時自動彈出）
+
+---
+
+#### F-B — Phase B：Firebase Auth + Firestore 成績儀表板（待規劃）
+
+**目標**：Google Sign-In（Firebase Auth）+ Firestore 存分數；老師 dashboard 頁面看全班成績。Classroom 作業仍手動建（連結到工具特定 section），但成績追蹤自動化。
+
+**需要新增**
+- Firebase Functions（Node.js）作 OAuth token 管理
+- Firestore 資料結構：`courses/{courseId}/students/{uid}/results/{resultId}`
+- 老師 dashboard：班級成績總覽、個別學生答題明細
+- 學生端：登入後成績自動上傳，不需手動複製連結
+
+**前置條件**：F-A 完成；確認 Firebase Functions 費用與 CI 部署流程
+
+---
+
+#### F-C — Phase C：完整 Google Classroom API 整合（待規劃）
+
+**目標**：老師在工具內一鍵建 Classroom 作業，學生完成後成績自動回寫 Classroom。
+
+**需要新增**
+- Firebase Functions 作 Classroom API OAuth proxy（避免 client secret 暴露）
+- Classroom API scopes：`classroom.coursework.students`、`classroom.rosters.readonly`
+- 作業類型：
+  - Quiz → Google Forms（FormItems API）或 Classroom Link 作業
+  - Lab-Reflect → Classroom 附件（學生填寫後提交）
+  - Lab-Metric → Classroom Link + 工具端自動 POST 成績
+- Google OAuth App 審查（需提交至 Google Cloud Console，審核約 1–4 週）
+
+**前置條件**：F-B 完成；Google Cloud 專案已申請 Classroom API 存取
+
+---
+
 ### D2. 關閉已完成的 GitHub Issues（已執行 2026-05-13）
 
 下列 issue 的對應 PR 均已 merge，已手動關閉：

--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,8 @@ import { createTestDoublesExplorer } from './components/TestDoublesExplorer.js';
 import { createDefectCostExplorer } from './components/DefectCostExplorer.js';
 import { createVModelExplorer } from './components/VModelExplorer.js';
 import { createPyramidAdjusterExplorer } from './components/PyramidAdjusterExplorer.js';
+import { createResultViewer } from './components/ResultViewer.js';
+import { buildShareUrl } from './utils/resultExporter.js';
 import { t, getLocale, setLocale, onLocaleChange } from './i18n/index.js';
 
 const learningSectionsConfig = [
@@ -615,4 +617,32 @@ export function renderApp(container) {
 
   paint();
   onLocaleChange(() => paint());
+
+  // Show ResultViewer if URL contains ?result= (Phase A share link)
+  const viewer = createResultViewer();
+  if (viewer) document.body.appendChild(viewer);
+
+  // Global delegated handler for all quiz share buttons
+  document.body.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-share-payload]');
+    if (!btn) return;
+    const url = buildShareUrl(btn.dataset.sharePayload);
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      const inp = document.createElement('input');
+      inp.value = url;
+      document.body.appendChild(inp);
+      inp.select();
+      document.execCommand('copy');
+      inp.remove();
+    }
+    const orig = btn.innerHTML;
+    btn.innerHTML = t('quiz.share.copied');
+    btn.classList.add('quiz-share-btn--copied');
+    setTimeout(() => {
+      btn.innerHTML = orig;
+      btn.classList.remove('quiz-share-btn--copied');
+    }, 2000);
+  });
 }

--- a/src/components/BoundaryValueExplorer.js
+++ b/src/components/BoundaryValueExplorer.js
@@ -1,5 +1,6 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
 import { generateBvaTests, generateRobustBvaTests } from '../utils/blackboxTesting.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 const STORAGE_KEY = 'stvisual.bva.v1';
 const PARAM_LIMIT = 5;
@@ -140,10 +141,12 @@ export function createBoundaryValueExplorer() {
       </div>`;
     }).join('');
 
+    const bvaLabels = [0, 1, 2, 3, 4].map((i) => t(`quiz.bva.labels.${i}`));
     const scoreRow = isGraded ? `<p class="quiz-score" data-testid="bva-quiz-score">
       ${t('quiz.bva.score').replace('{score}', quiz.result.score)}
       ${quiz.result.score === 5 ? ` <strong>${t('quiz.bva.perfect')}</strong>` : ''}
-    </p>` : '';
+    </p>
+    <button type="button" class="quiz-share-btn" data-share-payload="${encodeResult({ v: 1, explorer: 'bva', explorerLabel: t('quiz.bva.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: quiz.result.score, total: 5, items: [0,1,2,3,4].map((i) => ({ q: bvaLabels[i], a: String(quiz.answers[i]), expected: String(quiz.result.expected[i]), ok: quiz.result.correct[i] })) })}" data-testid="bva-quiz-share">📋 ${t('quiz.share.btn')}</button>` : '';
 
     return `<div class="quiz-panel" data-testid="bva-quiz">
       <div class="quiz-header">

--- a/src/components/ConcolicExecutionExplorer.js
+++ b/src/components/ConcolicExecutionExplorer.js
@@ -1,4 +1,5 @@
 import { t, getLocale, pickField } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import { concolicExecute } from '../utils/concolicExecution.js';
 import { concolicExecutionExamples } from '../data/testingData.js';
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
@@ -83,6 +84,7 @@ export function createConcolicExecutionExplorer() {
       const correct = state.result ? state.result.uniquePathCount : 0;
       const userAns = parseInt(concolicQuiz.answer, 10);
       const ok = userAns === correct;
+      const shareEncoded = encodeResult({ v: 1, explorer: 'concolic', explorerLabel: t('quiz.concolic.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: ok ? 1 : 0, total: 1, items: [{ q: t('quiz.concolic.prompt'), a: String(concolicQuiz.answer), expected: String(correct), ok }] });
       return `
         <div class="quiz-panel" data-testid="concolic-quiz-panel">
           <div class="quiz-header">
@@ -94,6 +96,7 @@ export function createConcolicExecutionExplorer() {
             ${ok ? t('quiz.graph.perfect') : ''}
             ${t('quiz.concolic.answer', { count: correct })}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="concolic-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="concolic-quiz-reset">${t('quiz.retry')}</button>
         </div>
       `;

--- a/src/components/DecisionTableExplorer.js
+++ b/src/components/DecisionTableExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import { generateDecisionTableTests, validateDecisionTable } from '../utils/blackboxTesting.js';
 
 const STORAGE_KEY = 'stvisual.dt.v1';
@@ -144,6 +145,7 @@ export function createDecisionTableExplorer() {
                   .replace('{covered}', validation.covered)
                   .replace('{dup}', validation.duplicate.length)}`}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${encodeResult({ v: 1, explorer: 'dt', explorerLabel: t('quiz.dt.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: (covCorrect ? 1 : 0) + (dupCorrect ? 1 : 0), total: 2, items: [{ q: t('quiz.dt.label.covered'), a: String(dtQuiz.ansCovered), expected: String(validation.covered), ok: covCorrect }, { q: t('quiz.dt.label.dup'), a: String(dtQuiz.ansDup), expected: String(validation.duplicate.length), ok: dupCorrect }] })}" data-testid="dt-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="dt-quiz-reset">${t('quiz.reset')}</button>
         ` : `
           <button type="button" class="quiz-start-btn" data-testid="dt-quiz-check">${t('quiz.check')}</button>

--- a/src/components/EquivalenceClassExplorer.js
+++ b/src/components/EquivalenceClassExplorer.js
@@ -1,5 +1,6 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
 import { generateWectTests, generateSectTests } from '../utils/blackboxTesting.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 const STORAGE_KEY = 'stvisual.ec.v1';
 
@@ -171,6 +172,7 @@ export function createEquivalenceClassExplorer() {
           ${isGraded ? 'disabled' : ''}/>
         ${sectFeedback}
       </div>
+      ${isGraded ? `<button type="button" class="quiz-share-btn" data-share-payload="${encodeResult({ v: 1, explorer: 'ec', explorerLabel: t('quiz.ec.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: (quiz.result.wectCorrect ? 1 : 0) + (quiz.result.sectCorrect ? 1 : 0), total: 2, items: [{ q: t('quiz.ec.wect.prompt'), a: String(quiz.wectAnswer), expected: String(quiz.result.wectCount), ok: quiz.result.wectCorrect }, { q: t('quiz.ec.sect.prompt'), a: String(quiz.sectAnswer), expected: String(quiz.result.sectCount), ok: quiz.result.sectCorrect }] })}" data-testid="ec-quiz-share">📋 ${t('quiz.share.btn')}</button>` : ''}
       <div class="quiz-actions">
         ${!isGraded
           ? `<button type="button" class="quiz-check-btn" data-testid="ec-quiz-check">${t('quiz.check')}</button>`

--- a/src/components/FuzzTestingExplorer.js
+++ b/src/components/FuzzTestingExplorer.js
@@ -1,4 +1,5 @@
-import { t, pickField } from '../i18n/index.js';
+import { t, getLocale, pickField } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import { fuzzTest, formatInput, formatOutput } from '../utils/fuzzTesting.js';
 import { fuzzTestingExamples } from '../data/testingData.js';
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
@@ -75,6 +76,7 @@ export function createFuzzTestingExplorer() {
     if (fuzzQuiz.phase === 'graded') {
       const userAns = parseInt(fuzzQuiz.answer, 10);
       const ok = userAns === nodeCov;
+      const shareEncoded = encodeResult({ v: 1, explorer: 'fuzz', explorerLabel: t('quiz.fuzz.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: ok ? 1 : 0, total: 1, items: [{ q: t('quiz.fuzz.prompt'), a: String(fuzzQuiz.answer), expected: String(nodeCov), ok }] });
       return `
         <div class="quiz-panel" data-testid="fuzz-quiz-panel">
           <div class="quiz-header">
@@ -86,6 +88,7 @@ export function createFuzzTestingExplorer() {
             ${ok ? t('quiz.graph.perfect') : ''}
             ${t('quiz.fuzz.answer', { pct: nodeCov })}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="fuzz-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="fuzz-quiz-reset">${t('quiz.retry')}</button>
         </div>
       `;

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -8,6 +8,7 @@ import { buildTestPathSetForRequirements, getCoverageRequirements } from '../uti
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
 import { buildDataFlowGraph } from '../utils/dataFlow.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 function cloneGraph(graph) {
   return {
@@ -505,7 +506,8 @@ export function createGraphCoverageExplorer() {
         ? ` <strong>${t('quiz.graph.perfect')}</strong>`
         : graphQuiz.result.covered < graphQuiz.result.total
           ? ` <em>${t('quiz.graph.incomplete')}</em>` : ''}
-    </p>` : '';
+    </p>
+    <button type="button" class="quiz-share-btn" data-share-payload="${encodeResult({ v: 1, explorer: 'graph', explorerLabel: t('quiz.graph.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: graphQuiz.result.covered, total: graphQuiz.result.total, items: candidates.map((path) => { const key = path.join('->'); const isOpt = optimalKeys.has(key); const checked = graphQuiz.selectedPaths.has(key); return { q: key.replaceAll('->', ' → '), a: checked ? '✓' : '—', expected: isOpt ? '✓' : '—', ok: checked === isOpt }; }) })}" data-testid="graph-quiz-share">📋 ${t('quiz.share.btn')}</button>` : '';
 
     const prompt = t('quiz.graph.prompt')
       .replace('{criterion}', escapeHtml(selectedCriterion ? selectedCriterion.label : criterionId))

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -9,6 +9,7 @@ import {
 } from '../utils/logicCoverage.js';
 import { buildKMap } from '../utils/karnaughMap.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import { createCloudIntegrationClient } from '../utils/cloudIntegration.js';
 import { solveBinding, formatWitnessStr, extractVarsFromBindings, buildConstraintStr } from '../utils/logicBinding.js';
 
@@ -249,6 +250,7 @@ export function createLogicCoverageExplorer() {
               ? `<strong>${t('quiz.bva.perfect')}</strong>`
               : `${t('quiz.ec.wrong')} ${t('quiz.ec.answer').replace('{count}', uniqueCount)}`}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${encodeResult({ v: 1, explorer: 'logic', explorerLabel: t('quiz.logic.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: correct ? 1 : 0, total: 1, items: [{ q: t('quiz.logic.prompt').replace('{expr}', state.expression).replace('{criterion}', criterionLabel), a: String(logicQuiz.answer), expected: String(uniqueCount), ok: correct }] })}" data-testid="logic-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="logic-quiz-reset">${t('quiz.reset')}</button>
         ` : `
           <button type="button" class="quiz-start-btn" data-testid="logic-quiz-check">${t('quiz.check')}</button>

--- a/src/components/MetamorphicTestingExplorer.js
+++ b/src/components/MetamorphicTestingExplorer.js
@@ -1,4 +1,5 @@
 import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import { metamorphicExamples, generateMrTests } from '../utils/metamorphicTesting.js';
 
 function escapeHtml(v = '') {
@@ -30,6 +31,7 @@ export function createMetamorphicTestingExplorer() {
       const correct = mtQuiz.autoResults ? mtQuiz.autoResults.filter((r) => r.holds).length : 0;
       const userAns = parseInt(mtQuiz.answer, 10);
       const ok = userAns === correct;
+      const shareEncoded = encodeResult({ v: 1, explorer: 'mt', explorerLabel: t('quiz.mt.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: ok ? 1 : 0, total: 1, items: [{ q: t('quiz.mt.prompt', { rel: relName }), a: String(mtQuiz.answer), expected: String(correct), ok }] });
       return `
         <div class="quiz-panel" data-testid="mt-quiz-panel">
           <div class="quiz-header">
@@ -41,6 +43,7 @@ export function createMetamorphicTestingExplorer() {
             ${ok ? t('quiz.graph.perfect') : ''}
             ${t('quiz.mt.answer', { count: correct })}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="mt-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="mt-quiz-reset">${t('quiz.retry')}</button>
         </div>
       `;

--- a/src/components/ResultViewer.css
+++ b/src/components/ResultViewer.css
@@ -1,0 +1,187 @@
+.rv-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9000;
+  padding: 1rem;
+  animation: rvOverlayIn 0.18s ease;
+}
+@keyframes rvOverlayIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.rv-card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1.5rem 1.75rem;
+  max-width: 560px;
+  width: 100%;
+  max-height: 88vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.25);
+  animation: rvCardIn 0.22s ease;
+}
+@keyframes rvCardIn {
+  from { opacity: 0; transform: translateY(12px) scale(0.97); }
+  to   { opacity: 1; transform: none; }
+}
+
+.rv-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.rv-kicker {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.3rem;
+}
+.rv-mode-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.rv-explorer {
+  font-size: 0.8rem;
+  color: #6b7280;
+  font-weight: 600;
+}
+.rv-title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1e293b;
+}
+
+.rv-close {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  color: #9ca3af;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+  flex-shrink: 0;
+}
+.rv-close:hover { color: #dc2626; }
+
+.rv-meta {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.2rem;
+  flex-wrap: wrap;
+}
+.rv-meta-item {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+/* Score */
+.rv-score-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1.2rem;
+}
+.rv-score {
+  font-size: 2.8rem;
+  font-weight: 800;
+  line-height: 1;
+  margin-bottom: 0.3rem;
+}
+.rv-score-sep { font-size: 1.6rem; font-weight: 400; color: #94a3b8; }
+.rv-score--pass    { color: #16a34a; }
+.rv-score--partial { color: #d97706; }
+.rv-score--fail    { color: #dc2626; }
+.rv-score-label { font-size: 0.82rem; color: #6b7280; }
+
+/* Items table */
+.rv-items {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  margin-bottom: 1rem;
+}
+.rv-items th {
+  text-align: left;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b7280;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 2px solid #e5e7eb;
+}
+.rv-items td {
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: top;
+}
+.rv-item-q  { color: #374151; max-width: 160px; }
+.rv-item-a  { color: #1e293b; font-family: ui-monospace, monospace; }
+.rv-item-exp { color: #6b7280; font-family: ui-monospace, monospace; }
+.rv-item-ok { font-size: 1rem; text-align: center; }
+.rv-items tr .rv-item-ok:last-child { color: #16a34a; }
+.rv-items tr:has(.rv-item-ok:not(:empty)) td.rv-item-ok { }
+.rv-items tr[data-ok="true"]  .rv-item-ok { color: #16a34a; }
+.rv-items tr[data-ok="false"] .rv-item-ok { color: #dc2626; }
+
+.rv-disclaimer {
+  font-size: 0.7rem;
+  color: #9ca3af;
+  font-style: italic;
+  margin: 0 0 1rem;
+}
+
+.rv-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+.rv-btn {
+  padding: 0.45rem 1.1rem;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  font-family: inherit;
+}
+.rv-btn--primary { background: #0f4c81; color: #fff; }
+.rv-btn--primary:hover { background: #0a3660; }
+
+/* Share button (injected into quiz panels) */
+.quiz-share-btn {
+  padding: 0.28rem 0.8rem;
+  border: 1px solid #0f4c81;
+  background: #fff;
+  color: #0f4c81;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  margin-top: 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  transition: background 0.15s, color 0.15s;
+}
+.quiz-share-btn:hover { background: #0f4c81; color: #fff; }
+.quiz-share-btn--copied { background: #16a34a; border-color: #16a34a; color: #fff; }
+
+@media (max-width: 560px) {
+  .rv-card { padding: 1.1rem 1rem; border-radius: 10px; }
+  .rv-score { font-size: 2rem; }
+}

--- a/src/components/ResultViewer.js
+++ b/src/components/ResultViewer.js
@@ -1,0 +1,119 @@
+import { t, getLocale } from '../i18n/index.js';
+import { parseResultFromUrl } from '../utils/resultExporter.js';
+
+function escapeHtml(v = '') {
+  return String(v).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+}
+
+function formatTs(ts) {
+  try {
+    return new Date(ts).toLocaleString(getLocale() === 'zh' ? 'zh-TW' : 'en-US');
+  } catch {
+    return String(ts);
+  }
+}
+
+export function createResultViewer(onClose) {
+  const result = parseResultFromUrl();
+  if (!result) return null;
+
+  // Clean the ?result= param from the URL so sharing the page again doesn't
+  // re-open the viewer for other visitors.
+  try {
+    const url = new URL(location.href);
+    url.searchParams.delete('result');
+    history.replaceState(null, '', url.pathname + (url.search || ''));
+  } catch {}
+
+  const overlay = document.createElement('div');
+  overlay.className = 'rv-overlay';
+  overlay.dataset.testid = 'result-viewer';
+
+  const scoreClass = result.total > 0 && result.score / result.total >= 0.8
+    ? 'rv-score--pass' : result.total > 0 && result.score / result.total >= 0.5
+    ? 'rv-score--partial' : 'rv-score--fail';
+
+  const modeBadge = result.mode === 'quiz'
+    ? t('rv.mode.quiz')
+    : result.mode === 'lab-reflect'
+    ? t('rv.mode.labReflect')
+    : t('rv.mode.labMetric');
+
+  const itemsHtml = (result.items && result.items.length > 0)
+    ? `<table class="rv-items">
+        <thead><tr>
+          <th>${t('rv.col.question')}</th>
+          <th>${t('rv.col.answer')}</th>
+          ${result.mode === 'quiz' ? `<th>${t('rv.col.expected')}</th><th></th>` : ''}
+        </tr></thead>
+        <tbody>
+          ${result.items.map((item) => `
+            <tr${result.mode === 'quiz' ? ` data-ok="${item.ok ? 'true' : 'false'}"` : ''}>
+              <td class="rv-item-q">${escapeHtml(item.q)}</td>
+              <td class="rv-item-a">${escapeHtml(item.a)}</td>
+              ${result.mode === 'quiz' ? `
+                <td class="rv-item-exp">${escapeHtml(String(item.expected ?? ''))}</td>
+                <td class="rv-item-ok">${item.ok ? '✓' : '✗'}</td>
+              ` : ''}
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>`
+    : '';
+
+  overlay.innerHTML = `
+    <div class="rv-card" role="dialog" aria-modal="true" aria-labelledby="rv-title">
+      <div class="rv-header">
+        <div>
+          <div class="rv-kicker">
+            <span class="rv-mode-badge">${escapeHtml(modeBadge)}</span>
+            <span class="rv-explorer">${escapeHtml(result.explorerLabel || result.explorer)}</span>
+          </div>
+          <h2 class="rv-title" id="rv-title">${t('rv.title')}</h2>
+        </div>
+        <button type="button" class="rv-close" data-testid="rv-close" aria-label="${t('common.close')}">×</button>
+      </div>
+
+      <div class="rv-meta">
+        <span class="rv-meta-item">🕐 ${escapeHtml(formatTs(result.ts))}</span>
+        <span class="rv-meta-item">🌐 ${result.lang === 'zh' ? '中文' : 'English'}</span>
+      </div>
+
+      ${result.mode === 'quiz' ? `
+        <div class="rv-score-wrap">
+          <div class="rv-score ${scoreClass}" data-testid="rv-score">
+            ${result.score} <span class="rv-score-sep">/</span> ${result.total}
+          </div>
+          <div class="rv-score-label">${t('rv.score.label')}</div>
+        </div>
+      ` : `
+        <div class="rv-score-wrap">
+          <div class="rv-score ${result.passed ? 'rv-score--pass' : 'rv-score--fail'}" data-testid="rv-score">
+            ${result.passed ? t('rv.passed') : t('rv.notPassed')}
+          </div>
+        </div>
+      `}
+
+      ${itemsHtml}
+
+      <p class="rv-disclaimer">${t('rv.disclaimer')}</p>
+
+      <div class="rv-actions">
+        <button type="button" class="rv-btn rv-btn--primary" data-rv-close data-testid="rv-close-btn">
+          ${t('rv.close')}
+        </button>
+      </div>
+    </div>
+  `;
+
+  function close() {
+    overlay.remove();
+    if (typeof onClose === 'function') onClose();
+  }
+
+  overlay.querySelector('[data-rv-close]').addEventListener('click', close);
+  overlay.querySelector('.rv-close').addEventListener('click', close);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+
+  return overlay;
+}

--- a/src/components/StateTransitionExplorer.js
+++ b/src/components/StateTransitionExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import { generateStTransitionTests, generateStSequenceTests } from '../utils/blackboxTesting.js';
 
 const STORAGE_KEY = 'stvisual.st.v1';
@@ -114,6 +115,7 @@ export function createStateTransitionExplorer() {
               ? `<strong>${t('quiz.bva.perfect')}</strong>`
               : `${t('quiz.ec.wrong')} ${t('quiz.ec.answer').replace('{count}', count)}`}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${encodeResult({ v: 1, explorer: 'st', explorerLabel: t('quiz.st.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: correct ? 1 : 0, total: 1, items: [{ q: t('quiz.st.prompt').replace('{mode}', modeLabel), a: String(stQuiz.answer), expected: String(count), ok: correct }] })}" data-testid="st-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="st-quiz-reset">${t('quiz.reset')}</button>
         ` : `
           <button type="button" class="quiz-start-btn" data-testid="st-quiz-check">${t('quiz.check')}</button>

--- a/src/components/SymbolicExecutionExplorer.js
+++ b/src/components/SymbolicExecutionExplorer.js
@@ -1,4 +1,5 @@
 import { t, getLocale, pickField } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import { symbolicExecute } from '../utils/symbolicExecution.js';
 import { symbolicExecutionExamples } from '../data/testingData.js';
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
@@ -66,6 +67,7 @@ export function createSymbolicExecutionExplorer() {
       const correct = state.result ? state.result.paths.filter((p) => p.feasible).length : 0;
       const userAns = parseInt(symbexQuiz.answer, 10);
       const ok = userAns === correct;
+      const shareEncoded = encodeResult({ v: 1, explorer: 'symbex', explorerLabel: t('quiz.symbex.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: ok ? 1 : 0, total: 1, items: [{ q: t('quiz.symbex.prompt'), a: String(symbexQuiz.answer), expected: String(correct), ok }] });
       return `
         <div class="quiz-panel" data-testid="symbex-quiz-panel">
           <div class="quiz-header">
@@ -77,6 +79,7 @@ export function createSymbolicExecutionExplorer() {
             ${ok ? t('quiz.graph.perfect') : ''}
             ${t('quiz.symbex.answer', { count: correct })}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="symbex-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="symbex-quiz-reset">${t('quiz.retry')}</button>
         </div>
       `;

--- a/src/components/SyntaxCoverageExplorer.js
+++ b/src/components/SyntaxCoverageExplorer.js
@@ -1,5 +1,6 @@
 import { mutationOperators, programExamples } from '../data/mutationData.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 import {
   generateMutants,
   evaluateMutants,
@@ -160,6 +161,7 @@ export function createSyntaxCoverageExplorer() {
       const correct = state.score.killed;
       const userAns = parseInt(syntaxQuiz.answer, 10);
       const ok = userAns === correct;
+      const shareEncoded = encodeResult({ v: 1, explorer: 'syntax', explorerLabel: t('quiz.syntax.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: ok ? 1 : 0, total: 1, items: [{ q: t('quiz.syntax.prompt', { program: state.exampleId }), a: String(syntaxQuiz.answer), expected: String(correct), ok }] });
       return `
         <div class="quiz-panel" data-testid="syntax-quiz-panel">
           <div class="quiz-header">
@@ -171,6 +173,7 @@ export function createSyntaxCoverageExplorer() {
             ${ok ? t('quiz.graph.perfect') : ''}
             ${t('quiz.syntax.answer', { killed: correct, total: state.score.total })}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="syntax-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="syntax-quiz-reset">${t('quiz.retry')}</button>
         </div>
       `;

--- a/src/components/TestDoublesExplorer.js
+++ b/src/components/TestDoublesExplorer.js
@@ -1,4 +1,5 @@
 import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 function escapeHtml(v = '') {
   return String(v)
@@ -597,6 +598,7 @@ export function createTestDoublesExplorer() {
 
     if (tdQuiz.phase === 'graded') {
       const ok = tdQuiz.selected === qs.correct;
+      const shareEncoded = encodeResult({ v: 1, explorer: 'td', explorerLabel: t('quiz.td.title'), mode: 'quiz', ts: Date.now(), lang: getLocale(), score: ok ? 1 : 0, total: 1, items: [{ q: desc, a: tdQuiz.selected, expected: qs.correct, ok }] });
       return `
         <div class="quiz-panel" data-testid="td-quiz-panel">
           <div class="quiz-header">
@@ -608,6 +610,7 @@ export function createTestDoublesExplorer() {
             ${ok ? t('quiz.graph.perfect') : ''}
             ${t('quiz.td.answer', { correct: qs.correct })}
           </p>
+          <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="td-quiz-share">📋 ${t('quiz.share.btn')}</button>
           <button type="button" class="quiz-start-btn" data-testid="td-quiz-reset">${t('quiz.retry')}</button>
         </div>
       `;

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -204,6 +204,22 @@ export const messages = {
     'et.note.add': 'Log',
     'common.delete': 'Delete',
 
+    // Result sharing (Phase A)
+    'quiz.share.btn': 'Share Results',
+    'quiz.share.copied': '✓ Copied!',
+    'rv.title': 'Quiz Results',
+    'rv.mode.quiz': 'Quiz',
+    'rv.mode.labReflect': 'Lab · Reflection',
+    'rv.mode.labMetric': 'Lab · Metric',
+    'rv.score.label': 'Score',
+    'rv.passed': 'Passed ✓',
+    'rv.notPassed': 'Not yet passed',
+    'rv.col.question': 'Question',
+    'rv.col.answer': 'Your Answer',
+    'rv.col.expected': 'Expected',
+    'rv.close': 'Close',
+    'rv.disclaimer': '* This result was self-reported and has not been verified by a server.',
+
     // Quiz (self-test) mode — shared and per-topic
     'quiz.start': 'Self-Test',
     'quiz.close': 'Close Quiz',
@@ -1066,6 +1082,22 @@ export const messages = {
     'et.note.placeholder': '描述你的發現…',
     'et.note.add': '記錄',
     'common.delete': '刪除',
+
+    // Result sharing (Phase A)
+    'quiz.share.btn': '分享成績',
+    'quiz.share.copied': '✓ 已複製！',
+    'rv.title': '測驗成績單',
+    'rv.mode.quiz': 'Quiz',
+    'rv.mode.labReflect': 'Lab · 反思',
+    'rv.mode.labMetric': 'Lab · 指標',
+    'rv.score.label': '得分',
+    'rv.passed': '通過 ✓',
+    'rv.notPassed': '尚未通過',
+    'rv.col.question': '題目',
+    'rv.col.answer': '你的答案',
+    'rv.col.expected': '正確答案',
+    'rv.close': '關閉',
+    'rv.disclaimer': '* 此成績為學生自我回報，尚未經伺服器驗證。',
 
     // Quiz (self-test) mode
     'quiz.start': '自我測驗',

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,4 +22,5 @@
 @import url('./components/DefectCostExplorer.css');
 @import url('./components/VModelExplorer.css');
 @import url('./components/PyramidAdjusterExplorer.css');
+@import url('./components/ResultViewer.css');
 @import url('./components/quiz.css');

--- a/src/utils/resultExporter.js
+++ b/src/utils/resultExporter.js
@@ -1,0 +1,32 @@
+/**
+ * Utilities for encoding quiz/lab results into shareable URL parameters.
+ * Phase A uses Base64 only (no server-side signing) — honour system.
+ *
+ * Payload schema v1:
+ *   { v, explorer, explorerLabel, mode, ts, lang, score, total, items? }
+ *   items: [{ q, a, expected?, ok }]
+ */
+
+export function encodeResult(payload) {
+  return btoa(encodeURIComponent(JSON.stringify(payload)));
+}
+
+export function decodeResult(b64) {
+  try {
+    return JSON.parse(decodeURIComponent(atob(b64)));
+  } catch {
+    return null;
+  }
+}
+
+export function buildShareUrl(encoded) {
+  const base = `${location.origin}${location.pathname}`;
+  return `${base}?result=${encoded}`;
+}
+
+export function parseResultFromUrl() {
+  const params = new URLSearchParams(location.search);
+  const b64 = params.get('result');
+  if (!b64) return null;
+  return decodeResult(b64);
+}


### PR DESCRIPTION
## Summary

Phase A of the Google Classroom integration — pure frontend, no backend.

- **F-A1**: `resultExporter.js` utility + `ResultViewer` modal component
- **F-A2**: Share button added to all 12 quiz panels  
- **F-A5**: `ResultViewer` auto-shown when page loads with `?result=` param

Closes #132

## How it works

1. Student completes a quiz → score shown + **📋 Share Results** button
2. Click → Base64-encoded result JSON written to `?result=` URL param, copied to clipboard
3. Student pastes URL into Google Classroom assignment comment
4. Teacher opens URL → `ResultViewer` overlay shows score, per-item breakdown, timestamp

## Result payload (v1)
```json
{ "v": 1, "explorer": "bva", "explorerLabel": "BVA Self-Test",
  "mode": "quiz", "ts": 1715600000000, "lang": "zh",
  "score": 4, "total": 5,
  "items": [{ "q": "min", "a": "0", "expected": "0", "ok": true }, ...] }
```

## Files changed
| File | Change |
|---|---|
| `src/utils/resultExporter.js` | New — encode/decode/URL helpers |
| `src/components/ResultViewer.js` | New — modal overlay component |
| `src/components/ResultViewer.css` | New — modal + `.quiz-share-btn` styles |
| `src/styles.css` | +1 import |
| `src/app.js` | ResultViewer init + global share-btn click handler |
| `src/i18n/dict.js` | `quiz.share.*` + `rv.*` in EN + ZH |
| 12 Explorer files | `encodeResult` import + share button in graded state |

## Test plan
- [ ] BVA: grade quiz → share button visible → click copies URL → paste in new tab shows score 4/5 with 5 rows
- [ ] Graph: grade quiz → share URL includes path checkboxes
- [ ] DT / EC: two-field quizzes encode both answers
- [ ] ResultViewer: close button + backdrop click both dismiss
- [ ] ZH locale: viewer labels show Chinese
- [ ] 346 unit tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)