### PR TITLE
feat(F-B1): Firestore result storage — saveResult / loadCourseResults

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,20 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // User settings: only the owner can read/write
+    match /users/{uid}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+
+    // Course results: authenticated users write their own; any authenticated
+    // user with the class code can read (the code itself acts as a join token).
+    match /courses/{classCode}/results/{resultId} {
+      allow create: if request.auth != null
+        && request.resource.data.uid == request.auth.uid;
+      allow read: if request.auth != null;
+      // Results are immutable once written
+      allow update, delete: if false;
+    }
+  }
+}

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -910,6 +910,7 @@ export const messages = {
     'cloud.err.uploadFailed': 'Failed to upload to Google Drive.',
     'cloud.err.listFailed': 'Failed to list Google Drive files.',
     'cloud.err.downloadFailed': 'Failed to download Google Drive file.',
+    'cloud.err.noClassCode': 'Class code is required to save results.',
 
     // Testing method tree
     'methods.intro': 'Hierarchical view of common testing methods. Hover or click each branch.',
@@ -2071,6 +2072,7 @@ export const messages = {
     'cloud.err.uploadFailed': '上傳到 Google Drive 失敗。',
     'cloud.err.listFailed': '讀取 Google Drive 檔案列表失敗。',
     'cloud.err.downloadFailed': '下載 Google Drive 檔案失敗。',
+    'cloud.err.noClassCode': '儲存成績需要填入班級代碼。',
 
     'methods.intro': '層級式呈現常見測試方法分類，可滑鼠移上或點選查看細節。',
     'methods.expandAll': '全部展開',

--- a/src/tests/cloudIntegration.test.js
+++ b/src/tests/cloudIntegration.test.js
@@ -10,6 +10,24 @@ describe('cloudIntegration client', () => {
     expect(typeof client.isSupportedOrigin).toBe('boolean');
   });
 
+  it('exposes getUser method', () => {
+    const client = createCloudIntegrationClient();
+    expect(typeof client.getUser).toBe('function');
+    expect(client.getUser()).toBeNull();
+  });
+
+  it('exposes saveResult method', () => {
+    const client = createCloudIntegrationClient();
+    expect(typeof client.saveResult).toBe('function');
+  });
+
+  it('exposes loadCourseResults method that resolves to empty array when unconfigured', async () => {
+    const client = createCloudIntegrationClient();
+    const results = await client.loadCourseResults('TEST');
+    expect(Array.isArray(results)).toBe(true);
+    expect(results).toHaveLength(0);
+  });
+
   it('fails sign-in in unsupported test environment with meaningful message', async () => {
     const client = createCloudIntegrationClient();
 
@@ -24,5 +42,13 @@ describe('cloudIntegration client', () => {
     }
 
     await expect(client.signInWithGoogle()).rejects.toThrow(/operation-not-supported|popup|auth|SDK 尚未載入/i);
+  });
+
+  it('saveResult rejects when unconfigured or unsupported', async () => {
+    const client = createCloudIntegrationClient();
+    if (client.isConfigured && client.isSupportedOrigin) return; // skip in live env
+    await expect(
+      client.saveResult('uid', 'Name', 'a@b.com', 'ABC', { explorer: 'graph', score: 1, total: 2 })
+    ).rejects.toThrow();
   });
 });

--- a/src/utils/cloudIntegration.js
+++ b/src/utils/cloudIntegration.js
@@ -36,6 +36,7 @@ export function createCloudIntegrationClient() {
       missingKeys,
       isSupportedOrigin,
       originWarning: originMessage,
+      getUser() { return null; },
       subscribeAuthState(callback) {
         callback(null);
         return () => {};
@@ -54,34 +55,48 @@ export function createCloudIntegrationClient() {
       },
       async uploadFileToDrive() {
         throw new Error(originMessage);
+      },
+      async saveResult() {
+        throw new Error(originMessage);
+      },
+      async loadCourseResults() {
+        return [];
       },
     };
   }
 
   if (!isConfigured) {
+    const incompleteMsg = () => t('cloud.err.firebaseIncomplete', { keys: missingKeys.join(', ') });
     return {
       isConfigured,
       missingKeys,
       isSupportedOrigin,
       originWarning: '',
+      getUser() { return null; },
       subscribeAuthState(callback) {
         callback(null);
         return () => {};
       },
       async signInWithGoogle() {
-        throw new Error(t('cloud.err.firebaseIncomplete', { keys: missingKeys.join(', ') }));
+        throw new Error(incompleteMsg());
       },
       async signOutGoogle() {
-        throw new Error(t('cloud.err.firebaseIncomplete', { keys: missingKeys.join(', ') }));
+        throw new Error(incompleteMsg());
       },
       async saveSettings() {
-        throw new Error(t('cloud.err.firebaseIncomplete', { keys: missingKeys.join(', ') }));
+        throw new Error(incompleteMsg());
       },
       async loadSettings() {
-        throw new Error(t('cloud.err.firebaseIncomplete', { keys: missingKeys.join(', ') }));
+        throw new Error(incompleteMsg());
       },
       async uploadFileToDrive() {
-        throw new Error(t('cloud.err.firebaseIncomplete', { keys: missingKeys.join(', ') }));
+        throw new Error(incompleteMsg());
+      },
+      async saveResult() {
+        throw new Error(incompleteMsg());
+      },
+      async loadCourseResults() {
+        return [];
       },
     };
   }
@@ -94,6 +109,7 @@ export function createCloudIntegrationClient() {
       missingKeys,
       isSupportedOrigin,
       originWarning: '',
+      getUser() { return null; },
       subscribeAuthState(callback) {
         callback(null);
         return () => {};
@@ -112,6 +128,12 @@ export function createCloudIntegrationClient() {
       },
       async uploadFileToDrive() {
         throw new Error(sdkMessage);
+      },
+      async saveResult() {
+        throw new Error(sdkMessage);
+      },
+      async loadCourseResults() {
+        return [];
       },
     };
   }
@@ -132,6 +154,9 @@ export function createCloudIntegrationClient() {
     missingKeys,
     isSupportedOrigin,
     originWarning: '',
+    getUser() {
+      return auth.currentUser;
+    },
     subscribeAuthState(callback) {
       return auth.onAuthStateChanged(callback);
     },
@@ -259,6 +284,40 @@ export function createCloudIntegrationClient() {
         throw new Error(msg);
       }
       return response.text();
+    },
+
+    // ── F-B result storage ────────────────────────────────────────────────────
+
+    async saveResult(uid, displayName, email, classCode, payload) {
+      if (!classCode || !classCode.trim()) throw new Error(t('cloud.err.noClassCode'));
+      const code = classCode.trim().toUpperCase();
+      const ts = payload.ts || Date.now();
+      const docId = `${uid}_${ts}`;
+      await db.collection('courses').doc(code).collection('results').doc(docId).set({
+        uid,
+        displayName: displayName || '',
+        email: email || '',
+        explorer: payload.explorer || '',
+        explorerLabel: payload.explorerLabel || '',
+        mode: payload.mode || '',
+        score: typeof payload.score === 'number' ? payload.score : 0,
+        total: typeof payload.total === 'number' ? payload.total : 0,
+        ts,
+        lang: payload.lang || 'en',
+        items: Array.isArray(payload.items) ? payload.items : [],
+        savedAt: firebase.firestore.FieldValue.serverTimestamp(),
+      });
+      return docId;
+    },
+
+    async loadCourseResults(classCode) {
+      if (!classCode || !classCode.trim()) return [];
+      const code = classCode.trim().toUpperCase();
+      const snapshot = await db.collection('courses').doc(code).collection('results')
+        .orderBy('ts', 'desc')
+        .limit(500)
+        .get();
+      return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
     },
   };
 }


### PR DESCRIPTION
## Summary

Core Firestore layer for F-B: quiz/lab results can now be saved to `courses/{classCode}/results/` and loaded for teacher dashboard.

- `saveResult` + `loadCourseResults` + `getUser` added to `cloudIntegration.js`
- All three stub branches (file://, unconfigured, SDK-not-loaded) have consistent stubs
- `firestore.rules` added (deploy via `firebase deploy --only firestore:rules`)
- `cloud.err.noClassCode` i18n key in EN + ZH
- 408 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)