### PR TITLE
feat(exporter): K5 — per-Explorer deeplinks in Markdown export

### DIFF
--- a/src/tests/courseSeries.test.js
+++ b/src/tests/courseSeries.test.js
@@ -85,3 +85,35 @@ describe('K3 — Markdown exporter', () => {
     expect(buildCoursePackMarkdown('no-such-pack')).toBe('');
   });
 });
+
+describe('K5 — per-Explorer deeplinks', () => {
+  it('every Explorer entry includes an Open URL with ?explorer=<id>', () => {
+    const md = buildCoursePackMarkdown('ai-assisted');
+    for (const id of getCoursePackExplorers('ai-assisted')) {
+      expect(md, `${id} should have an Open URL`).toContain(`- **Open:** `);
+      expect(md, `${id} URL`).toContain(`?explorer=${id}`);
+    }
+  });
+
+  it('custom baseUrl is honored in both demo link and every Open URL', () => {
+    const md = buildCoursePackMarkdown('ai-assisted', { baseUrl: 'https://example.test/app/' });
+    expect(md).toContain('**Live demo:** https://example.test/app/');
+    expect(md).toContain('https://example.test/app/?explorer=EquivalentMutantExplorer');
+    expect(md).not.toContain('skhuang.github.io');
+  });
+
+  it('defaults to the public demo URL when no baseUrl provided', () => {
+    const md = buildCoursePackMarkdown('foundations');
+    expect(md).toContain('https://skhuang.github.io/stvisual/');
+  });
+
+  it('Open URLs are present in every pack (not just ai-assisted)', () => {
+    for (const packId of ['foundations', 'coverage', 'blackbox', 'mutation', 'group-theory']) {
+      const md = buildCoursePackMarkdown(packId);
+      // Every emitted row should produce a ?explorer= URL.
+      const explorers = getCoursePackExplorers(packId);
+      const matches = md.match(/\?explorer=[A-Za-z]+/g) ?? [];
+      expect(matches.length, `pack ${packId} expected ${explorers.length} URLs`).toBe(explorers.length);
+    }
+  });
+});

--- a/src/utils/coursePackExporter.js
+++ b/src/utils/coursePackExporter.js
@@ -1,6 +1,7 @@
 import { t } from '../i18n/index.js';
 import { EXPLORER_TAGS } from '../data/explorerTags.js';
 import { getCoursePack, getCoursePackExplorers } from '../data/courseSeries.js';
+import { explorerToUrl } from './urlRouter.js';
 
 const DEMO_URL = 'https://skhuang.github.io/stvisual/';
 
@@ -31,7 +32,9 @@ function tagLine(tags) {
   return parts.join(' · ');
 }
 
-export function buildCoursePackMarkdown(packId) {
+// `baseUrl` is injectable so self-hosted deployments can swap the demo
+// origin and tests can pin a stable value. Defaults to the public demo.
+export function buildCoursePackMarkdown(packId, { baseUrl = DEMO_URL } = {}) {
   const pack = getCoursePack(packId);
   if (!pack) return '';
   const ids = getCoursePackExplorers(packId);
@@ -42,7 +45,7 @@ export function buildCoursePackMarkdown(packId) {
   lines.push('');
   lines.push(desc);
   lines.push('');
-  lines.push(`**Live demo:** ${DEMO_URL}`);
+  lines.push(`**Live demo:** ${baseUrl}`);
   lines.push('');
   lines.push(`## Explorers (${ids.length})`);
   lines.push('');
@@ -51,6 +54,8 @@ export function buildCoursePackMarkdown(packId) {
     lines.push(`### ${explorerDisplayName(id)}`);
     lines.push('');
     lines.push(`- **ID:** \`${id}\``);
+    const openUrl = explorerToUrl(id, baseUrl);
+    if (openUrl) lines.push(`- **Open:** ${openUrl}`);
     const tagBits = tagLine(tags);
     if (tagBits) lines.push(`- **Tags:** ${tagBits}`);
     lines.push('');
@@ -65,8 +70,8 @@ export function buildCoursePackMarkdown(packId) {
 // invocation. Safe to call from a click handler. Returns the markdown
 // string so tests / non-browser callers can still inspect it without
 // relying on the file-save side-effect.
-export function downloadCoursePackMarkdown(packId) {
-  const md = buildCoursePackMarkdown(packId);
+export function downloadCoursePackMarkdown(packId, options) {
+  const md = buildCoursePackMarkdown(packId, options);
   if (!md) return null;
   if (typeof document === 'undefined') return md;
   // Some test environments (jsdom) don't implement URL.createObjectURL.


### PR DESCRIPTION
## Summary
Closes out the **K. Tagging & Classification** roadmap. K4 (#191) shipped `urlRouter.explorerToUrl()`; this PR threads it through the course-pack Markdown exporter so generated handouts have a working "Open" link per Explorer.

## What's added
- `buildCoursePackMarkdown(packId, { baseUrl })` — `baseUrl` is now injectable (defaults to `https://skhuang.github.io/stvisual/`). Useful for self-host and for tests.
- Each Explorer row now emits a new line:
  ```
  - **Open:** <baseUrl>?explorer=<ComponentName>
  ```
  right after the `**ID:** \`<id>\`` line.
- `downloadCoursePackMarkdown` forwards the same options through.

## Sample output (excerpt of `ai-assisted` pack)
```
### Equivalent Mutant Explorer

- **ID:** `EquivalentMutantExplorer`
- **Open:** https://skhuang.github.io/stvisual/?explorer=EquivalentMutantExplorer
- **Tags:** level: unit · technique: mutation, llm-guided · difficulty: research · source: paper:arxiv-2501.12862
```

## Test plan
- [x] `npm run test:run` — 555/555 (was 551; +4 K5 assertions).
- [x] Manual: clicked `⬇ Export Markdown` on a few packs, opened resulting `.md` in a viewer, clicked an Open link — landed on the correct section + tab.
- [ ] CI green on GitHub Actions.

Closes #192. **Completes the K series**: K1 #184 · K2 #186 · K3 #188 · K4 #191 · **K5 (this)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)