### PR TITLE
feat(overview): K2 — tag-chip filter on Overview page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -33,6 +33,8 @@ import { createMutationScoreExplorer } from './components/MutationScoreExplorer.
 import { createLLMPipelineExplorer } from './components/LLMPipelineExplorer.js';
 import { createTestQualityExplorer } from './components/TestQualityExplorer.js';
 import { createFaultDirectedTestingExplorer } from './components/FaultDirectedTestingExplorer.js';
+import { createTagFilterBar, filterFromQuery, filterToQuery } from './components/TagFilterBar.js';
+import { sectionMatchesFilter } from './data/explorerTags.js';
 import { createResultViewer } from './components/ResultViewer.js';
 import { createTeacherDashboard } from './components/TeacherDashboard.js';
 import { buildShareUrl } from './utils/resultExporter.js';
@@ -139,6 +141,8 @@ export function renderApp(container) {
               <h2 id="section-overview-title">${t('section.all')}</h2>
               <p>${t('app.overview.subtitle')}</p>
             </div>
+            <div class="overview-filter" data-testid="overview-filter"></div>
+            <div class="overview-grid__counter" data-testid="overview-counter"></div>
             <div class="overview-grid" data-testid="overview-grid"></div>
           </section>
           <section data-testid="section-methods" tabindex="-1" aria-labelledby="section-methods-title"><h2 id="section-methods-title">${t('section.methods.title')}</h2><div data-slot="methods"></div></section>
@@ -537,33 +541,74 @@ export function renderApp(container) {
     let cloudDrawerOpen = false;
     const sectionsById = Object.fromEntries(sectionSelectConfig.map((section) => [section.id, section]));
     const overviewGrid = container.querySelector('[data-testid="overview-grid"]');
+    const overviewCounter = container.querySelector('[data-testid="overview-counter"]');
+    const overviewFilterHost = container.querySelector('[data-testid="overview-filter"]');
     const cloudTrigger = container.querySelector('[data-app-cloud]');
     const cloudDrawer = container.querySelector('[data-testid="cloud-settings-drawer"]');
     const cloudDrawerPanel = cloudDrawer.querySelector('.cloud-drawer__panel');
     let drawerReturnFocusTarget = null;
 
+    let activeFilter = filterFromQuery(globalThis.location?.search ?? '');
+    const filterBar = createTagFilterBar({
+      initial: activeFilter,
+      onChange: (next) => {
+        activeFilter = next;
+        syncFilterToUrl(next);
+        renderOverview();
+      },
+    });
+    overviewFilterHost.appendChild(filterBar.element);
+
+    function syncFilterToUrl(filter) {
+      try {
+        const qs = filterToQuery(filter);
+        const url = `${globalThis.location.pathname}${qs}${globalThis.location.hash}`;
+        globalThis.history?.replaceState?.(null, '', url);
+      } catch {
+        // Ignore — `replaceState` may be unavailable in some test envs.
+      }
+    }
+
     function renderOverview() {
-      overviewGrid.innerHTML = overviewGroups.map((group) => `
-        <section class="overview-group">
-          <h3>${t(group.key)}</h3>
-          <div class="overview-card-grid">
-            ${group.sectionIds.map((id) => {
-              const section = sectionsById[id];
-              return `
-                <button
-                  class="overview-card"
-                  type="button"
-                  data-overview-section="${section.id}"
-                >
-                  <span class="overview-card__label">${t(section.key)}</span>
-                  <span class="overview-card__title">${t(`section.${section.id}.title`)}</span>
-                  <span class="overview-card__desc">${t(`overview.desc.${section.id}`)}</span>
-                </button>
-              `;
-            }).join('')}
-          </div>
-        </section>
-      `).join('');
+      const totalSections = overviewGroups.reduce((n, g) => n + g.sectionIds.length, 0);
+      let visibleSections = 0;
+
+      overviewGrid.innerHTML = overviewGroups.map((group) => {
+        const visibleIds = group.sectionIds.filter((id) => sectionMatchesFilter(id, activeFilter));
+        visibleSections += visibleIds.length;
+        if (visibleIds.length === 0) {
+          return `<section class="overview-group overview-group--hidden" aria-hidden="true"></section>`;
+        }
+        return `
+          <section class="overview-group">
+            <h3>${t(group.key)}</h3>
+            <div class="overview-card-grid">
+              ${visibleIds.map((id) => {
+                const section = sectionsById[id];
+                return `
+                  <button
+                    class="overview-card"
+                    type="button"
+                    data-overview-section="${section.id}"
+                  >
+                    <span class="overview-card__label">${t(section.key)}</span>
+                    <span class="overview-card__title">${t(`section.${section.id}.title`)}</span>
+                    <span class="overview-card__desc">${t(`overview.desc.${section.id}`)}</span>
+                  </button>`;
+              }).join('')}
+            </div>
+          </section>`;
+      }).join('');
+
+      if (overviewCounter) {
+        if (visibleSections === 0) {
+          overviewCounter.textContent = t('filter.empty');
+        } else if (visibleSections === totalSections) {
+          overviewCounter.textContent = '';
+        } else {
+          overviewCounter.textContent = t('filter.results', { visible: visibleSections, total: totalSections });
+        }
+      }
 
       overviewGrid.querySelectorAll('[data-overview-section]').forEach((button) => {
         button.addEventListener('click', () => {

--- a/src/components/TagFilterBar.css
+++ b/src/components/TagFilterBar.css
@@ -1,0 +1,99 @@
+.tag-filter-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  background: var(--app-surface, #fff);
+  border: 1px solid var(--app-border, #e2e8f0);
+  border-radius: var(--app-radius-md, 8px);
+}
+
+.tag-filter-bar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tag-filter-bar__title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--app-text-strong, #1f2a44);
+}
+
+.tag-filter-bar__clear {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+  border: 1px solid var(--app-border, #e2e8f0);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--app-text-muted, #475569);
+  cursor: pointer;
+}
+.tag-filter-bar__clear:hover:not(:disabled) {
+  background: #f1f5f9;
+}
+.tag-filter-bar__clear:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.tag-filter-row {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: 8px;
+  align-items: flex-start;
+}
+@media (max-width: 700px) {
+  .tag-filter-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.tag-filter-row__label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--app-text-muted, #64748b);
+  padding-top: 4px;
+}
+
+.tag-filter-row__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-chip {
+  padding: 0.18rem 0.6rem;
+  border: 1px solid var(--app-border, #e2e8f0);
+  border-radius: 999px;
+  background: #f8fafc;
+  font-size: 0.74rem;
+  color: var(--app-text, #374151);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.tag-chip:hover {
+  background: #eef2f7;
+}
+.tag-chip--active {
+  background: #1d4ed8;
+  color: #fff;
+  border-color: #1d4ed8;
+  font-weight: 600;
+}
+.tag-chip--active:hover {
+  background: #1e40af;
+}
+
+.overview-grid__counter {
+  font-size: 0.82rem;
+  color: var(--app-text-muted, #64748b);
+  margin-bottom: 8px;
+}
+
+.overview-group--hidden,
+.overview-card--hidden {
+  display: none !important;
+}

--- a/src/components/TagFilterBar.js
+++ b/src/components/TagFilterBar.js
@@ -1,0 +1,128 @@
+import { t } from '../i18n/index.js';
+import {
+  TAG_LEVELS,
+  TAG_TECHNIQUES,
+  TAG_SERIES,
+  TAG_DIFFICULTY,
+} from '../data/explorerTags.js';
+
+const DIMENSIONS = [
+  { id: 'level',      values: TAG_LEVELS },
+  { id: 'series',     values: TAG_SERIES },
+  { id: 'difficulty', values: TAG_DIFFICULTY },
+  { id: 'technique',  values: TAG_TECHNIQUES },
+];
+
+const EMPTY_FILTER = () => ({ level: [], technique: [], series: [], difficulty: [] });
+
+export function createTagFilterBar({ initial, onChange } = {}) {
+  const state = {
+    filter: normalizeFilter(initial),
+    listener: typeof onChange === 'function' ? onChange : () => {},
+  };
+
+  const root = document.createElement('div');
+  root.className = 'tag-filter-bar';
+  root.dataset.testid = 'tag-filter-bar';
+
+  function render() {
+    const totalActive = Object.values(state.filter).reduce((n, arr) => n + arr.length, 0);
+    root.innerHTML = `
+      <div class="tag-filter-bar__header">
+        <span class="tag-filter-bar__title">${t('filter.title')}</span>
+        <button type="button" class="tag-filter-bar__clear"
+          data-testid="tag-filter-clear"
+          ${totalActive === 0 ? 'disabled' : ''}>
+          ${t('filter.clear')}
+        </button>
+      </div>
+      ${DIMENSIONS.map((dim) => `
+        <div class="tag-filter-row" data-dim="${dim.id}" data-testid="tag-filter-row-${dim.id}">
+          <span class="tag-filter-row__label">${t('filter.dim.' + dim.id)}</span>
+          <div class="tag-filter-row__chips">
+            ${dim.values.map((v) => {
+              const active = state.filter[dim.id].includes(v);
+              return `
+                <button type="button"
+                  class="tag-chip${active ? ' tag-chip--active' : ''}"
+                  data-dim="${dim.id}" data-value="${v}"
+                  data-testid="tag-chip-${dim.id}-${v}"
+                  aria-pressed="${active ? 'true' : 'false'}">
+                  ${t('tag.' + dim.id + '.' + v)}
+                </button>`;
+            }).join('')}
+          </div>
+        </div>
+      `).join('')}`;
+
+    root.querySelectorAll('[data-dim][data-value]').forEach((btn) => {
+      btn.addEventListener('click', () => toggle(btn.dataset.dim, btn.dataset.value));
+    });
+    root.querySelector('[data-testid="tag-filter-clear"]')?.addEventListener('click', () => clear());
+  }
+
+  function toggle(dim, value) {
+    const arr = state.filter[dim] ?? [];
+    const i = arr.indexOf(value);
+    if (i === -1) arr.push(value); else arr.splice(i, 1);
+    state.filter[dim] = arr;
+    render();
+    state.listener(getFilter());
+  }
+
+  function clear() {
+    state.filter = EMPTY_FILTER();
+    render();
+    state.listener(getFilter());
+  }
+
+  function getFilter() {
+    // Return a shallow clone so external consumers can't mutate internal state.
+    return {
+      level: [...state.filter.level],
+      technique: [...state.filter.technique],
+      series: [...state.filter.series],
+      difficulty: [...state.filter.difficulty],
+    };
+  }
+
+  function setFilter(next) {
+    state.filter = normalizeFilter(next);
+    render();
+  }
+
+  render();
+  return { element: root, getFilter, setFilter, clear };
+}
+
+function normalizeFilter(input) {
+  const out = EMPTY_FILTER();
+  if (!input || typeof input !== 'object') return out;
+  for (const dim of ['level', 'technique', 'series', 'difficulty']) {
+    const v = input[dim];
+    if (Array.isArray(v)) out[dim] = [...v];
+  }
+  return out;
+}
+
+// ── URL query-param sync helpers (used by app.js) ────────────────────
+
+export function filterFromQuery(search) {
+  const params = new URLSearchParams(search ?? '');
+  const out = EMPTY_FILTER();
+  for (const dim of ['level', 'technique', 'series', 'difficulty']) {
+    const v = params.get(dim);
+    if (v) out[dim] = v.split(',').filter(Boolean);
+  }
+  return out;
+}
+
+export function filterToQuery(filter) {
+  const params = new URLSearchParams();
+  for (const dim of ['level', 'technique', 'series', 'difficulty']) {
+    const arr = filter?.[dim];
+    if (Array.isArray(arr) && arr.length > 0) params.set(dim, arr.join(','));
+  }
+  const s = params.toString();
+  return s ? `?${s}` : '';
+}

--- a/src/data/explorerTags.js
+++ b/src/data/explorerTags.js
@@ -212,6 +212,48 @@ export const EXPLORER_TAGS = {
   },
 };
 
+// ── Section ↔ Explorer mapping (used by K2 Overview filter) ────────
+//
+// Each Overview section card represents one or more child Explorers; this
+// table is the bridge from "section card" (the user-facing unit) to the
+// tag entries in EXPLORER_TAGS (which are per-Explorer).
+
+export const SECTION_EXPLORERS = {
+  methods: ['TestingMethodTree'],
+  flow: ['TestingFlow', 'DefectCostExplorer', 'VModelExplorer'],
+  types: ['TestingTypesTable', 'PyramidAdjusterExplorer'],
+  graph: ['GraphCoverageExplorer'],
+  logic: ['LogicCoverageExplorer'],
+  syntax: ['SyntaxCoverageExplorer', 'GrammarCoverageExplorer', 'SpecMutationExplorer'],
+  codecov: ['CodeCoverageExplorer'],
+  groupth: ['GroupTheoryExplorer'],
+  symbex: ['SymbolicExecutionExplorer'],
+  concolic: ['ConcolicExecutionExplorer'],
+  fuzz: ['FuzzTestingExplorer'],
+  testgen: ['TestGenerationExplorer'],
+  pbt: ['PropertyBasedTestingExplorer'],
+  inttest: ['IntegrationTestingExplorer'],
+  rbt: ['RiskBasedTestingExplorer'],
+  blackbox: [
+    'BoundaryValueExplorer',
+    'EquivalenceClassExplorer',
+    'DecisionTableExplorer',
+    'StateTransitionExplorer',
+    'PairwiseExplorer',
+    'CauseEffectExplorer',
+    'MetamorphicTestingExplorer',
+    'ExploratoryTestingExplorer',
+    'TestDoublesExplorer',
+  ],
+  advanced: [
+    'EquivalentMutantExplorer',
+    'MutationScoreExplorer',
+    'LLMPipelineExplorer',
+    'TestQualityExplorer',
+    'FaultDirectedTestingExplorer',
+  ],
+};
+
 // ── Helpers ────────────────────────────────────────────────────────
 
 export function getExplorerTags(id) {
@@ -230,4 +272,36 @@ export function filterExplorersByTag(dim, value) {
 
 export function listExplorersInSeries(seriesId) {
   return filterExplorersByTag('series', seriesId);
+}
+
+// Aggregate every tag value (union) across the explorers in `sectionId`.
+// Returns { level: Set, technique: Set, series: Set, difficulty: Set, source: Set }.
+export function getSectionTags(sectionId) {
+  const explorers = SECTION_EXPLORERS[sectionId] ?? [];
+  const agg = { level: new Set(), technique: new Set(), series: new Set(), difficulty: new Set(), source: new Set() };
+  for (const id of explorers) {
+    const tags = EXPLORER_TAGS[id];
+    if (!tags) continue;
+    for (const v of tags.level ?? []) agg.level.add(v);
+    for (const v of tags.technique ?? []) agg.technique.add(v);
+    for (const v of tags.series ?? []) agg.series.add(v);
+    if (tags.difficulty) agg.difficulty.add(tags.difficulty);
+    for (const v of tags.source ?? []) agg.source.add(v);
+  }
+  return agg;
+}
+
+// AND between dims, OR within a dim. Empty dim arrays act as wildcards.
+// Filter shape: { level: ['unit'], technique: ['mutation', 'llm-guided'], ... }
+export function sectionMatchesFilter(sectionId, filter) {
+  if (!filter) return true;
+  const tags = getSectionTags(sectionId);
+  for (const dim of ['level', 'technique', 'series', 'difficulty', 'source']) {
+    const wanted = filter[dim];
+    if (!Array.isArray(wanted) || wanted.length === 0) continue;
+    const has = tags[dim];
+    const hit = wanted.some((v) => has.has(v));
+    if (!hit) return false;
+  }
+  return true;
 }

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -1083,6 +1083,16 @@ export const messages = {
     'tag.source.textbook': 'Textbook',
     'tag.source.paper.arxiv-2501.12862': 'Meta ACH (FSE 2025)',
 
+    // K2 overview filter
+    'filter.title': 'Filter by tag',
+    'filter.clear': 'Clear all',
+    'filter.dim.level': 'Level',
+    'filter.dim.technique': 'Technique',
+    'filter.dim.series': 'Series',
+    'filter.dim.difficulty': 'Difficulty',
+    'filter.results': 'Showing {visible} of {total} sections',
+    'filter.empty': 'No sections match the current filter. Clear to see all.',
+
     'common.run': 'Run',
     'common.reset': 'Reset',
     'common.save': 'Save',
@@ -2550,6 +2560,16 @@ export const messages = {
     'tag.difficulty.research': '研究前沿',
     'tag.source.textbook': '教科書',
     'tag.source.paper.arxiv-2501.12862': 'Meta ACH（FSE 2025）',
+
+    // K2 總覽篩選
+    'filter.title': '依標籤篩選',
+    'filter.clear': '全部清除',
+    'filter.dim.level': '層級',
+    'filter.dim.technique': '技術',
+    'filter.dim.series': '系列',
+    'filter.dim.difficulty': '難度',
+    'filter.results': '顯示 {visible} / {total} 區塊',
+    'filter.empty': '目前篩選沒有符合的區塊，請清除後查看全部。',
 
     'common.reset': '重設',
     'common.save': '儲存',

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,6 +33,7 @@
 @import url('./components/LLMPipelineExplorer.css');
 @import url('./components/TestQualityExplorer.css');
 @import url('./components/FaultDirectedTestingExplorer.css');
+@import url('./components/TagFilterBar.css');
 @import url('./components/IntegrationTestingExplorer.css');
 @import url('./components/PropertyBasedTestingExplorer.css');
 @import url('./components/RiskBasedTestingExplorer.css');

--- a/src/tests/TagFilterBar.test.jsx
+++ b/src/tests/TagFilterBar.test.jsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createTagFilterBar, filterFromQuery, filterToQuery } from '../components/TagFilterBar.js';
+
+function mount(opts = {}) {
+  document.body.innerHTML = '';
+  const bar = createTagFilterBar(opts);
+  document.body.appendChild(bar.element);
+  return bar;
+}
+
+describe('TagFilterBar smoke', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('renders bar container and chip rows', () => {
+    mount();
+    expect(document.querySelector('[data-testid="tag-filter-bar"]')).toBeInTheDocument();
+    for (const dim of ['level', 'series', 'difficulty', 'technique']) {
+      expect(document.querySelector(`[data-testid="tag-filter-row-${dim}"]`)).toBeInTheDocument();
+    }
+  });
+
+  it('clicking a chip toggles it and fires onChange with the active set', () => {
+    let captured = null;
+    const bar = mount({ onChange: (f) => { captured = f; } });
+    document.querySelector('[data-testid="tag-chip-series-ai-assisted"]').click();
+    expect(captured.series).toEqual(['ai-assisted']);
+    expect(bar.getFilter().series).toEqual(['ai-assisted']);
+  });
+
+  it('clicking the same chip twice removes it', () => {
+    const bar = mount();
+    const chip = document.querySelector('[data-testid="tag-chip-level-unit"]');
+    chip.click();
+    expect(bar.getFilter().level).toEqual(['unit']);
+    chip.click();
+    expect(bar.getFilter().level).toEqual([]);
+  });
+
+  it('clear button resets all dims', () => {
+    const bar = mount({ initial: { series: ['ai-assisted'], level: ['unit'] } });
+    expect(bar.getFilter().series).toEqual(['ai-assisted']);
+    document.querySelector('[data-testid="tag-filter-clear"]').click();
+    expect(bar.getFilter().series).toEqual([]);
+    expect(bar.getFilter().level).toEqual([]);
+  });
+
+  it('setFilter updates the chips visually', () => {
+    const bar = mount();
+    bar.setFilter({ technique: ['mutation'] });
+    const chip = document.querySelector('[data-testid="tag-chip-technique-mutation"]');
+    expect(chip.classList.contains('tag-chip--active')).toBe(true);
+  });
+});
+
+describe('TagFilterBar URL query sync', () => {
+  it('filterFromQuery parses comma-separated multi-values', () => {
+    const f = filterFromQuery('?level=unit&technique=mutation,llm-guided&series=ai-assisted');
+    expect(f.level).toEqual(['unit']);
+    expect(f.technique).toEqual(['mutation', 'llm-guided']);
+    expect(f.series).toEqual(['ai-assisted']);
+    expect(f.difficulty).toEqual([]);
+  });
+
+  it('filterFromQuery handles empty / malformed input', () => {
+    expect(filterFromQuery('').level).toEqual([]);
+    expect(filterFromQuery('?').level).toEqual([]);
+    expect(filterFromQuery('?level=').level).toEqual([]);
+  });
+
+  it('filterToQuery skips empty dims', () => {
+    expect(filterToQuery({ level: [], technique: [], series: [], difficulty: [] })).toBe('');
+    expect(filterToQuery({ level: ['unit'] })).toBe('?level=unit');
+    expect(filterToQuery({ technique: ['mutation', 'llm-guided'] })).toBe('?technique=mutation%2Cllm-guided');
+  });
+
+  it('roundtrip: filterToQuery → filterFromQuery preserves values', () => {
+    const original = { level: ['unit', 'system'], technique: ['mutation'], series: ['ai-assisted'], difficulty: ['research'] };
+    const qs = filterToQuery(original);
+    const parsed = filterFromQuery(qs);
+    expect(parsed).toEqual(original);
+  });
+});

--- a/src/tests/explorerTags.test.js
+++ b/src/tests/explorerTags.test.js
@@ -60,7 +60,7 @@ describe('Explorer tag metadata (K1)', () => {
     const componentFiles = import.meta.glob('../components/*.js', { eager: false });
     const componentNames = Object.keys(componentFiles)
       .map((p) => p.split('/').pop().replace(/\.js$/, ''))
-      .filter((n) => !['CloudStoragePanel', 'TeacherDashboard', 'ResultViewer'].includes(n));
+      .filter((n) => !['CloudStoragePanel', 'TeacherDashboard', 'ResultViewer', 'TagFilterBar'].includes(n));
     for (const name of componentNames) {
       expect(EXPLORER_TAGS, `missing tag entry for ${name}`).toHaveProperty(name);
     }

--- a/src/tests/overviewFilter.test.js
+++ b/src/tests/overviewFilter.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SECTION_EXPLORERS,
+  getSectionTags,
+  sectionMatchesFilter,
+} from '../data/explorerTags.js';
+
+describe('K2 — section ↔ tag aggregation', () => {
+  it('SECTION_EXPLORERS covers every Overview section card', () => {
+    const expected = [
+      'methods', 'flow', 'types', 'graph', 'logic', 'syntax', 'codecov',
+      'groupth', 'symbex', 'concolic', 'fuzz', 'testgen', 'pbt', 'inttest',
+      'rbt', 'blackbox', 'advanced',
+    ];
+    for (const id of expected) {
+      expect(SECTION_EXPLORERS, `missing ${id}`).toHaveProperty(id);
+      expect(SECTION_EXPLORERS[id].length, `${id} non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('getSectionTags(\'advanced\') aggregates all 5 I-series tags', () => {
+    const tags = getSectionTags('advanced');
+    expect(tags.level.has('unit')).toBe(true);
+    expect(tags.technique.has('mutation')).toBe(true);
+    expect(tags.technique.has('llm-guided')).toBe(true);
+    expect(tags.series.has('ai-assisted')).toBe(true);
+    expect(tags.difficulty.has('research')).toBe(true);
+    expect(tags.source.has('paper:arxiv-2501.12862')).toBe(true);
+  });
+
+  it('getSectionTags(\'blackbox\') includes pairwise and cause-effect', () => {
+    const tags = getSectionTags('blackbox');
+    expect(tags.technique.has('pairwise')).toBe(true);
+    expect(tags.technique.has('cause-effect')).toBe(true);
+    expect(tags.technique.has('boundary')).toBe(true);
+    expect(tags.series.has('blackbox')).toBe(true);
+  });
+
+  it('sectionMatchesFilter: empty filter matches everything', () => {
+    for (const id of Object.keys(SECTION_EXPLORERS)) {
+      expect(sectionMatchesFilter(id, {})).toBe(true);
+    }
+  });
+
+  it('sectionMatchesFilter: AND between dims, OR within a dim', () => {
+    // advanced section: level=unit, technique∋mutation, series∋ai-assisted
+    expect(sectionMatchesFilter('advanced', { series: ['ai-assisted'] })).toBe(true);
+    expect(sectionMatchesFilter('advanced', { technique: ['mutation'] })).toBe(true);
+    expect(sectionMatchesFilter('advanced', { technique: ['mutation'], series: ['ai-assisted'] })).toBe(true);
+    expect(sectionMatchesFilter('advanced', { technique: ['mutation'], series: ['blackbox'] })).toBe(false);
+    expect(sectionMatchesFilter('advanced', { technique: ['mutation', 'pairwise'] })).toBe(true); // OR
+  });
+
+  it('sectionMatchesFilter: filters out non-matching sections', () => {
+    expect(sectionMatchesFilter('graph', { series: ['ai-assisted'] })).toBe(false);
+    expect(sectionMatchesFilter('groupth', { difficulty: ['intro'] })).toBe(false);
+    expect(sectionMatchesFilter('groupth', { difficulty: ['research'] })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Second phase of **K. Tagging & Classification** (Plan.md § K). Builds on the K1 metadata layer (#184) to let users narrow the Overview by clicking tag chips, with URL state for shareable / bookmarkable filtered views.

## Filter behavior
- Chip rows for **level** (7), **series** (8), **difficulty** (4), **technique** (22).
- **AND** between dimensions, **OR** within a dimension. Empty dim = wildcard.
- **Clear all** button disables when nothing is selected.
- "Showing N of M sections" counter when filter is active; empty-state message when no section matches.

## URL sync
- Filter state encoded as `?level=unit&technique=mutation,llm-guided&series=ai-assisted&difficulty=research`.
- Read on page load via `filterFromQuery(location.search)`.
- Written on chip toggle via `history.replaceState` (no history-stack pollution).
- Survives locale switches because URL is the source of truth.

## What changed
- `src/data/explorerTags.js`: added `SECTION_EXPLORERS` (17 sections → child explorer IDs), `getSectionTags(sectionId)` (aggregates child tags as Sets), and `sectionMatchesFilter(sectionId, filter)` helper.
- New `src/components/TagFilterBar.{js,css}` — self-contained chip-row component returning `{ element, getFilter, setFilter, clear }`.
- `src/app.js` — mounts the bar above `overview-grid`, hooks chip changes back to `renderOverview()`.
- `src/i18n/dict.js` — `filter.*` keys for EN + ZH.
- 15 new tests (6 helper, 9 component / URL-sync).

## Test plan
- [x] `npm run test:run` — 504/504 (was 489; +15 for K2 helpers, component, URL sync).
- [x] Manually clicked through chip combos in dev to verify visual hiding + URL update.
- [ ] CI green on GitHub Actions.

Closes #185. K3 (course-series export) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)