### PR TITLE
feat(router): K4 — unified URL routing (?section / ?tab / ?explorer / ?pack)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -120,6 +120,9 @@ function persistActiveSection(sectionId) {
 
 export function renderApp(container) {
   function paint() {
+    // Read URL state once at the top of paint() — tabbed-section setups
+    // below reference it, so this MUST run before any of them.
+    const urlState = parseAppLocation(globalThis.location?.search ?? '');
     container.innerHTML = `
       <div class="app">
         <a class="skip-link" href="#app-main">${t('app.skipMain')}</a>
@@ -565,7 +568,6 @@ export function renderApp(container) {
     renderTypesTabs();
     updateTypesPanels();
 
-    const urlState = parseAppLocation(globalThis.location?.search ?? '');
     let activeSection = loadSavedSection(urlState.section);
     let cloudDrawerOpen = false;
     const sectionsById = Object.fromEntries(sectionSelectConfig.map((section) => [section.id, section]));

--- a/src/app.js
+++ b/src/app.js
@@ -33,9 +33,15 @@ import { createMutationScoreExplorer } from './components/MutationScoreExplorer.
 import { createLLMPipelineExplorer } from './components/LLMPipelineExplorer.js';
 import { createTestQualityExplorer } from './components/TestQualityExplorer.js';
 import { createFaultDirectedTestingExplorer } from './components/FaultDirectedTestingExplorer.js';
-import { createTagFilterBar, filterFromQuery, filterToQuery } from './components/TagFilterBar.js';
+import { createTagFilterBar } from './components/TagFilterBar.js';
 import { createCoursePackBar } from './components/CoursePackBar.js';
 import { sectionMatchesFilter } from './data/explorerTags.js';
+import { getCoursePackFilter } from './data/courseSeries.js';
+import {
+  parseAppLocation,
+  serializeLocation,
+  resolveInitialTab,
+} from './utils/urlRouter.js';
 import { createResultViewer } from './components/ResultViewer.js';
 import { createTeacherDashboard } from './components/TeacherDashboard.js';
 import { buildShareUrl } from './utils/resultExporter.js';
@@ -92,7 +98,9 @@ const overviewGroups = [
   },
 ];
 
-function loadSavedSection() {
+function loadSavedSection(urlSection) {
+  // URL > localStorage > default.
+  if (urlSection && learningSectionsConfig.some((s) => s.id === urlSection)) return urlSection;
   try {
     const saved = globalThis.localStorage?.getItem(ACTIVE_SECTION_KEY);
     return learningSectionsConfig.some((section) => section.id === saved) ? saved : 'all';
@@ -281,12 +289,14 @@ export function renderApp(container) {
       advancedPanels.appendChild(panel);
     }
     const ADVANCED_TAB_KEY = 'stvisual.advancedActiveTab';
-    let activeAdvancedTab = (() => {
-      try {
-        const v = globalThis.localStorage?.getItem(ADVANCED_TAB_KEY);
-        return advancedTabs.find((tb) => tb.id === v) ? v : 'equivmutant';
-      } catch { return 'equivmutant'; }
-    })();
+    let savedAdvancedTab = null;
+    try { savedAdvancedTab = globalThis.localStorage?.getItem(ADVANCED_TAB_KEY); } catch {}
+    let activeAdvancedTab = resolveInitialTab({
+      sectionId: 'advanced',
+      urlSection: urlState.section,
+      urlTab: urlState.tab,
+      saved: savedAdvancedTab,
+    });
     function renderAdvancedTabs() {
       advancedTabBar.innerHTML = advancedTabs.map((tab) => `
         <button type="button"
@@ -302,6 +312,7 @@ export function renderApp(container) {
           try { globalThis.localStorage?.setItem(ADVANCED_TAB_KEY, activeAdvancedTab); } catch {}
           renderAdvancedTabs();
           updateAdvancedPanels();
+          if (activeSection === 'advanced') syncUrl();
         });
       });
     }
@@ -336,12 +347,14 @@ export function renderApp(container) {
       syntaxPanels.appendChild(panel);
     }
     const SYNTAX_TAB_KEY = 'stvisual.syntaxActiveTab';
-    let activeSyntaxTab = (() => {
-      try {
-        const v = globalThis.localStorage?.getItem(SYNTAX_TAB_KEY);
-        return syntaxTabs.find((t) => t.id === v) ? v : 'mutation';
-      } catch { return 'mutation'; }
-    })();
+    let savedSyntaxTab = null;
+    try { savedSyntaxTab = globalThis.localStorage?.getItem(SYNTAX_TAB_KEY); } catch {}
+    let activeSyntaxTab = resolveInitialTab({
+      sectionId: 'syntax',
+      urlSection: urlState.section,
+      urlTab: urlState.tab,
+      saved: savedSyntaxTab,
+    });
     function renderSyntaxTabs() {
       syntaxTabBar.innerHTML = syntaxTabs.map((tab) => `
         <button type="button"
@@ -357,6 +370,7 @@ export function renderApp(container) {
           try { globalThis.localStorage?.setItem(SYNTAX_TAB_KEY, activeSyntaxTab); } catch {}
           renderSyntaxTabs();
           updateSyntaxPanels();
+          if (activeSection === 'syntax') syncUrl();
         });
       });
     }
@@ -397,12 +411,14 @@ export function renderApp(container) {
       blackboxPanels.appendChild(panel);
     }
     const BLACKBOX_TAB_KEY = 'stvisual.blackboxActiveTab';
-    let activeBlackboxTab = (() => {
-      try {
-        const v = globalThis.localStorage?.getItem(BLACKBOX_TAB_KEY);
-        return blackboxTabs.find((tb) => tb.id === v) ? v : 'bva';
-      } catch { return 'bva'; }
-    })();
+    let savedBlackboxTab = null;
+    try { savedBlackboxTab = globalThis.localStorage?.getItem(BLACKBOX_TAB_KEY); } catch {}
+    let activeBlackboxTab = resolveInitialTab({
+      sectionId: 'blackbox',
+      urlSection: urlState.section,
+      urlTab: urlState.tab,
+      saved: savedBlackboxTab,
+    });
     function renderBlackboxTabs() {
       blackboxTabBar.innerHTML = blackboxTabs.map((tab) => `
         <button type="button"
@@ -418,6 +434,7 @@ export function renderApp(container) {
           try { globalThis.localStorage?.setItem(BLACKBOX_TAB_KEY, activeBlackboxTab); } catch {}
           renderBlackboxTabs();
           updateBlackboxPanels();
+          if (activeSection === 'blackbox') syncUrl();
         });
       });
     }
@@ -457,12 +474,14 @@ export function renderApp(container) {
       flowPanels.appendChild(panel);
     }
     const FLOW_TAB_KEY = 'stvisual.flowActiveTab';
-    let activeFlowTab = (() => {
-      try {
-        const v = globalThis.localStorage?.getItem(FLOW_TAB_KEY);
-        return flowTabs.find((tb) => tb.id === v) ? v : 'flow';
-      } catch { return 'flow'; }
-    })();
+    let savedFlowTab = null;
+    try { savedFlowTab = globalThis.localStorage?.getItem(FLOW_TAB_KEY); } catch {}
+    let activeFlowTab = resolveInitialTab({
+      sectionId: 'flow',
+      urlSection: urlState.section,
+      urlTab: urlState.tab,
+      saved: savedFlowTab,
+    });
     function renderFlowTabs() {
       flowTabBar.innerHTML = flowTabs.map((tab) => `
         <button type="button"
@@ -478,6 +497,7 @@ export function renderApp(container) {
           try { globalThis.localStorage?.setItem(FLOW_TAB_KEY, activeFlowTab); } catch {}
           renderFlowTabs();
           updateFlowPanels();
+          if (activeSection === 'flow') syncUrl();
         });
       });
     }
@@ -495,7 +515,12 @@ export function renderApp(container) {
       { id: 'pyramid', key: 'typesTab.pyramid', component: components.types },
       { id: 'adjuster', key: 'typesTab.adjuster', component: components.pyramid },
     ];
-    let activeTypesTab = 'pyramid';
+    let activeTypesTab = resolveInitialTab({
+      sectionId: 'types',
+      urlSection: urlState.section,
+      urlTab: urlState.tab,
+      saved: null,
+    });
 
     const typesTabBar = document.createElement('nav');
     typesTabBar.className = 'syntax-tab-row';
@@ -528,6 +553,7 @@ export function renderApp(container) {
           activeTypesTab = btn.dataset.typesTab;
           renderTypesTabs();
           updateTypesPanels();
+          if (activeSection === 'types') syncUrl();
         });
       });
     }
@@ -539,7 +565,8 @@ export function renderApp(container) {
     renderTypesTabs();
     updateTypesPanels();
 
-    let activeSection = loadSavedSection();
+    const urlState = parseAppLocation(globalThis.location?.search ?? '');
+    let activeSection = loadSavedSection(urlState.section);
     let cloudDrawerOpen = false;
     const sectionsById = Object.fromEntries(sectionSelectConfig.map((section) => [section.id, section]));
     const overviewGrid = container.querySelector('[data-testid="overview-grid"]');
@@ -551,38 +578,63 @@ export function renderApp(container) {
     const cloudDrawerPanel = cloudDrawer.querySelector('.cloud-drawer__panel');
     let drawerReturnFocusTarget = null;
 
-    let activeFilter = filterFromQuery(globalThis.location?.search ?? '');
+    // Initial filter: pack > raw filter > empty.
+    const initialPackFilter = urlState.pack ? getCoursePackFilter(urlState.pack) : null;
+    let activeFilter = (urlState.filter || initialPackFilter)
+      ? { level: [], technique: [], series: [], difficulty: [], ...(urlState.filter || initialPackFilter || {}) }
+      : { level: [], technique: [], series: [], difficulty: [] };
+
     const filterBar = createTagFilterBar({
       initial: activeFilter,
       onChange: (next) => {
         activeFilter = next;
-        syncFilterToUrl(next);
         // User-driven filter changes clear any active course pack so the
         // UI doesn't show a stale "this pack is selected" state.
         packBar?.clear();
+        syncUrl();
         renderOverview();
       },
     });
     overviewFilterHost.appendChild(filterBar.element);
 
     const packBar = createCoursePackBar({
+      initial: urlState.pack ?? null,
       onApplyFilter: (filter) => {
         const next = filter ?? { level: [], technique: [], series: [], difficulty: [] };
         activeFilter = { level: [], technique: [], series: [], difficulty: [], ...next };
         filterBar.setFilter(activeFilter);
-        syncFilterToUrl(activeFilter);
+        syncUrl();
         renderOverview();
       },
     });
     overviewPacksHost.appendChild(packBar.element);
 
-    function syncFilterToUrl(filter) {
+    function syncUrl() {
       try {
-        const qs = filterToQuery(filter);
+        const state = {
+          section: activeSection,
+          tab: getCurrentTabForSection(activeSection),
+          pack: packBar?.getActiveId() ?? null,
+          filter: activeFilter,
+        };
+        const qs = serializeLocation(state);
         const url = `${globalThis.location.pathname}${qs}${globalThis.location.hash}`;
         globalThis.history?.replaceState?.(null, '', url);
       } catch {
         // Ignore — `replaceState` may be unavailable in some test envs.
+      }
+    }
+
+    // Returns the active tab id for sections that have tabs, else undefined.
+    // Defined below `paint()` body so closure captures the latest tab state.
+    function getCurrentTabForSection(sectionId) {
+      switch (sectionId) {
+        case 'syntax':   return activeSyntaxTab;
+        case 'blackbox': return activeBlackboxTab;
+        case 'advanced': return activeAdvancedTab;
+        case 'flow':     return activeFlowTab;
+        case 'types':    return activeTypesTab;
+        default: return undefined;
       }
     }
 
@@ -735,6 +787,7 @@ export function renderApp(container) {
       renderNav();
       updateSectionVisibility();
       updateCloudTriggerState();
+      syncUrl();
       if (shouldScroll) {
         requestAnimationFrame(() => {
           scrollToActiveSection();

--- a/src/components/CoursePackBar.js
+++ b/src/components/CoursePackBar.js
@@ -2,8 +2,9 @@ import { t } from '../i18n/index.js';
 import { COURSE_PACKS, getCoursePackExplorers, getCoursePackFilter } from '../data/courseSeries.js';
 import { downloadCoursePackMarkdown } from '../utils/coursePackExporter.js';
 
-export function createCoursePackBar({ onApplyFilter } = {}) {
-  const state = { activeId: null };
+export function createCoursePackBar({ initial, onApplyFilter } = {}) {
+  const validInitial = COURSE_PACKS.some((p) => p.id === initial);
+  const state = { activeId: validInitial ? initial : null };
   const root = document.createElement('div');
   root.className = 'course-pack-bar';
   root.dataset.testid = 'course-pack-bar';

--- a/src/tests/urlRouter.test.js
+++ b/src/tests/urlRouter.test.js
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TAB_SECTIONS,
+  EXPLORER_TO_LOCATION,
+  parseAppLocation,
+  serializeLocation,
+  explorerToUrl,
+  sectionHasTabs,
+  resolveInitialTab,
+} from '../utils/urlRouter.js';
+import { EXPLORER_TAGS } from '../data/explorerTags.js';
+
+describe('K4 — urlRouter parse', () => {
+  it('empty search returns empty state', () => {
+    expect(parseAppLocation('')).toEqual({});
+  });
+
+  it('?section=blackbox returns { section }', () => {
+    expect(parseAppLocation('?section=blackbox')).toEqual({ section: 'blackbox' });
+  });
+
+  it('?section=blackbox&tab=pairwise returns { section, tab }', () => {
+    expect(parseAppLocation('?section=blackbox&tab=pairwise'))
+      .toEqual({ section: 'blackbox', tab: 'pairwise' });
+  });
+
+  it('?tab= without matching section is ignored', () => {
+    expect(parseAppLocation('?section=graph&tab=pairwise')).toEqual({ section: 'graph' });
+  });
+
+  it('unknown ?tab= for a tabbed section is ignored', () => {
+    expect(parseAppLocation('?section=blackbox&tab=nope')).toEqual({ section: 'blackbox' });
+  });
+
+  it('?explorer= resolves to section + tab and wins over ?section/?tab', () => {
+    const state = parseAppLocation('?explorer=PairwiseExplorer&section=graph');
+    expect(state).toEqual({ explorer: 'PairwiseExplorer', section: 'blackbox', tab: 'pairwise' });
+  });
+
+  it('?explorer= for a non-tabbed section returns only section', () => {
+    expect(parseAppLocation('?explorer=GraphCoverageExplorer'))
+      .toEqual({ explorer: 'GraphCoverageExplorer', section: 'graph' });
+  });
+
+  it('unknown ?explorer= is ignored, falls through to other params', () => {
+    expect(parseAppLocation('?explorer=NoSuch&section=fuzz')).toEqual({ section: 'fuzz' });
+  });
+
+  it('?pack= is captured', () => {
+    expect(parseAppLocation('?pack=ai-assisted')).toEqual({ pack: 'ai-assisted' });
+  });
+
+  it('filter dims parse as comma-separated arrays', () => {
+    const state = parseAppLocation('?level=unit,system&technique=mutation');
+    expect(state.filter).toEqual({
+      level: ['unit', 'system'], technique: ['mutation'], series: [], difficulty: [],
+    });
+  });
+
+  it('combined: pack + section + tab + filter', () => {
+    const state = parseAppLocation('?section=blackbox&tab=pairwise&pack=blackbox&level=system');
+    expect(state.section).toBe('blackbox');
+    expect(state.tab).toBe('pairwise');
+    expect(state.pack).toBe('blackbox');
+    expect(state.filter.level).toEqual(['system']);
+  });
+});
+
+describe('K4 — urlRouter serialize', () => {
+  it('empty state → empty string', () => {
+    expect(serializeLocation({})).toBe('');
+    expect(serializeLocation({ section: 'all' })).toBe('');
+  });
+
+  it('section only', () => {
+    expect(serializeLocation({ section: 'blackbox' })).toBe('?section=blackbox');
+  });
+
+  it('section + tab (tab valid for section)', () => {
+    expect(serializeLocation({ section: 'blackbox', tab: 'pairwise' }))
+      .toBe('?section=blackbox&tab=pairwise');
+  });
+
+  it('section + tab where section has no tabs drops the tab', () => {
+    expect(serializeLocation({ section: 'graph', tab: 'pairwise' })).toBe('?section=graph');
+  });
+
+  it('pack only', () => {
+    expect(serializeLocation({ pack: 'ai-assisted' })).toBe('?pack=ai-assisted');
+  });
+
+  it('pack overrides filter params', () => {
+    const out = serializeLocation({
+      pack: 'ai-assisted',
+      filter: { level: ['unit'], technique: ['mutation'], series: [], difficulty: [] },
+    });
+    expect(out).toBe('?pack=ai-assisted');
+  });
+
+  it('filter without pack emits dim params', () => {
+    const out = serializeLocation({
+      filter: { level: ['unit'], technique: ['mutation'], series: [], difficulty: [] },
+    });
+    expect(out).toContain('level=unit');
+    expect(out).toContain('technique=mutation');
+  });
+
+  it('section + filter coexist', () => {
+    const out = serializeLocation({
+      section: 'blackbox',
+      filter: { level: ['unit'], technique: [], series: [], difficulty: [] },
+    });
+    expect(out).toContain('section=blackbox');
+    expect(out).toContain('level=unit');
+  });
+});
+
+describe('K4 — round-trip', () => {
+  it('section + tab + pack round-trip preserves state', () => {
+    const original = { section: 'advanced', tab: 'equivmutant', pack: 'ai-assisted' };
+    const qs = serializeLocation(original);
+    const parsed = parseAppLocation(qs);
+    expect(parsed.section).toBe('advanced');
+    expect(parsed.tab).toBe('equivmutant');
+    expect(parsed.pack).toBe('ai-assisted');
+  });
+
+  it('section + filter round-trip preserves filter values', () => {
+    const original = {
+      section: 'all',  // dropped on write
+      filter: { level: ['unit', 'system'], technique: ['mutation'], series: [], difficulty: [] },
+    };
+    const qs = serializeLocation(original);
+    const parsed = parseAppLocation(qs);
+    expect(parsed.filter).toEqual(original.filter);
+  });
+});
+
+describe('K4 — EXPLORER_TO_LOCATION', () => {
+  it('covers every entry in EXPLORER_TAGS', () => {
+    for (const id of Object.keys(EXPLORER_TAGS)) {
+      expect(EXPLORER_TO_LOCATION, `missing ${id}`).toHaveProperty(id);
+    }
+  });
+
+  it('every location names an existing section, and tab matches TAB_SECTIONS', () => {
+    for (const [name, loc] of Object.entries(EXPLORER_TO_LOCATION)) {
+      expect(loc.section, `${name} has section`).toBeTruthy();
+      if (loc.tab) {
+        const info = TAB_SECTIONS[loc.section];
+        expect(info, `${name}: ${loc.section} has tab info`).toBeTruthy();
+        expect(info.tabs, `${name}: tab ${loc.tab} valid for ${loc.section}`).toContain(loc.tab);
+      }
+    }
+  });
+});
+
+describe('K4 — explorerToUrl', () => {
+  it('returns ?explorer= form without baseUrl', () => {
+    expect(explorerToUrl('PairwiseExplorer')).toBe('?explorer=PairwiseExplorer');
+  });
+
+  it('returns absolute URL with baseUrl', () => {
+    expect(explorerToUrl('PairwiseExplorer', 'https://example.com/'))
+      .toBe('https://example.com/?explorer=PairwiseExplorer');
+  });
+
+  it('unknown component returns baseUrl (or empty)', () => {
+    expect(explorerToUrl('NoSuchExplorer')).toBe('');
+    expect(explorerToUrl('NoSuchExplorer', 'https://example.com/')).toBe('https://example.com/');
+  });
+});
+
+describe('K4 — resolveInitialTab', () => {
+  it('URL wins when section matches and tab is valid', () => {
+    const tab = resolveInitialTab({
+      sectionId: 'blackbox',
+      urlSection: 'blackbox',
+      urlTab: 'pairwise',
+      saved: 'bva',
+    });
+    expect(tab).toBe('pairwise');
+  });
+
+  it('falls through to saved value when URL section does not match', () => {
+    const tab = resolveInitialTab({
+      sectionId: 'blackbox',
+      urlSection: 'graph',
+      urlTab: 'pairwise',
+      saved: 'ec',
+    });
+    expect(tab).toBe('ec');
+  });
+
+  it('falls through to default when nothing usable', () => {
+    const tab = resolveInitialTab({
+      sectionId: 'blackbox',
+      urlSection: null,
+      urlTab: null,
+      saved: 'invalid-id',
+    });
+    expect(tab).toBe('bva');
+  });
+
+  it('returns null for sections without tabs', () => {
+    const tab = resolveInitialTab({
+      sectionId: 'graph',
+      urlSection: 'graph',
+      urlTab: 'whatever',
+      saved: null,
+    });
+    expect(tab).toBeNull();
+  });
+
+  it('sectionHasTabs reports correctly', () => {
+    expect(sectionHasTabs('blackbox')).toBe(true);
+    expect(sectionHasTabs('advanced')).toBe(true);
+    expect(sectionHasTabs('graph')).toBe(false);
+    expect(sectionHasTabs('all')).toBe(false);
+  });
+});

--- a/src/utils/urlRouter.js
+++ b/src/utils/urlRouter.js
@@ -1,0 +1,174 @@
+// Single source of truth for URL ↔ application state.
+//
+// URL params:
+//   ?section=<id>         Which section is active (omit on overview "all").
+//   ?tab=<id>             Inner tab for tabbed sections (only meaningful if the
+//                         current section actually has tabs).
+//   ?explorer=<Component> Single param that resolves to a section + tab via
+//                         EXPLORER_TO_LOCATION; takes precedence over section/tab
+//                         on parse so a generated link can be short and stable.
+//   ?pack=<id>            Course pack selection (highlights chip + applies its
+//                         filter); when present, raw filter params are ignored.
+//   ?level=...&technique=...&series=...&difficulty=...
+//                         K2 filter dims (comma-separated multi-values).
+//
+// History strategy: `history.replaceState` everywhere so the back button keeps
+// behaving like "previous user-initiated navigation" rather than burning
+// entries on every chip click.
+
+// ── Sections with internal tabs ──────────────────────────────────────
+// Maps section id → { tabs: [...], default: tab }. Used for parse-time
+// validation so `?tab=` from an outdated URL never enters an unknown state.
+export const TAB_SECTIONS = {
+  syntax:   { tabs: ['mutation', 'grammar', 'spec'],                                                  default: 'mutation' },
+  blackbox: { tabs: ['bva', 'ec', 'dt', 'st', 'mt', 'et', 'td', 'pairwise', 'ceg'],                   default: 'bva' },
+  advanced: { tabs: ['equivmutant', 'mutationscore', 'llmpipeline', 'testquality', 'faultdirected'], default: 'equivmutant' },
+  flow:     { tabs: ['flow', 'defectCost', 'vmodel'],                                                 default: 'flow' },
+  types:    { tabs: ['pyramid', 'adjuster'],                                                          default: 'pyramid' },
+};
+
+// ── ComponentName → { section, tab? } ────────────────────────────────
+// Used by `?explorer=` parsing and by K5's per-Explorer Markdown links.
+// Kept hand-maintained so adding/renaming an Explorer is an obvious one-liner.
+export const EXPLORER_TO_LOCATION = {
+  TestingMethodTree:           { section: 'methods' },
+  TestingFlow:                 { section: 'flow', tab: 'flow' },
+  DefectCostExplorer:          { section: 'flow', tab: 'defectCost' },
+  VModelExplorer:              { section: 'flow', tab: 'vmodel' },
+  TestingTypesTable:           { section: 'types', tab: 'pyramid' },
+  PyramidAdjusterExplorer:     { section: 'types', tab: 'adjuster' },
+  GraphCoverageExplorer:       { section: 'graph' },
+  LogicCoverageExplorer:       { section: 'logic' },
+  CodeCoverageExplorer:        { section: 'codecov' },
+  SyntaxCoverageExplorer:      { section: 'syntax', tab: 'mutation' },
+  GrammarCoverageExplorer:     { section: 'syntax', tab: 'grammar' },
+  SpecMutationExplorer:        { section: 'syntax', tab: 'spec' },
+  SymbolicExecutionExplorer:   { section: 'symbex' },
+  ConcolicExecutionExplorer:   { section: 'concolic' },
+  FuzzTestingExplorer:         { section: 'fuzz' },
+  TestGenerationExplorer:      { section: 'testgen' },
+  IntegrationTestingExplorer:  { section: 'inttest' },
+  PropertyBasedTestingExplorer:{ section: 'pbt' },
+  RiskBasedTestingExplorer:    { section: 'rbt' },
+  BoundaryValueExplorer:       { section: 'blackbox', tab: 'bva' },
+  EquivalenceClassExplorer:    { section: 'blackbox', tab: 'ec' },
+  DecisionTableExplorer:       { section: 'blackbox', tab: 'dt' },
+  StateTransitionExplorer:     { section: 'blackbox', tab: 'st' },
+  PairwiseExplorer:            { section: 'blackbox', tab: 'pairwise' },
+  CauseEffectExplorer:         { section: 'blackbox', tab: 'ceg' },
+  MetamorphicTestingExplorer:  { section: 'blackbox', tab: 'mt' },
+  ExploratoryTestingExplorer:  { section: 'blackbox', tab: 'et' },
+  TestDoublesExplorer:         { section: 'blackbox', tab: 'td' },
+  GroupTheoryExplorer:         { section: 'groupth' },
+  EquivalentMutantExplorer:    { section: 'advanced', tab: 'equivmutant' },
+  MutationScoreExplorer:       { section: 'advanced', tab: 'mutationscore' },
+  LLMPipelineExplorer:         { section: 'advanced', tab: 'llmpipeline' },
+  TestQualityExplorer:         { section: 'advanced', tab: 'testquality' },
+  FaultDirectedTestingExplorer:{ section: 'advanced', tab: 'faultdirected' },
+};
+
+const FILTER_DIMS = ['level', 'technique', 'series', 'difficulty'];
+
+// ── parse ────────────────────────────────────────────────────────────
+
+export function parseAppLocation(search) {
+  const params = new URLSearchParams(search ?? '');
+  const out = {};
+
+  // ?explorer= takes precedence over ?section/?tab.
+  const explorer = params.get('explorer');
+  if (explorer && EXPLORER_TO_LOCATION[explorer]) {
+    const loc = EXPLORER_TO_LOCATION[explorer];
+    out.explorer = explorer;
+    out.section = loc.section;
+    if (loc.tab) out.tab = loc.tab;
+  } else {
+    const sec = params.get('section');
+    if (sec) out.section = sec;
+    const tab = params.get('tab');
+    // Only accept ?tab= if it's valid for the named section.
+    if (tab && out.section && TAB_SECTIONS[out.section]?.tabs.includes(tab)) {
+      out.tab = tab;
+    }
+  }
+
+  const pack = params.get('pack');
+  if (pack) out.pack = pack;
+
+  const filter = { level: [], technique: [], series: [], difficulty: [] };
+  let anyFilter = false;
+  for (const dim of FILTER_DIMS) {
+    const raw = params.get(dim);
+    if (raw) {
+      filter[dim] = raw.split(',').filter(Boolean);
+      anyFilter = true;
+    }
+  }
+  if (anyFilter) out.filter = filter;
+
+  return out;
+}
+
+// ── serialize ────────────────────────────────────────────────────────
+
+// Builds the query string portion (incl. leading "?") given a state object.
+// Empty / overview-only state returns ''.
+//
+// `packOverridesFilter` is honored: when state.pack is set, raw filter params
+// are dropped from the URL (single source of truth).
+export function serializeLocation(state) {
+  if (!state) return '';
+  const params = new URLSearchParams();
+
+  if (state.section && state.section !== 'all') {
+    params.set('section', state.section);
+    const sectionInfo = TAB_SECTIONS[state.section];
+    if (sectionInfo && state.tab && sectionInfo.tabs.includes(state.tab)) {
+      params.set('tab', state.tab);
+    }
+  }
+
+  if (state.pack) {
+    params.set('pack', state.pack);
+  } else if (state.filter) {
+    for (const dim of FILTER_DIMS) {
+      const arr = state.filter[dim];
+      if (Array.isArray(arr) && arr.length > 0) params.set(dim, arr.join(','));
+    }
+  }
+
+  const s = params.toString();
+  return s ? `?${s}` : '';
+}
+
+// ── helpers used by app.js and K5 ────────────────────────────────────
+
+export function explorerToUrl(componentName, baseUrl = '') {
+  const loc = EXPLORER_TO_LOCATION[componentName];
+  if (!loc) return baseUrl || '';
+  // We could write `?section=X&tab=Y` instead, but `?explorer=X` is more
+  // compact and survives explorer-to-section restructuring without breaking
+  // old links (the reverse map is the only thing that needs updating).
+  const url = new URL(baseUrl || 'https://example.invalid');
+  url.searchParams.set('explorer', componentName);
+  // When baseUrl is absent we strip the dummy origin so callers get a
+  // relative-style "?explorer=…" they can paste into Markdown verbatim.
+  return baseUrl
+    ? url.toString()
+    : `?${url.searchParams.toString()}`;
+}
+
+// Returns true iff the section actually has tabs.
+export function sectionHasTabs(sectionId) {
+  return Object.prototype.hasOwnProperty.call(TAB_SECTIONS, sectionId);
+}
+
+// Pick the initial tab id for a section: URL takes precedence, then a
+// caller-supplied "saved" value (typically from localStorage), then default.
+export function resolveInitialTab({ sectionId, urlSection, urlTab, saved }) {
+  const info = TAB_SECTIONS[sectionId];
+  if (!info) return null;
+  if (urlSection === sectionId && urlTab && info.tabs.includes(urlTab)) return urlTab;
+  if (saved && info.tabs.includes(saved)) return saved;
+  return info.default;
+}


### PR DESCRIPTION
## Summary
Elevates URLs from "filter state only" (K2) to **full application state**: section, inner tab, course pack, and `?explorer=` short-form deeplinks. Unlocks K5 (per-Explorer Markdown deeplinks).

## URL grammar

| Param | Behavior |
|-------|----------|
| `?section=<id>` | Open that section directly. |
| `?section=<id>&tab=<id>` | Plus pick the inner tab for tabbed sections (syntax / blackbox / advanced / flow / types). |
| `?explorer=<ComponentName>` | Single param; resolves to section+tab via `EXPLORER_TO_LOCATION`. Wins over `?section/?tab`. |
| `?pack=<id>` | Highlights the course-pack chip *and* applies its filter; raw filter params are dropped from the canonical URL when a pack is active. |
| `?level=` `?technique=` `?series=` `?difficulty=` | Existing K2 filter dims (comma-separated). |

## Implementation
- **`src/utils/urlRouter.js`** centralizes parse / serialize / `explorerToUrl` / `resolveInitialTab` so app.js and K5 share one vocabulary.
- **`EXPLORER_TO_LOCATION`** maps all 34 component names to `{ section, tab? }`. A test enforces coverage against `EXPLORER_TAGS`, so adding an Explorer without a location entry breaks CI.
- **`src/app.js`** boot reads the URL once; each of the 5 tabbed sections uses `resolveInitialTab({ urlSection, urlTab, saved, … })`. Tab clicks, section nav, pack chip clicks, and filter chip clicks all funnel through a single `syncUrl()` that writes via `history.replaceState` (no history pollution).
- **`CoursePackBar`** now accepts an `initial` prop so a bookmarked `?pack=` URL restores chip highlighting on reload.

## Test plan
- [x] `npm run test:run` — 551/551 (was 520; +31 K4-specific assertions).
- [x] Manual: opened `?explorer=PairwiseExplorer` → lands on `section-blackbox` + `tab=pairwise`; opened `?pack=ai-assisted` → both pack chip and filter chip restored.
- [ ] CI green on GitHub Actions.

Closes #190. K5 (per-Explorer Markdown deeplinks) follows next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)