### PR TITLE
feat(lab): Lab Reflect (F-A3) + Lab Metric (F-A4) modes

### DIFF
--- a/src/components/FuzzTestingExplorer.js
+++ b/src/components/FuzzTestingExplorer.js
@@ -1,5 +1,5 @@
 import { t, getLocale, pickField } from '../i18n/index.js';
-import { encodeResult } from '../utils/resultExporter.js';
+import { encodeResult, buildShareUrl } from '../utils/resultExporter.js';
 import { fuzzTest, formatInput, formatOutput } from '../utils/fuzzTesting.js';
 import { fuzzTestingExamples } from '../data/testingData.js';
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
@@ -67,6 +67,30 @@ export function createFuzzTestingExplorer() {
   };
 
   const fuzzQuiz = { active: false, phase: 'question', answer: '', result: null };
+  const fuzzLabReflect = { active: false, a1: '', a2: '' };
+
+  function renderFuzzLabReflectPanel() {
+    if (!fuzzLabReflect.active) return '';
+    return `
+      <div class="lab-panel" data-testid="fuzz-lab-reflect">
+        <div class="lab-panel-header">
+          <span class="lab-panel-title">${t('lab.reflect.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="fuzz-lab-reflect-close">✕</button>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.fuzz.1')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="fuzz-lab-reflect-a1" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(fuzzLabReflect.a1)}</textarea>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.fuzz.2')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="fuzz-lab-reflect-a2" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(fuzzLabReflect.a2)}</textarea>
+        </div>
+        <div class="lab-reflect-actions">
+          <button type="button" class="quiz-share-btn" data-testid="fuzz-lab-reflect-share">📋 ${t('quiz.share.btn')}</button>
+        </div>
+      </div>
+    `;
+  }
 
   function renderFuzzQuizPanel() {
     if (!fuzzQuiz.active) return '';
@@ -208,6 +232,14 @@ export function createFuzzTestingExplorer() {
       ? `<div class="fuzz-error" data-testid="fuzz-error">${escapeHtml(error)}</div>`
       : renderTestCases(result);
 
+    const FUZZ_THRESHOLD = 80;
+    const fuzzMetricEncoded = state.result ? encodeResult({
+      v: 1, explorer: 'fuzz', explorerLabel: t('section.fuzz'),
+      mode: 'lab-metric', ts: Date.now(), lang: getLocale(),
+      score: nodeCov >= FUZZ_THRESHOLD ? 1 : 0, total: 1,
+      items: [{ q: t('lab.metric.fuzz.label', { pct: nodeCov }), a: `${nodeCov}%`, ok: nodeCov >= FUZZ_THRESHOLD }],
+    }) : null;
+
     root.innerHTML = `
       <nav class="explorer-mobile-nav" aria-label="${t('explorer.mobileNav')}" data-testid="fuzz-mobile-nav">
         <a href="#fuzz-input-panel">${t('explorer.panel.input')}</a>
@@ -262,8 +294,11 @@ export function createFuzzTestingExplorer() {
           <p class="fuzz-summary" data-testid="fuzz-summary">
             ${summary}
             ${!fuzzQuiz.active && state.result ? `<button type="button" class="quiz-start-btn" data-testid="fuzz-quiz-start" style="margin-left:0.5rem">${t('quiz.start')}</button>` : ''}
+            ${state.result && !fuzzLabReflect.active ? `<button type="button" class="quiz-start-btn" data-testid="fuzz-lab-reflect-start" style="margin-left:0.5rem">${t('lab.reflect.start')}</button>` : ''}
+            ${fuzzMetricEncoded ? `<button type="button" class="quiz-share-btn" data-share-payload="${fuzzMetricEncoded}" data-testid="fuzz-lab-metric" style="margin-left:0.5rem">📊 ${t('lab.metric.record')}</button>` : ''}
           </p>
           ${renderFuzzQuizPanel()}
+          ${renderFuzzLabReflectPanel()}
           ${testCasesMarkup}
         </section>
       </div>
@@ -480,6 +515,49 @@ export function createFuzzTestingExplorer() {
         fuzzQuiz.phase = 'question';
         fuzzQuiz.answer = '';
         render();
+      });
+    }
+
+    root.querySelector('[data-testid="fuzz-lab-reflect-start"]')?.addEventListener('click', () => {
+      fuzzLabReflect.active = true;
+      render();
+    });
+
+    root.querySelector('[data-testid="fuzz-lab-reflect-close"]')?.addEventListener('click', () => {
+      fuzzLabReflect.a1 = root.querySelector('[data-testid="fuzz-lab-reflect-a1"]')?.value || fuzzLabReflect.a1;
+      fuzzLabReflect.a2 = root.querySelector('[data-testid="fuzz-lab-reflect-a2"]')?.value || fuzzLabReflect.a2;
+      fuzzLabReflect.active = false;
+      render();
+    });
+
+    root.querySelector('[data-testid="fuzz-lab-reflect-a1"]')?.addEventListener('input', (e) => {
+      fuzzLabReflect.a1 = e.target.value;
+    });
+    root.querySelector('[data-testid="fuzz-lab-reflect-a2"]')?.addEventListener('input', (e) => {
+      fuzzLabReflect.a2 = e.target.value;
+    });
+
+    const fuzzLrShare = root.querySelector('[data-testid="fuzz-lab-reflect-share"]');
+    if (fuzzLrShare) {
+      fuzzLrShare.addEventListener('click', async () => {
+        const a1 = root.querySelector('[data-testid="fuzz-lab-reflect-a1"]')?.value || '';
+        const a2 = root.querySelector('[data-testid="fuzz-lab-reflect-a2"]')?.value || '';
+        const url = buildShareUrl(encodeResult({
+          v: 1, explorer: 'fuzz', explorerLabel: t('lab.reflect.title'), mode: 'lab-reflect',
+          ts: Date.now(), lang: getLocale(), score: (a1.trim() ? 1 : 0) + (a2.trim() ? 1 : 0), total: 2,
+          items: [
+            { q: t('lab.reflect.q.fuzz.1'), a: a1 },
+            { q: t('lab.reflect.q.fuzz.2'), a: a2 },
+          ],
+        }));
+        try { await navigator.clipboard.writeText(url); } catch {
+          const ta = document.createElement('textarea');
+          ta.value = url; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
+        }
+        const orig = fuzzLrShare.innerHTML;
+        fuzzLrShare.innerHTML = t('quiz.share.copied');
+        fuzzLrShare.classList.add('quiz-share-btn--copied');
+        setTimeout(() => { fuzzLrShare.innerHTML = orig; fuzzLrShare.classList.remove('quiz-share-btn--copied'); }, 2000);
       });
     }
   }

--- a/src/components/GraphCoverageExplorer.js
+++ b/src/components/GraphCoverageExplorer.js
@@ -8,7 +8,7 @@ import { buildTestPathSetForRequirements, getCoverageRequirements } from '../uti
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
 import { buildDataFlowGraph } from '../utils/dataFlow.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
-import { encodeResult } from '../utils/resultExporter.js';
+import { encodeResult, buildShareUrl } from '../utils/resultExporter.js';
 
 function cloneGraph(graph) {
   return {
@@ -445,6 +445,7 @@ export function createGraphCoverageExplorer() {
   let draft = createDraftFromGraph(defaultGraph);
 
   const graphQuiz = { active: false, selectedPaths: new Set(), phase: 'question', result: null };
+  const graphLabReflect = { active: false, a1: '', a2: '' };
 
   function getQuizCandidates(pathPlan) {
     const seen = new Set();
@@ -476,6 +477,29 @@ export function createGraphCoverageExplorer() {
     };
     graphQuiz.phase = 'graded';
     render();
+  }
+
+  function renderGraphLabReflectPanel() {
+    if (!graphLabReflect.active) return '';
+    return `
+      <div class="lab-panel" data-testid="graph-lab-reflect">
+        <div class="lab-panel-header">
+          <span class="lab-panel-title">${t('lab.reflect.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="graph-lab-reflect-close">✕</button>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.graph.1')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="graph-lab-reflect-a1" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(graphLabReflect.a1)}</textarea>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.graph.2')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="graph-lab-reflect-a2" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(graphLabReflect.a2)}</textarea>
+        </div>
+        <div class="lab-reflect-actions">
+          <button type="button" class="quiz-share-btn" data-testid="graph-lab-reflect-share">📋 ${t('quiz.share.btn')}</button>
+        </div>
+      </div>
+    `;
   }
 
   function renderGraphQuizPanel(pathPlan, selectedCriterion) {
@@ -594,6 +618,13 @@ export function createGraphCoverageExplorer() {
     const { requirements, selectedRequirement, selectedCriterion, pathPlan } = getState();
     const selectedSourceNodes = getSelectedSourceNodes(graph, selectedRequirement);
     const quizPanel = renderGraphQuizPanel(pathPlan, selectedCriterion);
+    const labReflectPanel = renderGraphLabReflectPanel();
+    const metricEncoded = encodeResult({
+      v: 1, explorer: 'graph', explorerLabel: t('section.graph'),
+      mode: 'lab-metric', ts: Date.now(), lang: getLocale(),
+      score: 1, total: 1,
+      items: [{ q: t('lab.metric.graph.label', { criterion: selectedCriterion?.label || criterionId, paths: pathPlan.selectedPaths.length }), a: '', ok: true }],
+    });
 
     root.className = 'graph-coverage';
     root.dataset.testid = 'graph-coverage-explorer';
@@ -706,6 +737,8 @@ export function createGraphCoverageExplorer() {
           `).join('')}
         </div>
         <button type="button" class="quiz-start-btn" data-testid="graph-quiz-start">${t('quiz.start')}</button>
+        ${!graphLabReflect.active ? `<button type="button" class="quiz-start-btn" data-testid="graph-lab-reflect-start">${t('lab.reflect.start')}</button>` : ''}
+        <button type="button" class="quiz-share-btn" data-share-payload="${metricEncoded}" data-testid="graph-lab-metric">📊 ${t('lab.metric.record')}</button>
       </div>
 
       <div class="graph-coverage-layout">
@@ -799,6 +832,7 @@ export function createGraphCoverageExplorer() {
       </div>
 
       ${quizPanel}
+      ${labReflectPanel}
     `;
 
     root.querySelector('[data-testid="graph-reset-btn"]').addEventListener('click', () => {
@@ -951,6 +985,49 @@ export function createGraphCoverageExplorer() {
       graphQuiz.result = null;
       render();
     });
+
+    root.querySelector('[data-testid="graph-lab-reflect-start"]')?.addEventListener('click', () => {
+      graphLabReflect.active = true;
+      render();
+    });
+
+    root.querySelector('[data-testid="graph-lab-reflect-close"]')?.addEventListener('click', () => {
+      graphLabReflect.a1 = root.querySelector('[data-testid="graph-lab-reflect-a1"]')?.value || graphLabReflect.a1;
+      graphLabReflect.a2 = root.querySelector('[data-testid="graph-lab-reflect-a2"]')?.value || graphLabReflect.a2;
+      graphLabReflect.active = false;
+      render();
+    });
+
+    root.querySelector('[data-testid="graph-lab-reflect-a1"]')?.addEventListener('input', (e) => {
+      graphLabReflect.a1 = e.target.value;
+    });
+    root.querySelector('[data-testid="graph-lab-reflect-a2"]')?.addEventListener('input', (e) => {
+      graphLabReflect.a2 = e.target.value;
+    });
+
+    const lrShare = root.querySelector('[data-testid="graph-lab-reflect-share"]');
+    if (lrShare) {
+      lrShare.addEventListener('click', async () => {
+        const a1 = root.querySelector('[data-testid="graph-lab-reflect-a1"]')?.value || '';
+        const a2 = root.querySelector('[data-testid="graph-lab-reflect-a2"]')?.value || '';
+        const url = buildShareUrl(encodeResult({
+          v: 1, explorer: 'graph', explorerLabel: t('lab.reflect.title'), mode: 'lab-reflect',
+          ts: Date.now(), lang: getLocale(), score: (a1.trim() ? 1 : 0) + (a2.trim() ? 1 : 0), total: 2,
+          items: [
+            { q: t('lab.reflect.q.graph.1'), a: a1 },
+            { q: t('lab.reflect.q.graph.2'), a: a2 },
+          ],
+        }));
+        try { await navigator.clipboard.writeText(url); } catch {
+          const ta = document.createElement('textarea');
+          ta.value = url; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
+        }
+        const orig = lrShare.innerHTML;
+        lrShare.innerHTML = t('quiz.share.copied');
+        lrShare.classList.add('quiz-share-btn--copied');
+        setTimeout(() => { lrShare.innerHTML = orig; lrShare.classList.remove('quiz-share-btn--copied'); }, 2000);
+      });
+    }
   }
 
   render();

--- a/src/components/LabPanel.css
+++ b/src/components/LabPanel.css
@@ -1,0 +1,59 @@
+.lab-panel {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 2px solid #059669;
+  border-radius: var(--app-radius-md, 8px);
+  background: #f0fdf4;
+}
+
+.lab-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.lab-panel-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #065f46;
+}
+
+.lab-reflect-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.lab-reflect-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f2a44;
+  line-height: 1.4;
+}
+
+.lab-reflect-textarea {
+  width: 100%;
+  min-height: 5rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #a7f3d0;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-family: inherit;
+  resize: vertical;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.lab-reflect-textarea:focus {
+  outline: none;
+  border-color: #059669;
+  box-shadow: 0 0 0 2px rgba(5, 150, 105, 0.15);
+}
+
+.lab-reflect-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -9,7 +9,7 @@ import {
 } from '../utils/logicCoverage.js';
 import { buildKMap } from '../utils/karnaughMap.js';
 import { t, getLocale, pickField } from '../i18n/index.js';
-import { encodeResult } from '../utils/resultExporter.js';
+import { encodeResult, buildShareUrl } from '../utils/resultExporter.js';
 import { createCloudIntegrationClient } from '../utils/cloudIntegration.js';
 import { solveBinding, formatWitnessStr, extractVarsFromBindings, buildConstraintStr } from '../utils/logicBinding.js';
 
@@ -206,6 +206,7 @@ export function createLogicCoverageExplorer() {
   };
 
   const logicQuiz = { active: false, phase: 'question', answer: '', result: null };
+  const logicLabReflect = { active: false, a1: '', a2: '' };
 
   function getQuizUniqueCount() {
     const set = getActiveSet();
@@ -215,6 +216,29 @@ export function createLogicCoverageExplorer() {
       seen.add(`r${test.row.index}`);
     }
     return seen.size;
+  }
+
+  function renderLogicLabReflectPanel() {
+    if (!logicLabReflect.active) return '';
+    return `
+      <div class="lab-panel" data-testid="logic-lab-reflect">
+        <div class="lab-panel-header">
+          <span class="lab-panel-title">${t('lab.reflect.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="logic-lab-reflect-close">✕</button>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.logic.1')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="logic-lab-reflect-a1" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(logicLabReflect.a1)}</textarea>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.logic.2')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="logic-lab-reflect-a2" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(logicLabReflect.a2)}</textarea>
+        </div>
+        <div class="lab-reflect-actions">
+          <button type="button" class="quiz-share-btn" data-testid="logic-lab-reflect-share">📋 ${t('quiz.share.btn')}</button>
+        </div>
+      </div>
+    `;
   }
 
   function renderLogicQuizPanel() {
@@ -414,11 +438,14 @@ export function createLogicCoverageExplorer() {
           ${!state.error && state.analysis ? `
             <button type="button" class="quiz-start-btn" data-testid="logic-quiz-start">
               ${t('quiz.start')}
-            </button>` : ''}
+            </button>
+            ${!logicLabReflect.active ? `<button type="button" class="quiz-start-btn" data-testid="logic-lab-reflect-start">${t('lab.reflect.start')}</button>` : ''}
+          ` : ''}
         </div>
       </div>
 
       ${renderLogicQuizPanel()}
+      ${renderLogicLabReflectPanel()}
 
       <div class="logic-summary" data-testid="logic-summary">${summaryMarkup}</div>
 
@@ -921,6 +948,49 @@ export function createLogicCoverageExplorer() {
       logicQuiz.answer = '';
       render();
     });
+
+    root.querySelector('[data-testid="logic-lab-reflect-start"]')?.addEventListener('click', () => {
+      logicLabReflect.active = true;
+      render();
+    });
+
+    root.querySelector('[data-testid="logic-lab-reflect-close"]')?.addEventListener('click', () => {
+      logicLabReflect.a1 = root.querySelector('[data-testid="logic-lab-reflect-a1"]')?.value || logicLabReflect.a1;
+      logicLabReflect.a2 = root.querySelector('[data-testid="logic-lab-reflect-a2"]')?.value || logicLabReflect.a2;
+      logicLabReflect.active = false;
+      render();
+    });
+
+    root.querySelector('[data-testid="logic-lab-reflect-a1"]')?.addEventListener('input', (e) => {
+      logicLabReflect.a1 = e.target.value;
+    });
+    root.querySelector('[data-testid="logic-lab-reflect-a2"]')?.addEventListener('input', (e) => {
+      logicLabReflect.a2 = e.target.value;
+    });
+
+    const logicLrShare = root.querySelector('[data-testid="logic-lab-reflect-share"]');
+    if (logicLrShare) {
+      logicLrShare.addEventListener('click', async () => {
+        const a1 = root.querySelector('[data-testid="logic-lab-reflect-a1"]')?.value || '';
+        const a2 = root.querySelector('[data-testid="logic-lab-reflect-a2"]')?.value || '';
+        const url = buildShareUrl(encodeResult({
+          v: 1, explorer: 'logic', explorerLabel: t('lab.reflect.title'), mode: 'lab-reflect',
+          ts: Date.now(), lang: getLocale(), score: (a1.trim() ? 1 : 0) + (a2.trim() ? 1 : 0), total: 2,
+          items: [
+            { q: t('lab.reflect.q.logic.1'), a: a1 },
+            { q: t('lab.reflect.q.logic.2'), a: a2 },
+          ],
+        }));
+        try { await navigator.clipboard.writeText(url); } catch {
+          const ta = document.createElement('textarea');
+          ta.value = url; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
+        }
+        const orig = logicLrShare.innerHTML;
+        logicLrShare.innerHTML = t('quiz.share.copied');
+        logicLrShare.classList.add('quiz-share-btn--copied');
+        setTimeout(() => { logicLrShare.innerHTML = orig; logicLrShare.classList.remove('quiz-share-btn--copied'); }, 2000);
+      });
+    }
 
     // Binding inputs — update results section only (no full re-render → no focus loss).
     let bindingTimer = null;

--- a/src/components/SymbolicExecutionExplorer.js
+++ b/src/components/SymbolicExecutionExplorer.js
@@ -1,5 +1,5 @@
 import { t, getLocale, pickField } from '../i18n/index.js';
-import { encodeResult } from '../utils/resultExporter.js';
+import { encodeResult, buildShareUrl } from '../utils/resultExporter.js';
 import { symbolicExecute } from '../utils/symbolicExecution.js';
 import { symbolicExecutionExamples } from '../data/testingData.js';
 import { generateControlFlowGraphFromProgram } from '../utils/programToGraph.js';
@@ -60,6 +60,30 @@ export function createSymbolicExecutionExplorer() {
   };
 
   const symbexQuiz = { active: false, phase: 'question', answer: '', result: null };
+  const symbexLabReflect = { active: false, a1: '', a2: '' };
+
+  function renderSymbexLabReflectPanel() {
+    if (!symbexLabReflect.active) return '';
+    return `
+      <div class="lab-panel" data-testid="symbex-lab-reflect">
+        <div class="lab-panel-header">
+          <span class="lab-panel-title">${t('lab.reflect.title')}</span>
+          <button type="button" class="quiz-close-btn" data-testid="symbex-lab-reflect-close">✕</button>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.symbex.1')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="symbex-lab-reflect-a1" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(symbexLabReflect.a1)}</textarea>
+        </div>
+        <div class="lab-reflect-field">
+          <label class="lab-reflect-label">${t('lab.reflect.q.symbex.2')}</label>
+          <textarea class="lab-reflect-textarea" data-testid="symbex-lab-reflect-a2" placeholder="${t('lab.reflect.placeholder')}">${escapeHtml(symbexLabReflect.a2)}</textarea>
+        </div>
+        <div class="lab-reflect-actions">
+          <button type="button" class="quiz-share-btn" data-testid="symbex-lab-reflect-share">📋 ${t('quiz.share.btn')}</button>
+        </div>
+      </div>
+    `;
+  }
 
   function renderSymbexQuizPanel() {
     if (!symbexQuiz.active) return '';
@@ -209,8 +233,10 @@ export function createSymbolicExecutionExplorer() {
           <p class="symbex-summary" data-testid="symbex-summary">
             ${summary}
             ${!symbexQuiz.active ? `<button type="button" class="quiz-start-btn" data-testid="symbex-quiz-start" style="margin-left:0.5rem">${t('quiz.start')}</button>` : ''}
+            ${!symbexLabReflect.active ? `<button type="button" class="quiz-start-btn" data-testid="symbex-lab-reflect-start" style="margin-left:0.5rem">${t('lab.reflect.start')}</button>` : ''}
           </p>
           ${renderSymbexQuizPanel()}
+          ${renderSymbexLabReflectPanel()}
           ${pathsMarkup}
         </section>
       </div>
@@ -388,6 +414,49 @@ export function createSymbolicExecutionExplorer() {
         symbexQuiz.phase = 'question';
         symbexQuiz.answer = '';
         render();
+      });
+    }
+
+    root.querySelector('[data-testid="symbex-lab-reflect-start"]')?.addEventListener('click', () => {
+      symbexLabReflect.active = true;
+      render();
+    });
+
+    root.querySelector('[data-testid="symbex-lab-reflect-close"]')?.addEventListener('click', () => {
+      symbexLabReflect.a1 = root.querySelector('[data-testid="symbex-lab-reflect-a1"]')?.value || symbexLabReflect.a1;
+      symbexLabReflect.a2 = root.querySelector('[data-testid="symbex-lab-reflect-a2"]')?.value || symbexLabReflect.a2;
+      symbexLabReflect.active = false;
+      render();
+    });
+
+    root.querySelector('[data-testid="symbex-lab-reflect-a1"]')?.addEventListener('input', (e) => {
+      symbexLabReflect.a1 = e.target.value;
+    });
+    root.querySelector('[data-testid="symbex-lab-reflect-a2"]')?.addEventListener('input', (e) => {
+      symbexLabReflect.a2 = e.target.value;
+    });
+
+    const symbexLrShare = root.querySelector('[data-testid="symbex-lab-reflect-share"]');
+    if (symbexLrShare) {
+      symbexLrShare.addEventListener('click', async () => {
+        const a1 = root.querySelector('[data-testid="symbex-lab-reflect-a1"]')?.value || '';
+        const a2 = root.querySelector('[data-testid="symbex-lab-reflect-a2"]')?.value || '';
+        const url = buildShareUrl(encodeResult({
+          v: 1, explorer: 'symbex', explorerLabel: t('lab.reflect.title'), mode: 'lab-reflect',
+          ts: Date.now(), lang: getLocale(), score: (a1.trim() ? 1 : 0) + (a2.trim() ? 1 : 0), total: 2,
+          items: [
+            { q: t('lab.reflect.q.symbex.1'), a: a1 },
+            { q: t('lab.reflect.q.symbex.2'), a: a2 },
+          ],
+        }));
+        try { await navigator.clipboard.writeText(url); } catch {
+          const ta = document.createElement('textarea');
+          ta.value = url; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
+        }
+        const orig = symbexLrShare.innerHTML;
+        symbexLrShare.innerHTML = t('quiz.share.copied');
+        symbexLrShare.classList.add('quiz-share-btn--copied');
+        setTimeout(() => { symbexLrShare.innerHTML = orig; symbexLrShare.classList.remove('quiz-share-btn--copied'); }, 2000);
       });
     }
   }

--- a/src/components/SyntaxCoverageExplorer.js
+++ b/src/components/SyntaxCoverageExplorer.js
@@ -476,6 +476,13 @@ export function createSyntaxCoverageExplorer() {
     ` : `<p class="syntax-mutant-empty">${t('syntax.mutant.empty')}</p>`;
 
     const scorePct = Math.round(state.score.score * 100);
+    const SYNTAX_THRESHOLD = 75;
+    const syntaxMetricEncoded = encodeResult({
+      v: 1, explorer: 'syntax', explorerLabel: t('section.syntax'),
+      mode: 'lab-metric', ts: Date.now(), lang: getLocale(),
+      score: scorePct >= SYNTAX_THRESHOLD ? 1 : 0, total: 1,
+      items: [{ q: t('lab.metric.syntax.label', { pct: scorePct }), a: `${scorePct}%`, ok: scorePct >= SYNTAX_THRESHOLD }],
+    });
 
     root.innerHTML = `
       <div class="syntax-toolbar">
@@ -541,6 +548,7 @@ export function createSyntaxCoverageExplorer() {
           equivalent <strong>${state.score.equivalent}</strong>
           <span class="syntax-divider">·</span>
           ${!syntaxQuiz.active ? `<button type="button" class="quiz-start-btn" data-testid="syntax-quiz-start">${t('quiz.start')}</button>` : ''}
+          <button type="button" class="quiz-share-btn" data-share-payload="${syntaxMetricEncoded}" data-testid="syntax-lab-metric">📊 ${t('lab.metric.record')}</button>
         </p>
         ${renderSyntaxQuizPanel()}
       </section>

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -220,6 +220,24 @@ export const messages = {
     'rv.close': 'Close',
     'rv.disclaimer': '* This result was self-reported and has not been verified by a server.',
 
+    // Lab modes (F-A3 Reflection, F-A4 Metric)
+    'lab.reflect.title': 'Lab · Reflection',
+    'lab.reflect.start': 'Lab Reflect',
+    'lab.reflect.placeholder': 'Enter your reflection…',
+    'lab.reflect.q.graph.1': 'Which coverage criterion requires the most test paths? Why?',
+    'lab.reflect.q.graph.2': 'What would you add to achieve full edge-pair coverage?',
+    'lab.reflect.q.logic.1': 'Which clauses were hardest to satisfy independently? Why?',
+    'lab.reflect.q.logic.2': 'How does test-case count change between PC and MCDC?',
+    'lab.reflect.q.fuzz.1': 'Which nodes were hardest to reach through random fuzzing? Why?',
+    'lab.reflect.q.fuzz.2': 'How would you design a seed corpus to improve node coverage?',
+    'lab.reflect.q.symbex.1': 'How many paths are feasible vs infeasible? What causes infeasible paths?',
+    'lab.reflect.q.symbex.2': 'Which path constraints were most complex? How could you improve testability?',
+    'lab.metric.title': 'Lab · Metric',
+    'lab.metric.record': 'Record Metric',
+    'lab.metric.graph.label': 'Criterion: {criterion} · Paths: {paths}',
+    'lab.metric.syntax.label': 'Kill rate: {pct}%',
+    'lab.metric.fuzz.label': 'Node coverage: {pct}%',
+
     // Quiz (self-test) mode — shared and per-topic
     'quiz.start': 'Self-Test',
     'quiz.close': 'Close Quiz',
@@ -1098,6 +1116,24 @@ export const messages = {
     'rv.col.expected': '正確答案',
     'rv.close': '關閉',
     'rv.disclaimer': '* 此成績為學生自我回報，尚未經伺服器驗證。',
+
+    // Lab modes (F-A3 Reflection, F-A4 Metric)
+    'lab.reflect.title': 'Lab · 反思',
+    'lab.reflect.start': 'Lab 反思',
+    'lab.reflect.placeholder': '請輸入您的反思…',
+    'lab.reflect.q.graph.1': '哪種覆蓋準則需要最多測試路徑？為什麼？',
+    'lab.reflect.q.graph.2': '若要達到完整 Edge-Pair Coverage，你會加入哪些路徑？',
+    'lab.reflect.q.logic.1': '哪些子句最難獨立滿足？為什麼？',
+    'lab.reflect.q.logic.2': '在 PC 與 MCDC 準則之間，測試案例數如何變化？',
+    'lab.reflect.q.fuzz.1': '哪些節點最難透過隨機模糊測試到達？為什麼？',
+    'lab.reflect.q.fuzz.2': '你會如何設計 seed corpus 以提升節點覆蓋率？',
+    'lab.reflect.q.symbex.1': '可行路徑與不可行路徑各有幾條？造成不可行的原因是什麼？',
+    'lab.reflect.q.symbex.2': '哪些路徑條件最複雜？如何改善程式的可測試性？',
+    'lab.metric.title': 'Lab · 指標',
+    'lab.metric.record': '記錄指標',
+    'lab.metric.graph.label': '準則：{criterion} · 路徑數：{paths}',
+    'lab.metric.syntax.label': '殺死率：{pct}%',
+    'lab.metric.fuzz.label': '節點覆蓋率：{pct}%',
 
     // Quiz (self-test) mode
     'quiz.start': '自我測驗',

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,4 +23,5 @@
 @import url('./components/VModelExplorer.css');
 @import url('./components/PyramidAdjusterExplorer.css');
 @import url('./components/ResultViewer.css');
+@import url('./components/LabPanel.css');
 @import url('./components/quiz.css');


### PR DESCRIPTION
Closes #134

## Summary
- **F-A3 Lab Reflect** — Graph, Logic, Fuzz, Symbex each gain a "Lab Reflect" button that opens a two-question reflection panel (green border); answers are encoded into a shareable `?result=` URL at click time (`mode: lab-reflect`)
- **F-A4 Lab Metric** — Graph, Fuzz, Syntax gain a "📊 Record Metric" button that snapshot the current coverage/score into a shareable URL (`mode: lab-metric`), with threshold indicators (Fuzz ≥80%, Syntax ≥75%)

## New files
- `src/components/LabPanel.css`

## Modified files
- `src/styles.css` — import LabPanel.css
- `src/i18n/dict.js` — 18 new bilingual keys (EN + ZH)
- 5 explorer files — reflect panel render function, state variables, event handlers

## Test plan
- [x] All 346 unit tests pass
- [ ] Lab Reflect button visible in Graph/Logic/Fuzz/Symbex
- [ ] Text area values preserved when switching criteria / re-rendering
- [ ] Share button copies URL; ResultViewer shows reflection items
- [ ] Metric button visible in Graph/Fuzz(post-run)/Syntax; threshold coloring correct
- [ ] EN and ZH i18n renders without missing keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)