### PR TITLE
feat(acceptance): J4 — Consumer-Driven Contract Testing (Pact) Explorer

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -36,6 +36,7 @@ import { createFaultDirectedTestingExplorer } from './components/FaultDirectedTe
 import { createBDDGherkinExplorer } from './components/BDDGherkinExplorer.js';
 import { createUseCaseDerivationExplorer } from './components/UseCaseDerivationExplorer.js';
 import { createE2EUserJourneyExplorer } from './components/E2EUserJourneyExplorer.js';
+import { createContractTestingExplorer } from './components/ContractTestingExplorer.js';
 import { createTagFilterBar } from './components/TagFilterBar.js';
 import { createCoursePackBar } from './components/CoursePackBar.js';
 import { sectionMatchesFilter } from './data/explorerTags.js';
@@ -263,6 +264,7 @@ export function renderApp(container) {
       gherkin: createBDDGherkinExplorer(),
       usecase: createUseCaseDerivationExplorer(),
       e2ejourney: createE2EUserJourneyExplorer(),
+      contract: createContractTestingExplorer(),
       cloud: createCloudStoragePanel(),
       flow: createTestingFlow(),
       defectCost: createDefectCostExplorer(),
@@ -345,6 +347,7 @@ export function renderApp(container) {
       { id: 'gherkin', key: 'acceptanceTab.gherkin', component: components.gherkin },
       { id: 'usecase', key: 'acceptanceTab.usecase', component: components.usecase },
       { id: 'e2ejourney', key: 'acceptanceTab.e2ejourney', component: components.e2ejourney },
+      { id: 'contract', key: 'acceptanceTab.contract', component: components.contract },
     ];
     const acceptanceSlot = container.querySelector('[data-slot="acceptance"]');
     const acceptanceTabBar = document.createElement('nav');

--- a/src/components/ContractTestingExplorer.css
+++ b/src/components/ContractTestingExplorer.css
@@ -1,0 +1,89 @@
+.ct-wrap { display: flex; flex-direction: column; gap: 1.25rem; padding: 1rem 0; }
+.ct-title { margin: 0; font-size: 1.2rem; font-weight: 800; color: #1f2a44; }
+.ct-desc  { margin: 0; color: #475569; font-size: 0.9rem; }
+
+.ct-presets { display: flex; flex-wrap: wrap; gap: 6px; }
+.ct-preset-chip {
+  padding: 0.3rem 0.7rem; border: 1px solid #e2e8f0; border-radius: 999px;
+  background: #f8fafc; font-size: 0.8rem; cursor: pointer; color: #374151;
+}
+.ct-preset-chip:hover { background: #eef2f7; }
+.ct-preset-chip--active {
+  background: #1d4ed8; border-color: #1d4ed8; color: #fff; font-weight: 600;
+}
+
+.ct-triad { display: grid; grid-template-columns: 1fr 0.8fr 1fr; gap: 1rem; }
+@media (max-width: 900px) { .ct-triad { grid-template-columns: 1fr; } }
+
+.ct-actor, .ct-broker {
+  background: #fff; border: 1px solid #e2e8f0; border-radius: 8px;
+  padding: 0.7rem 0.85rem; display: flex; flex-direction: column; gap: 0.4rem;
+}
+.ct-actor header, .ct-broker header {
+  font-weight: 700; color: #1f2a44; font-size: 0.95rem; display: flex; align-items: center; gap: 0.5rem;
+}
+.ct-actor__role {
+  font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; color: #fff;
+}
+.ct-actor--consumer { border-left: 4px solid #1d4ed8; }
+.ct-actor--consumer .ct-actor__role { background: #1d4ed8; }
+.ct-actor--provider { border-left: 4px solid #166534; }
+.ct-actor--provider .ct-actor__role { background: #166534; }
+.ct-broker { border-left: 4px solid #92400e; background: #fff7ed; }
+.ct-broker__note { margin: 0; font-size: 0.78rem; color: #78350f; }
+
+.ct-actor h4, .ct-broker h4 { margin: 0; font-size: 0.78rem; color: #475569; font-weight: 600; }
+.ct-json {
+  margin: 0; padding: 0.5rem 0.65rem;
+  background: #1e1e1e; color: #d4d4d4; border-radius: 6px;
+  font-family: 'Fira Code', monospace; font-size: 0.72rem; line-height: 1.5;
+  white-space: pre; overflow-x: auto;
+}
+
+.ct-verdict {
+  padding: 0.6rem 0.85rem; border-radius: 8px; font-size: 0.88rem; display: flex;
+  flex-direction: column; gap: 0.3rem;
+}
+.ct-verdict--pass { background: #f0fdf4; border: 1px solid #86efac; color: #166534; }
+.ct-verdict--fail { background: #fef2f2; border: 1px solid #fca5a5; color: #b91c1c; }
+.ct-issues { margin: 0; padding-left: 1.1rem; font-size: 0.8rem; }
+
+.ct-matrix {
+  background: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 0.9rem 1rem;
+  display: flex; flex-direction: column; gap: 0.6rem;
+}
+.ct-matrix h3 { margin: 0; font-size: 0.95rem; color: #1f2a44; }
+.ct-matrix__table { border-collapse: collapse; font-size: 0.82rem; }
+.ct-matrix__table th, .ct-matrix__table td {
+  border: 1px solid #e2e8f0; padding: 0.35rem 0.7rem; text-align: center;
+}
+.ct-matrix__table th { background: #f1f5f9; color: #1f2a44; }
+.ct-cell { font-weight: 700; }
+.ct-cell--pass { background: #f0fdf4; color: #166534; }
+.ct-cell--fail { background: #fef2f2; color: #b91c1c; }
+.ct-cell--na { color: #94a3b8; }
+
+.ct-bridges { display: flex; flex-wrap: wrap; gap: 6px; }
+.ct-bridge {
+  padding: 0.22rem 0.6rem; border: 1px solid #1d4ed8; border-radius: 999px;
+  background: #fff; color: #1d4ed8; font-size: 0.74rem; cursor: pointer;
+}
+.ct-bridge:hover { background: #1d4ed8; color: #fff; }
+
+.ct-self-test { display: flex; flex-direction: column; gap: 0.7rem; }
+.ct-self-test h3 { margin: 0; font-size: 0.95rem; color: #1f2a44; }
+.ct-quiz-start, .ct-lab-start {
+  padding: 0.35rem 0.9rem; background: #1d4ed8; color: #fff;
+  border: none; border-radius: 5px; font-size: 0.82rem; cursor: pointer; align-self: flex-start;
+}
+.ct-quiz-start:hover, .ct-lab-start:hover { background: #1e40af; }
+.ct-quiz-prompt { font-size: 0.88rem; font-weight: 600; margin: 0 0 0.5rem; color: #1f2a44; }
+.ct-quiz-option { display: flex; align-items: flex-start; gap: 0.4rem; font-size: 0.85rem; margin-bottom: 0.3rem; cursor: pointer; color: #374151; }
+.ct-quiz-submit {
+  margin-top: 0.5rem; padding: 0.3rem 0.8rem;
+  background: #1d4ed8; color: #fff; border: none; border-radius: 5px; font-size: 0.82rem; cursor: pointer;
+}
+.ct-quiz-submit:disabled { opacity: 0.4; cursor: default; }
+.ct-quiz-result { padding: 0.5rem 0.75rem; border-radius: 6px; font-size: 0.85rem; }
+.ct-lab-prompt { font-size: 0.88rem; color: #374151; margin: 0 0 0.4rem; }
+.ct-lab-textarea { width: 100%; border: 1px solid #d0d7e2; border-radius: 5px; padding: 0.4rem 0.6rem; font-size: 0.85rem; resize: vertical; box-sizing: border-box; }

--- a/src/components/ContractTestingExplorer.js
+++ b/src/components/ContractTestingExplorer.js
@@ -1,0 +1,295 @@
+import { t } from '../i18n/index.js';
+
+// Each scenario describes a consumer's expectation and the provider's
+// actual response. verifyScenario() runs a small structural diff:
+// breaking-change kinds (BC.*) come from real-world Pact semantics.
+const SCENARIOS = [
+  {
+    id: 'web-orders',
+    titleKey: 'ct.s.web.title',
+    consumerId: 'web',
+    providerId: 'orders',
+    consumer: {
+      request: { method: 'GET', path: '/orders/42', headers: { Accept: 'application/json' } },
+      response: { status: 200, body: { id: 42, status: 'paid', total: 199.0 } },
+    },
+    provider: {
+      response: { status: 200, body: { id: 42, status: 'paid', total: 199.0 } },
+    },
+  },
+  {
+    id: 'mobile-orders',
+    titleKey: 'ct.s.mobile.title',
+    consumerId: 'mobile',
+    providerId: 'orders',
+    consumer: {
+      request: { method: 'GET', path: '/orders/42', headers: { Accept: 'application/json' } },
+      response: { status: 200, body: { id: 42, status: 'paid', total: 199.0 } },
+    },
+    provider: {
+      // Provider added an optional field 'currency'. Non-breaking — the
+      // consumer simply ignores fields it doesn't read.
+      response: { status: 200, body: { id: 42, status: 'paid', total: 199.0, currency: 'USD' } },
+    },
+  },
+  {
+    id: 'partner-payments',
+    titleKey: 'ct.s.partner.title',
+    consumerId: 'partner',
+    providerId: 'payments',
+    consumer: {
+      request: { method: 'POST', path: '/charges', headers: { 'Content-Type': 'application/json' }, body: { amount: 199, currency: 'USD' } },
+      // Consumer expects `idempotency_key` to be absent (optional in their version).
+      response: { status: 201, body: { id: 'ch_1', amount: 199, currency: 'USD' } },
+    },
+    provider: {
+      // Provider made `idempotency_key` required on the REQUEST, and renamed
+      // `id` → `charge_id` on the RESPONSE. Both are breaking.
+      requiredRequestFields: ['amount', 'currency', 'idempotency_key'],
+      response: { status: 201, body: { charge_id: 'ch_1', amount: 199, currency: 'USD' } },
+    },
+  },
+];
+
+// ── Verification engine (pure, exported for tests) ──────────────────
+
+export const BREAKAGE = {
+  MISSING_REQUIRED_REQUEST: 'missing-required-request',
+  MISSING_RESPONSE_FIELD:   'missing-response-field',
+  STATUS_MISMATCH:          'status-mismatch',
+};
+
+export function verifyScenario(scenario) {
+  const issues = [];
+
+  if (scenario.provider.requiredRequestFields) {
+    const req = scenario.consumer.request.body ?? {};
+    for (const f of scenario.provider.requiredRequestFields) {
+      if (!Object.prototype.hasOwnProperty.call(req, f)) {
+        issues.push({ kind: BREAKAGE.MISSING_REQUIRED_REQUEST, field: f });
+      }
+    }
+  }
+
+  const ec = scenario.consumer.response;
+  const ep = scenario.provider.response;
+  if (ec.status !== ep.status) {
+    issues.push({ kind: BREAKAGE.STATUS_MISMATCH, expected: ec.status, actual: ep.status });
+  }
+  for (const k of Object.keys(ec.body ?? {})) {
+    if (!Object.prototype.hasOwnProperty.call(ep.body ?? {}, k)) {
+      issues.push({ kind: BREAKAGE.MISSING_RESPONSE_FIELD, field: k });
+    }
+  }
+  // Extra fields on provider response are NON-breaking; do not record them.
+
+  return { passed: issues.length === 0, issues };
+}
+
+export function buildMatrix() {
+  const consumers = [...new Set(SCENARIOS.map((s) => s.consumerId))];
+  const providers = [...new Set(SCENARIOS.map((s) => s.providerId))];
+  const cells = {};
+  for (const s of SCENARIOS) cells[`${s.consumerId}|${s.providerId}`] = verifyScenario(s);
+  return { consumers, providers, cells };
+}
+
+// ── State ───────────────────────────────────────────────────────────
+
+const state = {
+  scenarioIdx: 0,
+  quiz: { active: false, phase: 'idle', answer: '' },
+  lab:  { active: false, text: '' },
+};
+
+let root;
+
+function pretty(obj) {
+  return JSON.stringify(obj, null, 2);
+}
+
+function renderTriad() {
+  const s = SCENARIOS[state.scenarioIdx];
+  const v = verifyScenario(s);
+  return `
+    <div class="ct-triad" data-testid="ct-triad">
+      <div class="ct-actor ct-actor--consumer">
+        <header><span class="ct-actor__role">${t('ct.role.consumer')}</span>${t('ct.actor.' + s.consumerId)}</header>
+        <h4>${t('ct.request')}</h4>
+        <pre class="ct-json" data-testid="ct-consumer-req">${pretty(s.consumer.request)}</pre>
+        <h4>${t('ct.expectedResp')}</h4>
+        <pre class="ct-json" data-testid="ct-consumer-resp">${pretty(s.consumer.response)}</pre>
+      </div>
+      <div class="ct-broker">
+        <header>${t('ct.broker')}</header>
+        <p class="ct-broker__note">${t('ct.broker.desc')}</p>
+        <pre class="ct-json" data-testid="ct-broker-contract">${pretty({ consumer: s.consumerId, provider: s.providerId, interaction: s.consumer })}</pre>
+      </div>
+      <div class="ct-actor ct-actor--provider">
+        <header><span class="ct-actor__role">${t('ct.role.provider')}</span>${t('ct.actor.' + s.providerId)}</header>
+        ${s.provider.requiredRequestFields ? `
+          <h4>${t('ct.requiredFields')}</h4>
+          <pre class="ct-json">${pretty(s.provider.requiredRequestFields)}</pre>` : ''}
+        <h4>${t('ct.actualResp')}</h4>
+        <pre class="ct-json" data-testid="ct-provider-resp">${pretty(s.provider.response)}</pre>
+      </div>
+    </div>
+    ${renderVerdict(v)}`;
+}
+
+function renderVerdict(v) {
+  if (v.passed) {
+    return `
+      <div class="ct-verdict ct-verdict--pass" data-testid="ct-verdict">
+        <strong>${t('ct.verdict.pass')}</strong>
+        <p>${t('ct.verdict.pass.desc')}</p>
+      </div>`;
+  }
+  return `
+    <div class="ct-verdict ct-verdict--fail" data-testid="ct-verdict">
+      <strong>${t('ct.verdict.fail', { n: v.issues.length })}</strong>
+      <ul class="ct-issues">
+        ${v.issues.map((i) => `<li>${t('ct.issue.' + i.kind, { field: i.field ?? '', expected: i.expected ?? '', actual: i.actual ?? '' })}</li>`).join('')}
+      </ul>
+    </div>`;
+}
+
+function renderMatrix() {
+  const { consumers, providers, cells } = buildMatrix();
+  return `
+    <div class="ct-matrix" data-testid="ct-matrix">
+      <h3>${t('ct.matrix.title')}</h3>
+      <table class="ct-matrix__table">
+        <thead>
+          <tr>
+            <th></th>
+            ${providers.map((p) => `<th>${t('ct.actor.' + p)}</th>`).join('')}
+          </tr>
+        </thead>
+        <tbody>
+          ${consumers.map((c) => `
+            <tr>
+              <th>${t('ct.actor.' + c)}</th>
+              ${providers.map((p) => {
+                const cell = cells[`${c}|${p}`];
+                if (!cell) return `<td class="ct-cell ct-cell--na">—</td>`;
+                return `<td class="ct-cell ct-cell--${cell.passed ? 'pass' : 'fail'}"
+                  data-testid="ct-cell-${c}-${p}">
+                  ${cell.passed ? '✓' : `✗ ×${cell.issues.length}`}
+                </td>`;
+              }).join('')}
+            </tr>`).join('')}
+        </tbody>
+      </table>
+      <div class="ct-bridges">
+        <button type="button" class="ct-bridge" data-testid="ct-bridge-inttest"
+          title="${t('ct.bridge.inttest.title')}">
+          🔗 → ${t('section.inttest')}
+        </button>
+      </div>
+    </div>`;
+}
+
+function renderQuiz() {
+  if (!state.quiz.active) {
+    return `<button type="button" class="ct-quiz-start" data-testid="ct-quiz-start">${t('quiz.start')}</button>`;
+  }
+  if (state.quiz.phase === 'done') {
+    const correct = state.quiz.answer === 'b';
+    return `<div class="ct-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="ct-quiz-result">
+      <p>${correct ? t('ct.quiz.correct') : t('ct.quiz.wrong')}</p>
+    </div>`;
+  }
+  return `
+    <div class="ct-quiz" data-testid="ct-quiz">
+      <p class="ct-quiz-prompt">${t('ct.quiz.prompt')}</p>
+      ${['a', 'b', 'c', 'd'].map((k) => `
+        <label class="ct-quiz-option">
+          <input type="radio" name="ct-quiz" value="${k}" ${state.quiz.answer === k ? 'checked' : ''}>
+          ${t('ct.quiz.' + k)}
+        </label>`).join('')}
+      <button type="button" class="ct-quiz-submit" data-testid="ct-quiz-submit"
+        ${!state.quiz.answer ? 'disabled' : ''}>${t('quiz.submit')}</button>
+    </div>`;
+}
+
+function renderLab() {
+  if (!state.lab.active) {
+    return `<button type="button" class="ct-lab-start" data-testid="ct-lab-start">${t('lab.start')}</button>`;
+  }
+  return `
+    <div class="ct-lab" data-testid="ct-lab">
+      <p class="ct-lab-prompt">${t('ct.lab.prompt')}</p>
+      <textarea class="ct-lab-textarea" data-testid="ct-lab-text" rows="5"
+        placeholder="${t('lab.reflect.placeholder')}">${state.lab.text}</textarea>
+    </div>`;
+}
+
+function render() {
+  root.innerHTML = `
+    <div class="ct-wrap" data-testid="ct-wrap">
+      <h2 class="ct-title">${t('ct.title')}</h2>
+      <p class="ct-desc">${t('ct.desc')}</p>
+
+      <div class="ct-presets" data-testid="ct-presets">
+        ${SCENARIOS.map((s, i) => `
+          <button type="button"
+            class="ct-preset-chip${i === state.scenarioIdx ? ' ct-preset-chip--active' : ''}"
+            data-scenario="${i}"
+            data-testid="ct-preset-${s.id}">${t(s.titleKey)}</button>`).join('')}
+      </div>
+
+      ${renderTriad()}
+      ${renderMatrix()}
+
+      <section class="ct-self-test">
+        <h3>${t('quiz.title')}</h3>
+        ${renderQuiz()}
+        <h3>${t('lab.reflect.title')}</h3>
+        ${renderLab()}
+      </section>
+    </div>`;
+  bindEvents();
+}
+
+function bindEvents() {
+  root.querySelectorAll('[data-scenario]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      state.scenarioIdx = Number(btn.dataset.scenario);
+      render();
+    });
+  });
+  root.querySelector('[data-testid="ct-bridge-inttest"]')?.addEventListener('click', () => {
+    document.querySelector('[data-section="inttest"]')?.click();
+    document.querySelector('[data-testid="section-inttest"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+  root.querySelector('[data-testid="ct-quiz-start"]')?.addEventListener('click', () => {
+    state.quiz = { active: true, phase: 'question', answer: '' };
+    render();
+  });
+  root.querySelectorAll('input[name="ct-quiz"]').forEach((inp) => {
+    inp.addEventListener('change', () => { state.quiz.answer = inp.value; render(); });
+  });
+  root.querySelector('[data-testid="ct-quiz-submit"]')?.addEventListener('click', () => {
+    state.quiz.phase = 'done';
+    render();
+  });
+  root.querySelector('[data-testid="ct-lab-start"]')?.addEventListener('click', () => {
+    state.lab.active = true;
+    render();
+  });
+  root.querySelector('[data-testid="ct-lab-text"]')?.addEventListener('input', (e) => {
+    state.lab.text = e.target.value;
+  });
+}
+
+export function createContractTestingExplorer() {
+  state.scenarioIdx = 0;
+  state.quiz = { active: false, phase: 'idle', answer: '' };
+  state.lab  = { active: false, text: '' };
+  root = document.createElement('div');
+  render();
+  return root;
+}
+
+export { SCENARIOS };

--- a/src/data/explorerTags.js
+++ b/src/data/explorerTags.js
@@ -224,6 +224,10 @@ export const EXPLORER_TAGS = {
     level: ['e2e'], technique: ['process'], series: ['acceptance-e2e'],
     difficulty: 'intermediate', source: [TEXTBOOK],
   },
+  ContractTestingExplorer: {
+    level: ['integration', 'acceptance'], technique: ['contract'], series: ['acceptance-e2e'],
+    difficulty: 'advanced', source: [TEXTBOOK],
+  },
 };
 
 // ── Section ↔ Explorer mapping (used by K2 Overview filter) ────────
@@ -270,6 +274,7 @@ export const SECTION_EXPLORERS = {
     'BDDGherkinExplorer',
     'UseCaseDerivationExplorer',
     'E2EUserJourneyExplorer',
+    'ContractTestingExplorer',
   ],
 };
 

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -310,6 +310,7 @@ export const messages = {
     'acceptanceTab.gherkin': 'BDD / Gherkin',
     'acceptanceTab.usecase': 'Use Case Derivation',
     'acceptanceTab.e2ejourney': 'E2E User Journey',
+    'acceptanceTab.contract': 'Contract Testing',
 
     // BDD / Gherkin Explorer (J1)
     'bdd.title': 'BDD / Gherkin Explorer',
@@ -415,6 +416,43 @@ export const messages = {
     'e2e.quiz.correct': 'Right — the CSS transition on the parent is the giveaway; this is an animation-flake. Fix: disable transitions in test mode or await transitionend.',
     'e2e.quiz.wrong': 'Not quite. The log mentions active CSS transitions on the parent; that\'s the canonical animation flake.',
     'e2e.lab.prompt': 'What is the most common flaky source in your own project right now? How do you reproduce it (or do you only see it on CI)?',
+
+    // Contract Testing (J4)
+    'ct.title': 'Consumer-Driven Contract Testing Explorer',
+    'ct.desc': 'Pact-style: consumer writes its expectations, broker stores the contract, provider verifies against its actual implementation. Watch how non-breaking vs breaking schema changes propagate through the verification matrix.',
+    'ct.s.web.title': 'Web ↔ Orders API · compatible',
+    'ct.s.mobile.title': 'Mobile ↔ Orders API · added optional field (non-breaking)',
+    'ct.s.partner.title': 'Partner ↔ Payments API · required field + renamed response (breaking)',
+    'ct.role.consumer': 'Consumer',
+    'ct.role.provider': 'Provider',
+    'ct.actor.web': 'Web client',
+    'ct.actor.mobile': 'Mobile client',
+    'ct.actor.partner': 'Partner integration',
+    'ct.actor.orders': 'Orders API',
+    'ct.actor.payments': 'Payments API',
+    'ct.broker': 'Pact Broker',
+    'ct.broker.desc': 'Stores the contract published by the consumer; the provider pulls it during its verification step.',
+    'ct.request': 'Request',
+    'ct.expectedResp': 'Expected response',
+    'ct.actualResp': 'Actual response',
+    'ct.requiredFields': 'Required request fields',
+    'ct.verdict.pass': '✓ Verification passes',
+    'ct.verdict.pass.desc': 'Provider satisfies the consumer\'s contract (extra response fields are tolerated).',
+    'ct.verdict.fail': '✗ Verification fails — {n} issue(s)',
+    'ct.issue.missing-required-request': 'Provider now requires "{field}" in the request, but the consumer never sends it. Breaking — bump the API version or feature-flag the change.',
+    'ct.issue.missing-response-field': 'Consumer expects response field "{field}" but the provider no longer returns it. Breaking — keep the old field until every consumer migrates.',
+    'ct.issue.status-mismatch': 'Consumer expects HTTP {expected}, provider returns {actual}. Breaking — version the endpoint or restore the prior status code.',
+    'ct.matrix.title': 'Verification matrix',
+    'ct.bridge.inttest.title': 'Open Integration Testing Explorer — contract testing is the strict consumer-driven cousin of stub-based integration.',
+    'ct.quiz.prompt': 'A provider quietly adds an optional response field that no current consumer reads. Is this a breaking change?',
+    'ct.quiz.a': 'A. Yes — any schema change requires a major version bump.',
+    'ct.quiz.b': 'B. No — Pact tolerates extra response fields; verification still passes.',
+    'ct.quiz.c': 'C. Yes if it\'s nullable, no otherwise — nullability is what Pact actually compares.',
+    'ct.quiz.d': 'D. Only if the consumer\'s contract was registered before the new field was added.',
+    'ct.quiz.correct': 'Correct! Pact compares each field the consumer claims it reads. Anything else on the provider side is invisible to the verification.',
+    'ct.quiz.wrong': 'Not quite. Pact only fails when the consumer\'s expected fields are missing; extra provider fields slide through. That asymmetry is the consumer-driven part.',
+    'ct.lab.prompt': 'Contract testing vs E2E testing — what does each catch that the other misses? Sketch one example bug for each.',
+
 
 
     // J2 ATM use case
@@ -1996,6 +2034,7 @@ export const messages = {
     'acceptanceTab.gherkin': 'BDD / Gherkin',
     'acceptanceTab.usecase': '用例衍生',
     'acceptanceTab.e2ejourney': 'E2E 使用者旅程',
+    'acceptanceTab.contract': '契約測試',
 
     // BDD / Gherkin 探索器（J1）
     'bdd.title': 'BDD / Gherkin 探索器',
@@ -2101,6 +2140,43 @@ export const messages = {
     'e2e.quiz.correct': '正確！父層的 CSS transition 是關鍵線索——這是動畫 flaky。修法：測試模式關閉 transition，或等 transitionend。',
     'e2e.quiz.wrong': '不對。log 提到父層仍在做 CSS transition，這是典型的動畫 flaky。',
     'e2e.lab.prompt': '你目前專案中最常見的 flaky 來源是什麼？你怎麼重現（或只在 CI 上看到）？',
+
+    // 契約測試（J4）
+    'ct.title': '消費者導向契約測試探索器',
+    'ct.desc': 'Pact 風格：消費者寫下期望、Broker 儲存契約、Provider 用真實實作驗證。觀察「非破壞性」與「破壞性」結構變更如何在驗證矩陣上散播。',
+    'ct.s.web.title': 'Web ↔ Orders API · 相容',
+    'ct.s.mobile.title': 'Mobile ↔ Orders API · 新增選填欄位（非破壞性）',
+    'ct.s.partner.title': 'Partner ↔ Payments API · 新增必填 + 改名（破壞性）',
+    'ct.role.consumer': '消費者',
+    'ct.role.provider': '提供者',
+    'ct.actor.web': 'Web 客戶端',
+    'ct.actor.mobile': '行動端',
+    'ct.actor.partner': '合作夥伴整合',
+    'ct.actor.orders': 'Orders API',
+    'ct.actor.payments': 'Payments API',
+    'ct.broker': 'Pact Broker',
+    'ct.broker.desc': '儲存消費者發布的契約；提供者在驗證階段拉取使用。',
+    'ct.request': '請求',
+    'ct.expectedResp': '預期回應',
+    'ct.actualResp': '實際回應',
+    'ct.requiredFields': '必填請求欄位',
+    'ct.verdict.pass': '✓ 驗證通過',
+    'ct.verdict.pass.desc': 'Provider 滿足消費者契約（額外回應欄位是允許的）。',
+    'ct.verdict.fail': '✗ 驗證失敗——{n} 項問題',
+    'ct.issue.missing-required-request': 'Provider 現在要求「{field}」欄位，但消費者沒送出。破壞性——請升版本或加功能旗標。',
+    'ct.issue.missing-response-field': '消費者預期回應欄位「{field}」，但 Provider 不再回傳。破壞性——保留舊欄位直到所有消費者遷移。',
+    'ct.issue.status-mismatch': '消費者預期 HTTP {expected}，Provider 回 {actual}。破壞性——版本化端點或還原狀態碼。',
+    'ct.matrix.title': '驗證矩陣',
+    'ct.bridge.inttest.title': '開啟整合測試探索器——契約測試是 stub 整合的嚴格消費者導向版。',
+    'ct.quiz.prompt': 'Provider 在現有消費者都沒讀的欄位裡靜悄悄加了一個選填欄位，這是破壞性變更嗎？',
+    'ct.quiz.a': 'A. 是——任何 schema 變更都要升大版本。',
+    'ct.quiz.b': 'B. 不是——Pact 容許額外回應欄位，驗證仍通過。',
+    'ct.quiz.c': 'C. 看 nullability——可空才不破壞，否則破壞。',
+    'ct.quiz.d': 'D. 只有當消費者契約是在新欄位前註冊的才會破壞。',
+    'ct.quiz.correct': '正確！Pact 只比對消費者宣稱會讀的欄位；Provider 多出來的東西不會出現在驗證裡。這個不對稱性就是「consumer-driven」的核心。',
+    'ct.quiz.wrong': '不對。Pact 只在消費者預期欄位缺失時失敗；額外 Provider 欄位會直接通過。這個不對稱性才是「consumer-driven」的精神。',
+    'ct.lab.prompt': '契約測試 vs E2E 測試——各自能捕捉到對方錯過的什麼缺陷？分別舉一個典型例子。',
+
 
 
     // J2 ATM

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,6 +36,7 @@
 @import url('./components/BDDGherkinExplorer.css');
 @import url('./components/UseCaseDerivationExplorer.css');
 @import url('./components/E2EUserJourneyExplorer.css');
+@import url('./components/ContractTestingExplorer.css');
 @import url('./components/TagFilterBar.css');
 @import url('./components/CoursePackBar.css');
 @import url('./components/IntegrationTestingExplorer.css');

--- a/src/tests/ContractTestingExplorer.test.jsx
+++ b/src/tests/ContractTestingExplorer.test.jsx
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createContractTestingExplorer,
+  SCENARIOS,
+  verifyScenario,
+  buildMatrix,
+  BREAKAGE,
+} from '../components/ContractTestingExplorer.js';
+
+function mount() {
+  document.body.innerHTML = '';
+  const el = createContractTestingExplorer();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('Contract verification engine', () => {
+  it('compatible scenario passes', () => {
+    const result = verifyScenario(SCENARIOS.find((s) => s.id === 'web-orders'));
+    expect(result.passed).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('extra provider field is non-breaking', () => {
+    const result = verifyScenario(SCENARIOS.find((s) => s.id === 'mobile-orders'));
+    expect(result.passed).toBe(true);
+  });
+
+  it('missing-required-request fires when provider adds a required field the consumer never sends', () => {
+    const result = verifyScenario(SCENARIOS.find((s) => s.id === 'partner-payments'));
+    expect(result.passed).toBe(false);
+    const kinds = result.issues.map((i) => i.kind);
+    expect(kinds).toContain(BREAKAGE.MISSING_REQUIRED_REQUEST);
+  });
+
+  it('missing-response-field fires when provider renames a response key', () => {
+    const result = verifyScenario(SCENARIOS.find((s) => s.id === 'partner-payments'));
+    const kinds = result.issues.map((i) => i.kind);
+    expect(kinds).toContain(BREAKAGE.MISSING_RESPONSE_FIELD);
+  });
+
+  it('status-mismatch fires for HTTP status drift', () => {
+    const result = verifyScenario({
+      id: 'tmp', titleKey: 'x', consumerId: 'web', providerId: 'orders',
+      consumer: { request: { method: 'GET', path: '/x' }, response: { status: 200, body: {} } },
+      provider: { response: { status: 500, body: {} } },
+    });
+    expect(result.passed).toBe(false);
+    expect(result.issues[0].kind).toBe(BREAKAGE.STATUS_MISMATCH);
+  });
+
+  it('buildMatrix labels every scenario cell and tracks issue counts', () => {
+    const m = buildMatrix();
+    expect(m.consumers).toContain('web');
+    expect(m.providers).toContain('orders');
+    expect(m.cells['web|orders'].passed).toBe(true);
+    expect(m.cells['partner|payments'].passed).toBe(false);
+    expect(m.cells['partner|payments'].issues.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('ContractTestingExplorer smoke', () => {
+  it('renders wrap, presets, triad, matrix', () => {
+    mount();
+    expect(document.querySelector('[data-testid="ct-wrap"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ct-presets"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ct-triad"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ct-matrix"]')).toBeInTheDocument();
+  });
+
+  it('default scenario passes; verdict is pass-green', () => {
+    mount();
+    const v = document.querySelector('[data-testid="ct-verdict"]');
+    expect(v.classList.contains('ct-verdict--pass')).toBe(true);
+  });
+
+  it('switching to the breaking scenario flips the verdict to fail', () => {
+    mount();
+    document.querySelector('[data-testid="ct-preset-partner-payments"]').click();
+    const v = document.querySelector('[data-testid="ct-verdict"]');
+    expect(v.classList.contains('ct-verdict--fail')).toBe(true);
+  });
+
+  it('matrix renders per-scenario cells', () => {
+    mount();
+    expect(document.querySelector('[data-testid="ct-cell-web-orders"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ct-cell-partner-payments"]')).toBeInTheDocument();
+  });
+
+  it('quiz: start, pick correct option, submit shows correct result', () => {
+    mount();
+    document.querySelector('[data-testid="ct-quiz-start"]').click();
+    document.querySelector('input[name="ct-quiz"][value="b"]').click();
+    document.querySelector('[data-testid="ct-quiz-submit"]').click();
+    const result = document.querySelector('[data-testid="ct-quiz-result"]');
+    expect(result.classList.contains('quiz-correct')).toBe(true);
+  });
+
+  it('lab reflect activates and shows textarea', () => {
+    mount();
+    document.querySelector('[data-testid="ct-lab-start"]').click();
+    expect(document.querySelector('[data-testid="ct-lab"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ct-lab-text"]')).toBeInTheDocument();
+  });
+});

--- a/src/utils/urlRouter.js
+++ b/src/utils/urlRouter.js
@@ -26,7 +26,7 @@ export const TAB_SECTIONS = {
   flow:     { tabs: ['flow', 'defectCost', 'vmodel'],                                                 default: 'flow' },
   types:    { tabs: ['pyramid', 'adjuster'],                                                          default: 'pyramid' },
   // J-series acceptance tabs grow as J2-J8 land; J1 ships 'gherkin'.
-  acceptance: { tabs: ['gherkin', 'usecase', 'e2ejourney'],                                           default: 'gherkin' },
+  acceptance: { tabs: ['gherkin', 'usecase', 'e2ejourney', 'contract'],                               default: 'gherkin' },
 };
 
 // ── ComponentName → { section, tab? } ────────────────────────────────
@@ -70,6 +70,7 @@ export const EXPLORER_TO_LOCATION = {
   BDDGherkinExplorer:          { section: 'acceptance', tab: 'gherkin' },
   UseCaseDerivationExplorer:   { section: 'acceptance', tab: 'usecase' },
   E2EUserJourneyExplorer:      { section: 'acceptance', tab: 'e2ejourney' },
+  ContractTestingExplorer:     { section: 'acceptance', tab: 'contract' },
 };
 
 const FILTER_DIMS = ['level', 'technique', 'series', 'difficulty'];


### PR DESCRIPTION
## Summary
Fourth tab in J. Acceptance. Visualizes the consumer-driven contract workflow: consumer declares expectations, broker stores them, provider verifies against its real implementation. Compatibility matrix shows how non-breaking vs breaking changes propagate.

## Component
- **3 scenarios:**
  - **Web ↔ Orders API** — compatible (verification passes)
  - **Mobile ↔ Orders API** — provider added optional response field (non-breaking; passes)
  - **Partner ↔ Payments API** — provider added required request field AND renamed response field (both breaking; multi-issue)
- **Three-pane triad** — Consumer (expected request/response) / Pact Broker (stored contract) / Provider (actual response), each with rendered JSON.
- **Pure verification engine** (`verifyScenario`) with three breakage kinds (`MISSING_REQUIRED_REQUEST`, `MISSING_RESPONSE_FIELD`, `STATUS_MISMATCH`). Extra provider response fields are intentionally tolerated — the asymmetry that defines consumer-driven testing.
- **Compatibility matrix** — consumer × provider grid, green/red cells with issue counts.
- **Bridge** 🔗 → Integration Testing — contract is the strict consumer-driven cousin of stub-based integration.
- **Quiz** on the "extra optional field" asymmetry; **lab reflect** on Contract vs E2E roles.

## Test plan
- [x] `npm run test:run` — 600/600 (was 588; +12 J4 assertions, 6 of them on the pure engine).
- [x] Manual: `?explorer=ContractTestingExplorer` lands directly here; cycled all three scenarios; matrix matches verdicts.
- [ ] CI green on GitHub Actions.

Closes #202. J5 (Performance Load Profile) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)