### PR TITLE
fix(i18n): sync document.title and <html lang> with current locale

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="zh-TW">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>軟體測試方法視覺化</title>
+    <title>Software Testing Methods Visualization</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="./src/styles.css" />

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -33,9 +33,7 @@ export function setLocale(locale) {
   listeners.forEach((cb) => {
     try { cb(locale); } catch (err) { console.error(err); }
   });
-  if (typeof document !== 'undefined') {
-    document.documentElement?.setAttribute('lang', locale === 'zh' ? 'zh-TW' : 'en');
-  }
+  applyDocumentLocale();
 }
 
 export function onLocaleChange(callback) {
@@ -81,7 +79,14 @@ export function pickField(item, base) {
   return item[base] ?? item[base + 'En'] ?? '';
 }
 
-// Initialise <html lang> attribute on load.
-if (typeof document !== 'undefined') {
+// Sync <html lang> and <title> with the current locale.
+function applyDocumentLocale() {
+  if (typeof document === 'undefined') return;
   document.documentElement?.setAttribute('lang', current === 'zh' ? 'zh-TW' : 'en');
+  const title = t('app.title');
+  if (title && title !== 'app.title') {
+    document.title = title;
+  }
 }
+
+applyDocumentLocale();

--- a/src/tests/i18n.test.js
+++ b/src/tests/i18n.test.js
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getLocale, setLocale, t } from '../i18n/index.js';
+
+describe('i18n document side-effects', () => {
+  let initialLocale;
+
+  beforeEach(() => {
+    initialLocale = getLocale();
+    document.title = 'PLACEHOLDER';
+  });
+
+  afterEach(() => {
+    setLocale(initialLocale);
+  });
+
+  it('setLocale("en") updates <html lang> to "en"', () => {
+    setLocale('zh'); // start from zh
+    setLocale('en');
+    expect(document.documentElement.getAttribute('lang')).toBe('en');
+  });
+
+  it('setLocale("zh") updates <html lang> to "zh-TW"', () => {
+    setLocale('en');
+    setLocale('zh');
+    expect(document.documentElement.getAttribute('lang')).toBe('zh-TW');
+  });
+
+  it('setLocale("en") updates document.title to the English app.title', () => {
+    setLocale('zh');
+    setLocale('en');
+    expect(document.title).toBe(t('app.title'));
+    expect(document.title).toBe('Software Testing Methods Visualization');
+  });
+
+  it('setLocale("zh") updates document.title to the Chinese app.title', () => {
+    setLocale('en');
+    setLocale('zh');
+    expect(document.title).toBe(t('app.title'));
+    expect(document.title).toBe('軟體測試方法視覺化');
+  });
+});


### PR DESCRIPTION
## Bug
The browser tab title stayed in Chinese (軟體測試方法視覺化) even after the user switched the UI to English. The `<title>` element in `index.html` was hard-coded and never updated on locale change. The `<html lang>` attribute was already being synced — this fix extends the same mechanism to `<title>`.

## Fix
- New `applyDocumentLocale()` helper in `src/i18n/index.js` centralizes the DOM side-effects.
  - Sets `<html lang>` to `en` / `zh-TW`.
  - Sets `document.title` to `t('app.title')`, which already exists in both EN and ZH dictionaries.
- Called from `setLocale()` and on module initialization.
- `index.html` static `<html lang>` and `<title>` switched to the English canonical default — pre-JS render matches what most users see; Chinese users get the right title once the i18n module initializes (essentially instantly).
- 4 regression tests in `src/tests/i18n.test.js` cover both directions for both `lang` and `title`.

## Test plan
- [x] `npm run test:run` — 479/479 pass (was 475 before, +4 for i18n).
- [ ] CI green on GitHub Actions.
- [ ] Manual: open the live demo, toggle the language switcher, confirm the browser tab title updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)