### PR TITLE
fix(groupth): bridge button targets correct section (section-blackbox + MT tab)

### DIFF
--- a/src/components/GroupTheoryExplorer.js
+++ b/src/components/GroupTheoryExplorer.js
@@ -533,7 +533,9 @@ export function createGroupTheoryExplorer() {
     }
 
     root.querySelector('[data-testid="gth-bridge-mt"]')?.addEventListener('click', () => {
-      document.querySelector('[data-testid="section-mt"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // MT is a tab inside section-blackbox, not a standalone section
+      document.querySelector('[data-blackbox-tab="mt"]')?.click();
+      document.querySelector('[data-testid="section-blackbox"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
 
     // Covering array controls


### PR DESCRIPTION
Fixes bridge button in GroupTheoryExplorer → Metamorphic Testing having no effect.

## Root cause

`MetamorphicTestingExplorer` is rendered as a **tab inside `section-blackbox`**, not as a standalone top-level section. The click handler was calling:

\`\`\`js
document.querySelector('[data-testid="section-mt"]')?.scrollIntoView(...)
\`\`\`

`section-mt` doesn't exist in the DOM, so the optional-chain silently did nothing.

## Fix

\`\`\`js
document.querySelector('[data-blackbox-tab="mt"]')?.click();        // activate the MT tab
document.querySelector('[data-testid="section-blackbox"]')?.scrollIntoView(...);
\`\`\`

This programmatically switches the blackbox tab bar to "Metamorphic Testing" and then scrolls the section into view.

## Test plan

- [x] \`npm test -- --run\` → 404/404 pass
- [ ] In GroupTheoryExplorer Orbit tab, click "→ Metamorphic Testing" → page scrolls to blackbox section with MT tab active

🤖 Generated with [Claude Code](https://claude.com/claude-code)