### PR TITLE
feat(acceptance): J5 — Performance Load Profile Explorer

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -37,6 +37,7 @@ import { createBDDGherkinExplorer } from './components/BDDGherkinExplorer.js';
 import { createUseCaseDerivationExplorer } from './components/UseCaseDerivationExplorer.js';
 import { createE2EUserJourneyExplorer } from './components/E2EUserJourneyExplorer.js';
 import { createContractTestingExplorer } from './components/ContractTestingExplorer.js';
+import { createPerformanceLoadProfileExplorer } from './components/PerformanceLoadProfileExplorer.js';
 import { createTagFilterBar } from './components/TagFilterBar.js';
 import { createCoursePackBar } from './components/CoursePackBar.js';
 import { sectionMatchesFilter } from './data/explorerTags.js';
@@ -265,6 +266,7 @@ export function renderApp(container) {
       usecase: createUseCaseDerivationExplorer(),
       e2ejourney: createE2EUserJourneyExplorer(),
       contract: createContractTestingExplorer(),
+      perfload: createPerformanceLoadProfileExplorer(),
       cloud: createCloudStoragePanel(),
       flow: createTestingFlow(),
       defectCost: createDefectCostExplorer(),
@@ -348,6 +350,7 @@ export function renderApp(container) {
       { id: 'usecase', key: 'acceptanceTab.usecase', component: components.usecase },
       { id: 'e2ejourney', key: 'acceptanceTab.e2ejourney', component: components.e2ejourney },
       { id: 'contract', key: 'acceptanceTab.contract', component: components.contract },
+      { id: 'perfload', key: 'acceptanceTab.perfload', component: components.perfload },
     ];
     const acceptanceSlot = container.querySelector('[data-slot="acceptance"]');
     const acceptanceTabBar = document.createElement('nav');

--- a/src/components/PerformanceLoadProfileExplorer.css
+++ b/src/components/PerformanceLoadProfileExplorer.css
@@ -1,0 +1,85 @@
+.plp-wrap { display: flex; flex-direction: column; gap: 1.25rem; padding: 1rem 0; }
+.plp-title { margin: 0; font-size: 1.2rem; font-weight: 800; color: #1f2a44; }
+.plp-desc  { margin: 0; color: #475569; font-size: 0.9rem; }
+
+.plp-systems { display: flex; flex-wrap: wrap; gap: 6px; }
+.plp-system-chip {
+  padding: 0.3rem 0.7rem; border: 1px solid #e2e8f0; border-radius: 999px;
+  background: #f8fafc; font-size: 0.8rem; cursor: pointer; color: #374151;
+}
+.plp-system-chip:hover { background: #eef2f7; }
+.plp-system-chip--active {
+  background: #1d4ed8; border-color: #1d4ed8; color: #fff; font-weight: 600;
+}
+
+.plp-profiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+@media (max-width: 800px) { .plp-profiles { grid-template-columns: repeat(2, 1fr); } }
+.plp-profile-chip {
+  display: flex; flex-direction: column; align-items: stretch; gap: 0.3rem;
+  padding: 0.5rem 0.65rem; border: 1px solid #e2e8f0; border-radius: 8px;
+  background: #fff; color: #1f2a44; cursor: pointer;
+  font-size: 0.78rem; text-align: left;
+}
+.plp-profile-chip:hover { background: #f8fafc; }
+.plp-profile-chip--active { background: #eef2ff; border-color: #1d4ed8; }
+.plp-profile-chip__name { font-weight: 700; color: #1f2a44; }
+.plp-profile-chip__desc { font-size: 0.7rem; color: #64748b; }
+.plp-shape__svg { width: 100%; height: 50px; }
+
+.plp-dashboard, .plp-little {
+  background: #fff; border: 1px solid #e2e8f0; border-radius: 8px;
+  padding: 0.9rem 1rem;
+}
+.plp-dashboard h3, .plp-little h3 { margin: 0 0 0.5rem; font-size: 0.95rem; color: #1f2a44; }
+
+.plp-metrics {
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 8px;
+  margin-bottom: 0.5rem;
+}
+@media (max-width: 800px) { .plp-metrics { grid-template-columns: repeat(3, 1fr); } }
+.plp-metric {
+  background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px;
+  padding: 0.4rem 0.55rem; display: flex; flex-direction: column; gap: 0.15rem;
+  font-size: 0.7rem; color: #64748b;
+}
+.plp-metric strong { color: #1f2a44; font-size: 0.95rem; font-weight: 700; }
+.plp-metric strong.plp-metric--err { color: #b91c1c; }
+.plp-knee { margin: 0; padding: 0.4rem 0.6rem; background: #fef3c7; border-left: 3px solid #f59e0b; border-radius: 4px; font-size: 0.78rem; color: #78350f; }
+
+.plp-little__formula {
+  font-family: 'Fira Code', monospace; font-size: 1rem;
+  margin: 0 0 0.5rem; color: #1d4ed8; font-weight: 700;
+}
+.plp-little__controls { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; align-items: end; }
+@media (max-width: 700px) { .plp-little__controls { grid-template-columns: 1fr; } }
+.plp-little__controls label { display: flex; flex-direction: column; gap: 0.2rem; font-size: 0.76rem; color: #475569; }
+.plp-little__controls label strong { color: #1f2a44; font-size: 0.85rem; }
+.plp-little__controls input[type=range] { width: 100%; }
+.plp-little__derived { display: flex; flex-direction: column; gap: 0.2rem; font-size: 0.76rem; color: #475569; padding: 0.4rem 0.6rem; background: #f0fdf4; border: 1px solid #86efac; border-radius: 6px; }
+.plp-little__derived strong { color: #166534; font-size: 1.05rem; font-weight: 800; }
+.plp-little__hint { margin: 0.5rem 0 0; font-size: 0.78rem; color: #64748b; }
+
+.plp-bridges { display: flex; flex-wrap: wrap; gap: 6px; }
+.plp-bridge {
+  padding: 0.22rem 0.6rem; border: 1px solid #1d4ed8; border-radius: 999px;
+  background: #fff; color: #1d4ed8; font-size: 0.74rem; cursor: pointer;
+}
+.plp-bridge:hover { background: #1d4ed8; color: #fff; }
+
+.plp-self-test { display: flex; flex-direction: column; gap: 0.7rem; }
+.plp-self-test h3 { margin: 0; font-size: 0.95rem; color: #1f2a44; }
+.plp-quiz-start, .plp-lab-start {
+  padding: 0.35rem 0.9rem; background: #1d4ed8; color: #fff;
+  border: none; border-radius: 5px; font-size: 0.82rem; cursor: pointer; align-self: flex-start;
+}
+.plp-quiz-start:hover, .plp-lab-start:hover { background: #1e40af; }
+.plp-quiz-prompt { font-size: 0.88rem; font-weight: 600; margin: 0 0 0.5rem; color: #1f2a44; }
+.plp-quiz-option { display: flex; align-items: flex-start; gap: 0.4rem; font-size: 0.85rem; margin-bottom: 0.3rem; cursor: pointer; color: #374151; }
+.plp-quiz-submit {
+  margin-top: 0.5rem; padding: 0.3rem 0.8rem;
+  background: #1d4ed8; color: #fff; border: none; border-radius: 5px; font-size: 0.82rem; cursor: pointer;
+}
+.plp-quiz-submit:disabled { opacity: 0.4; cursor: default; }
+.plp-quiz-result { padding: 0.5rem 0.75rem; border-radius: 6px; font-size: 0.85rem; }
+.plp-lab-prompt { font-size: 0.88rem; color: #374151; margin: 0 0 0.4rem; }
+.plp-lab-textarea { width: 100%; border: 1px solid #d0d7e2; border-radius: 5px; padding: 0.4rem 0.6rem; font-size: 0.85rem; resize: vertical; box-sizing: border-box; }

--- a/src/components/PerformanceLoadProfileExplorer.js
+++ b/src/components/PerformanceLoadProfileExplorer.js
@@ -1,0 +1,306 @@
+import { t } from '../i18n/index.js';
+
+// Four load shapes. Each emits target concurrency at every tick (0–100).
+// load: steady; stress: ramp; spike: brief impulse; soak: long flat hold.
+export const PROFILES = ['load', 'stress', 'spike', 'soak'];
+
+export function loadShape(profile, tick, peak = 100) {
+  switch (profile) {
+    case 'load':   return peak * 0.6;
+    case 'stress': return Math.min(peak, peak * (tick / 100));
+    case 'spike':  return tick === 30 || tick === 31 || tick === 32 ? peak : peak * 0.2;
+    case 'soak':   return peak * 0.5;
+    default:       return 0;
+  }
+}
+
+// System model: latency grows with concurrency once we pass the system's
+// natural capacity. Below capacity, latency is roughly flat. Above, it
+// climbs hyperbolically — the textbook "hockey stick".
+const SYSTEMS = [
+  {
+    id: 'gateway',
+    titleKey: 'plp.sys.gateway',
+    capacity: 70,    // concurrent in-flight requests it can absorb before queuing
+    baseLatencyMs: 20,
+    breakingError: 0.04,
+  },
+  {
+    id: 'db',
+    titleKey: 'plp.sys.db',
+    capacity: 40,
+    baseLatencyMs: 60,
+    breakingError: 0.08,
+  },
+  {
+    id: 'cpu',
+    titleKey: 'plp.sys.cpu',
+    capacity: 25,
+    baseLatencyMs: 35,
+    breakingError: 0.12,
+  },
+];
+
+// Pure responder for tests. Returns latency (ms) and error fraction at
+// the given concurrency for the given system. Latency formula keeps the
+// numbers intuitive: base * (1 + max(0, (c − cap) / cap)^2).
+export function systemResponse(system, concurrency) {
+  const over = Math.max(0, concurrency - system.capacity);
+  const ratio = over / system.capacity;
+  const latency = system.baseLatencyMs * (1 + ratio * ratio * 4);
+  const error = ratio <= 0 ? 0.001 : Math.min(0.6, system.breakingError * (1 + ratio * 2));
+  const throughput = Math.min(concurrency / (latency / 1000), system.capacity / (system.baseLatencyMs / 1000));
+  return { latency, error, throughput };
+}
+
+// p50/p95/p99 are simple multiples of mean latency to keep this teachable.
+export function percentiles(mean) {
+  return { p50: mean * 0.85, p95: mean * 1.8, p99: mean * 2.6 };
+}
+
+// Little's Law: L = λ × W. Given any two, return the third.
+export function littlesLaw({ L, lambda, W }) {
+  if (L === undefined && lambda !== undefined && W !== undefined) return { L: lambda * W };
+  if (lambda === undefined && L !== undefined && W !== undefined) return { lambda: L / W };
+  if (W === undefined && L !== undefined && lambda !== undefined) return { W: L / lambda };
+  return {};
+}
+
+// Find the smallest concurrency where latency first exceeds 2× base — a
+// reasonable approximation of "knee of the curve" for teaching.
+export function kneeConcurrency(system) {
+  for (let c = 1; c <= 200; c++) {
+    if (systemResponse(system, c).latency >= system.baseLatencyMs * 2) return c;
+  }
+  return null;
+}
+
+// ── State ───────────────────────────────────────────────────────────
+
+const state = {
+  profile: 'load',
+  systemIdx: 0,
+  // Little's-Law toy: independent set of (λ, W) that students drag.
+  ll: { lambda: 200, W: 0.05 },  // L derived
+  quiz: { active: false, phase: 'idle', answer: '' },
+  lab:  { active: false, text: '' },
+};
+
+let root;
+
+function currentSystem() {
+  return SYSTEMS[state.systemIdx];
+}
+
+function shapePoints(profile, ticks = 30) {
+  const out = [];
+  for (let i = 0; i <= ticks; i++) {
+    const tickN = (i / ticks) * 100;
+    out.push({ x: i, y: loadShape(profile, tickN) });
+  }
+  return out;
+}
+
+function shapeSvg(profile) {
+  const pts = shapePoints(profile);
+  const max = Math.max(...pts.map((p) => p.y));
+  const W = 240, H = 70;
+  const path = pts.map((p, i) => {
+    const x = (i / (pts.length - 1)) * W;
+    const y = H - (p.y / max) * (H - 6) - 3;
+    return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`;
+  }).join(' ');
+  return `<svg viewBox="0 0 ${W} ${H}" class="plp-shape__svg" aria-hidden="true">
+    <path d="${path}" fill="none" stroke="#1d4ed8" stroke-width="1.6"/>
+  </svg>`;
+}
+
+function renderProfiles() {
+  return `
+    <div class="plp-profiles" data-testid="plp-profiles">
+      ${PROFILES.map((p) => `
+        <button type="button"
+          class="plp-profile-chip${state.profile === p ? ' plp-profile-chip--active' : ''}"
+          data-profile="${p}"
+          data-testid="plp-profile-${p}">
+          <span class="plp-profile-chip__name">${t('plp.profile.' + p)}</span>
+          ${shapeSvg(p)}
+          <span class="plp-profile-chip__desc">${t('plp.profile.' + p + '.desc')}</span>
+        </button>`).join('')}
+    </div>`;
+}
+
+function renderDashboard() {
+  const sys = currentSystem();
+  // Sample at peak of profile.
+  const peakConcurrency = state.profile === 'spike' ? 100 : (state.profile === 'stress' ? 90 : (state.profile === 'load' ? 60 : 50));
+  const r = systemResponse(sys, peakConcurrency);
+  const pct = percentiles(r.latency);
+  const knee = kneeConcurrency(sys);
+  return `
+    <div class="plp-dashboard" data-testid="plp-dashboard">
+      <h3>${t('plp.dash.title', { sys: t(sys.titleKey), profile: t('plp.profile.' + state.profile) })}</h3>
+      <div class="plp-metrics">
+        <div class="plp-metric"><span>${t('plp.metric.concurrency')}</span><strong data-testid="plp-met-concurrency">${peakConcurrency.toFixed(0)}</strong></div>
+        <div class="plp-metric"><span>${t('plp.metric.throughput')}</span><strong data-testid="plp-met-throughput">${r.throughput.toFixed(1)} req/s</strong></div>
+        <div class="plp-metric"><span>${t('plp.metric.p50')}</span><strong data-testid="plp-met-p50">${pct.p50.toFixed(0)} ms</strong></div>
+        <div class="plp-metric"><span>${t('plp.metric.p95')}</span><strong data-testid="plp-met-p95">${pct.p95.toFixed(0)} ms</strong></div>
+        <div class="plp-metric"><span>${t('plp.metric.p99')}</span><strong data-testid="plp-met-p99">${pct.p99.toFixed(0)} ms</strong></div>
+        <div class="plp-metric"><span>${t('plp.metric.error')}</span><strong class="plp-metric--err" data-testid="plp-met-error">${(r.error * 100).toFixed(2)}%</strong></div>
+      </div>
+      <p class="plp-knee" data-testid="plp-knee">${t('plp.knee', { knee, cap: sys.capacity })}</p>
+    </div>`;
+}
+
+function renderLittlesLaw() {
+  const L = state.ll.lambda * state.ll.W;
+  return `
+    <div class="plp-little" data-testid="plp-little">
+      <h3>${t('plp.little.title')}</h3>
+      <p class="plp-little__formula">L = λ × W</p>
+      <div class="plp-little__controls">
+        <label>
+          <span>λ (req/s)</span>
+          <input type="range" min="10" max="2000" step="10"
+            value="${state.ll.lambda}" data-ll-input="lambda" data-testid="plp-ll-lambda">
+          <strong>${state.ll.lambda}</strong>
+        </label>
+        <label>
+          <span>W (s/req)</span>
+          <input type="range" min="0.005" max="0.5" step="0.005"
+            value="${state.ll.W}" data-ll-input="W" data-testid="plp-ll-W">
+          <strong>${state.ll.W.toFixed(3)}</strong>
+        </label>
+        <div class="plp-little__derived">
+          <span>${t('plp.little.derivedL')}</span>
+          <strong data-testid="plp-ll-derived">${L.toFixed(1)}</strong>
+        </div>
+      </div>
+      <p class="plp-little__hint">${t('plp.little.hint')}</p>
+    </div>`;
+}
+
+function renderBridges() {
+  return `
+    <div class="plp-bridges">
+      <button type="button" class="plp-bridge" data-testid="plp-bridge-rbt"
+        title="${t('plp.bridge.rbt.title')}">
+        🔗 → ${t('section.rbt')}
+      </button>
+    </div>`;
+}
+
+function renderQuiz() {
+  if (!state.quiz.active) {
+    return `<button type="button" class="plp-quiz-start" data-testid="plp-quiz-start">${t('quiz.start')}</button>`;
+  }
+  if (state.quiz.phase === 'done') {
+    const correct = state.quiz.answer === 'b';
+    return `<div class="plp-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="plp-quiz-result">
+      <p>${correct ? t('plp.quiz.correct') : t('plp.quiz.wrong')}</p>
+    </div>`;
+  }
+  return `
+    <div class="plp-quiz" data-testid="plp-quiz">
+      <p class="plp-quiz-prompt">${t('plp.quiz.prompt')}</p>
+      ${['a', 'b', 'c', 'd'].map((k) => `
+        <label class="plp-quiz-option">
+          <input type="radio" name="plp-quiz" value="${k}" ${state.quiz.answer === k ? 'checked' : ''}>
+          ${t('plp.quiz.' + k)}
+        </label>`).join('')}
+      <button type="button" class="plp-quiz-submit" data-testid="plp-quiz-submit"
+        ${!state.quiz.answer ? 'disabled' : ''}>${t('quiz.submit')}</button>
+    </div>`;
+}
+
+function renderLab() {
+  if (!state.lab.active) {
+    return `<button type="button" class="plp-lab-start" data-testid="plp-lab-start">${t('lab.start')}</button>`;
+  }
+  return `
+    <div class="plp-lab" data-testid="plp-lab">
+      <p class="plp-lab-prompt">${t('plp.lab.prompt')}</p>
+      <textarea class="plp-lab-textarea" data-testid="plp-lab-text" rows="5"
+        placeholder="${t('lab.reflect.placeholder')}">${state.lab.text}</textarea>
+    </div>`;
+}
+
+function render() {
+  root.innerHTML = `
+    <div class="plp-wrap" data-testid="plp-wrap">
+      <h2 class="plp-title">${t('plp.title')}</h2>
+      <p class="plp-desc">${t('plp.desc')}</p>
+
+      <div class="plp-systems" data-testid="plp-systems">
+        ${SYSTEMS.map((s, i) => `
+          <button type="button"
+            class="plp-system-chip${i === state.systemIdx ? ' plp-system-chip--active' : ''}"
+            data-system="${i}"
+            data-testid="plp-system-${s.id}">${t(s.titleKey)}</button>`).join('')}
+      </div>
+
+      ${renderProfiles()}
+      ${renderDashboard()}
+      ${renderLittlesLaw()}
+      ${renderBridges()}
+
+      <section class="plp-self-test">
+        <h3>${t('quiz.title')}</h3>
+        ${renderQuiz()}
+        <h3>${t('lab.reflect.title')}</h3>
+        ${renderLab()}
+      </section>
+    </div>`;
+  bindEvents();
+}
+
+function bindEvents() {
+  root.querySelectorAll('[data-system]').forEach((btn) => {
+    btn.addEventListener('click', () => { state.systemIdx = Number(btn.dataset.system); render(); });
+  });
+  root.querySelectorAll('[data-profile]').forEach((btn) => {
+    btn.addEventListener('click', () => { state.profile = btn.dataset.profile; render(); });
+  });
+  root.querySelectorAll('[data-ll-input]').forEach((input) => {
+    input.addEventListener('input', () => {
+      const key = input.dataset.llInput;
+      state.ll[key] = Number(input.value);
+      render();
+    });
+  });
+  root.querySelector('[data-testid="plp-bridge-rbt"]')?.addEventListener('click', () => {
+    document.querySelector('[data-section="rbt"]')?.click();
+    document.querySelector('[data-testid="section-rbt"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+  root.querySelector('[data-testid="plp-quiz-start"]')?.addEventListener('click', () => {
+    state.quiz = { active: true, phase: 'question', answer: '' };
+    render();
+  });
+  root.querySelectorAll('input[name="plp-quiz"]').forEach((inp) => {
+    inp.addEventListener('change', () => { state.quiz.answer = inp.value; render(); });
+  });
+  root.querySelector('[data-testid="plp-quiz-submit"]')?.addEventListener('click', () => {
+    state.quiz.phase = 'done';
+    render();
+  });
+  root.querySelector('[data-testid="plp-lab-start"]')?.addEventListener('click', () => {
+    state.lab.active = true;
+    render();
+  });
+  root.querySelector('[data-testid="plp-lab-text"]')?.addEventListener('input', (e) => {
+    state.lab.text = e.target.value;
+  });
+}
+
+export function createPerformanceLoadProfileExplorer() {
+  state.profile = 'load';
+  state.systemIdx = 0;
+  state.ll = { lambda: 200, W: 0.05 };
+  state.quiz = { active: false, phase: 'idle', answer: '' };
+  state.lab  = { active: false, text: '' };
+  root = document.createElement('div');
+  render();
+  return root;
+}
+
+export { SYSTEMS };

--- a/src/data/explorerTags.js
+++ b/src/data/explorerTags.js
@@ -228,6 +228,10 @@ export const EXPLORER_TAGS = {
     level: ['integration', 'acceptance'], technique: ['contract'], series: ['acceptance-e2e'],
     difficulty: 'advanced', source: [TEXTBOOK],
   },
+  PerformanceLoadProfileExplorer: {
+    level: ['nonfunctional'], technique: ['process'], series: ['acceptance-e2e'],
+    difficulty: 'intermediate', source: [TEXTBOOK],
+  },
 };
 
 // ── Section ↔ Explorer mapping (used by K2 Overview filter) ────────
@@ -275,6 +279,7 @@ export const SECTION_EXPLORERS = {
     'UseCaseDerivationExplorer',
     'E2EUserJourneyExplorer',
     'ContractTestingExplorer',
+    'PerformanceLoadProfileExplorer',
   ],
 };
 

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -311,6 +311,7 @@ export const messages = {
     'acceptanceTab.usecase': 'Use Case Derivation',
     'acceptanceTab.e2ejourney': 'E2E User Journey',
     'acceptanceTab.contract': 'Contract Testing',
+    'acceptanceTab.perfload': 'Performance Load Profile',
 
     // BDD / Gherkin Explorer (J1)
     'bdd.title': 'BDD / Gherkin Explorer',
@@ -452,6 +453,42 @@ export const messages = {
     'ct.quiz.correct': 'Correct! Pact compares each field the consumer claims it reads. Anything else on the provider side is invisible to the verification.',
     'ct.quiz.wrong': 'Not quite. Pact only fails when the consumer\'s expected fields are missing; extra provider fields slide through. That asymmetry is the consumer-driven part.',
     'ct.lab.prompt': 'Contract testing vs E2E testing — what does each catch that the other misses? Sketch one example bug for each.',
+
+    // Performance Load Profile (J5)
+    'plp.title': 'Performance Load Profile Explorer',
+    'plp.desc': 'Four canonical load shapes (Load / Stress / Spike / Soak) reveal different system pathologies. Use Little\'s Law (L = λ × W) as your spine.',
+    'plp.sys.gateway': 'API gateway (stateless)',
+    'plp.sys.db': 'DB-bound service',
+    'plp.sys.cpu': 'CPU-bound service',
+    'plp.profile.load': 'Load',
+    'plp.profile.stress': 'Stress',
+    'plp.profile.spike': 'Spike',
+    'plp.profile.soak': 'Soak',
+    'plp.profile.load.desc': 'Steady normal traffic. Baseline measurement.',
+    'plp.profile.stress.desc': 'Ramp until it breaks. Finds saturation.',
+    'plp.profile.spike.desc': 'Brief impulse beyond capacity.',
+    'plp.profile.soak.desc': 'Long flat hold. Surfaces leaks.',
+    'plp.dash.title': '{sys} under {profile} load',
+    'plp.metric.concurrency': 'In-flight',
+    'plp.metric.throughput':  'Throughput',
+    'plp.metric.p50': 'p50',
+    'plp.metric.p95': 'p95',
+    'plp.metric.p99': 'p99',
+    'plp.metric.error': 'Error rate',
+    'plp.knee': 'Knee of the curve: latency starts doubling at ~{knee} in-flight (capacity ≈ {cap}).',
+    'plp.little.title': 'Little\'s Law',
+    'plp.little.derivedL': 'L (concurrent requests in system)',
+    'plp.little.hint': 'L = λ × W links throughput and latency to in-flight count. Pick any two and the third is fixed.',
+    'plp.bridge.rbt.title': 'Open Risk-Based Testing — pair load profile with risk to set the perf-test budget.',
+    'plp.quiz.prompt': 'A service averages 200 req/s with a mean response time of 80 ms. What is the average concurrent in-flight count?',
+    'plp.quiz.a': 'A. 2.5 (the inverse)',
+    'plp.quiz.b': 'B. 16 (200 × 0.08)',
+    'plp.quiz.c': 'C. 80 (latency in ms is the answer)',
+    'plp.quiz.d': 'D. Cannot tell without queue depth.',
+    'plp.quiz.correct': 'Correct! L = λ × W = 200 × 0.08 s = 16 concurrent in-flight requests.',
+    'plp.quiz.wrong': 'Not quite. Little\'s Law: L = λ × W → 200 × 0.08 s = 16 concurrent requests.',
+    'plp.lab.prompt': 'Why does a Soak test find bugs that a Stress test misses? Sketch one realistic example you have seen or would expect.',
+
 
 
 
@@ -2035,6 +2072,7 @@ export const messages = {
     'acceptanceTab.usecase': '用例衍生',
     'acceptanceTab.e2ejourney': 'E2E 使用者旅程',
     'acceptanceTab.contract': '契約測試',
+    'acceptanceTab.perfload': '效能負載剖面',
 
     // BDD / Gherkin 探索器（J1）
     'bdd.title': 'BDD / Gherkin 探索器',
@@ -2176,6 +2214,42 @@ export const messages = {
     'ct.quiz.correct': '正確！Pact 只比對消費者宣稱會讀的欄位；Provider 多出來的東西不會出現在驗證裡。這個不對稱性就是「consumer-driven」的核心。',
     'ct.quiz.wrong': '不對。Pact 只在消費者預期欄位缺失時失敗；額外 Provider 欄位會直接通過。這個不對稱性才是「consumer-driven」的精神。',
     'ct.lab.prompt': '契約測試 vs E2E 測試——各自能捕捉到對方錯過的什麼缺陷？分別舉一個典型例子。',
+
+    // 效能負載剖面（J5）
+    'plp.title': '效能負載剖面探索器',
+    'plp.desc': '四種經典負載曲線（穩態 / 極限 / 突波 / 持久）揭露不同的系統病理。以 Little\'s Law（L = λ × W）作為骨幹。',
+    'plp.sys.gateway': 'API Gateway（無狀態）',
+    'plp.sys.db': 'DB 受限服務',
+    'plp.sys.cpu': 'CPU 受限服務',
+    'plp.profile.load': '穩態 Load',
+    'plp.profile.stress': '極限 Stress',
+    'plp.profile.spike': '突波 Spike',
+    'plp.profile.soak': '持久 Soak',
+    'plp.profile.load.desc': '正常持續流量，作為基準。',
+    'plp.profile.stress.desc': '逐步加壓直到崩潰，找飽和點。',
+    'plp.profile.spike.desc': '短時間超量衝擊。',
+    'plp.profile.soak.desc': '長時間穩定運行，浮現洩漏。',
+    'plp.dash.title': '{sys} 在 {profile} 下的表現',
+    'plp.metric.concurrency': '同時在線',
+    'plp.metric.throughput':  '吞吐量',
+    'plp.metric.p50': 'p50',
+    'plp.metric.p95': 'p95',
+    'plp.metric.p99': 'p99',
+    'plp.metric.error': '錯誤率',
+    'plp.knee': '曲線拐點：延遲在 ~{knee} 同時請求開始加倍（容量 ≈ {cap}）。',
+    'plp.little.title': 'Little\'s Law',
+    'plp.little.derivedL': 'L（系統內並行請求數）',
+    'plp.little.hint': 'L = λ × W 連結吞吐量、延遲與並行數。任意兩個固定，第三個就確定了。',
+    'plp.bridge.rbt.title': '開啟風險導向測試——將負載剖面與風險搭配，決定效能測試預算。',
+    'plp.quiz.prompt': '某服務平均 200 req/s、平均回應時間 80 ms。系統內平均並行請求數是多少？',
+    'plp.quiz.a': 'A. 2.5（倒數）',
+    'plp.quiz.b': 'B. 16（200 × 0.08）',
+    'plp.quiz.c': 'C. 80（延遲毫秒就是答案）',
+    'plp.quiz.d': 'D. 不知 queue 深度無法回答。',
+    'plp.quiz.correct': '正確！L = λ × W = 200 × 0.08 s = 16 並行請求。',
+    'plp.quiz.wrong': '不對。Little\'s Law：L = λ × W → 200 × 0.08 s = 16 並行請求。',
+    'plp.lab.prompt': '為什麼 Soak 測試能找到 Stress 測試找不到的 bug？舉一個你看過或想得到的真實例子。',
+
 
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -37,6 +37,7 @@
 @import url('./components/UseCaseDerivationExplorer.css');
 @import url('./components/E2EUserJourneyExplorer.css');
 @import url('./components/ContractTestingExplorer.css');
+@import url('./components/PerformanceLoadProfileExplorer.css');
 @import url('./components/TagFilterBar.css');
 @import url('./components/CoursePackBar.css');
 @import url('./components/IntegrationTestingExplorer.css');

--- a/src/tests/PerformanceLoadProfileExplorer.test.jsx
+++ b/src/tests/PerformanceLoadProfileExplorer.test.jsx
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPerformanceLoadProfileExplorer,
+  PROFILES,
+  SYSTEMS,
+  loadShape,
+  systemResponse,
+  percentiles,
+  littlesLaw,
+  kneeConcurrency,
+} from '../components/PerformanceLoadProfileExplorer.js';
+
+function mount() {
+  document.body.innerHTML = '';
+  const el = createPerformanceLoadProfileExplorer();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('Load shape generators', () => {
+  it('exposes exactly the four canonical profiles', () => {
+    expect(PROFILES).toEqual(['load', 'stress', 'spike', 'soak']);
+  });
+
+  it('load is flat', () => {
+    expect(loadShape('load', 0)).toBe(loadShape('load', 50));
+  });
+
+  it('stress ramps with tick', () => {
+    expect(loadShape('stress', 10)).toBeLessThan(loadShape('stress', 90));
+  });
+
+  it('spike is high only during the brief impulse window', () => {
+    expect(loadShape('spike', 30)).toBeGreaterThan(loadShape('spike', 0));
+    expect(loadShape('spike', 0)).toBeLessThan(loadShape('spike', 30));
+  });
+
+  it('soak holds at a steady mid level', () => {
+    expect(loadShape('soak', 5)).toBe(loadShape('soak', 95));
+  });
+});
+
+describe('System response math', () => {
+  it('latency at exactly capacity equals base latency', () => {
+    for (const sys of SYSTEMS) {
+      const r = systemResponse(sys, sys.capacity);
+      expect(r.latency).toBeCloseTo(sys.baseLatencyMs, 5);
+    }
+  });
+
+  it('latency grows non-linearly past capacity', () => {
+    const sys = SYSTEMS[0];
+    const a = systemResponse(sys, sys.capacity + 10).latency;
+    const b = systemResponse(sys, sys.capacity + 20).latency;
+    const c = systemResponse(sys, sys.capacity + 30).latency;
+    expect(b - a).toBeGreaterThan(0);
+    expect(c - b).toBeGreaterThan(b - a);
+  });
+
+  it('errors stay near floor below capacity and grow above', () => {
+    const sys = SYSTEMS[0];
+    expect(systemResponse(sys, 1).error).toBeLessThan(0.005);
+    expect(systemResponse(sys, sys.capacity * 2).error).toBeGreaterThan(systemResponse(sys, sys.capacity).error);
+  });
+
+  it('percentiles place p99 above p95 above p50', () => {
+    const p = percentiles(100);
+    expect(p.p99).toBeGreaterThan(p.p95);
+    expect(p.p95).toBeGreaterThan(p.p50);
+  });
+});
+
+describe("Little's Law solver", () => {
+  it('computes L from λ and W', () => {
+    expect(littlesLaw({ lambda: 200, W: 0.08 })).toEqual({ L: 16 });
+  });
+
+  it('computes λ from L and W', () => {
+    expect(littlesLaw({ L: 16, W: 0.08 })).toEqual({ lambda: 200 });
+  });
+
+  it('computes W from L and λ', () => {
+    expect(littlesLaw({ L: 16, lambda: 200 })).toEqual({ W: 0.08 });
+  });
+
+  it('returns empty object when fewer than two inputs', () => {
+    expect(littlesLaw({ L: 16 })).toEqual({});
+  });
+});
+
+describe('kneeConcurrency', () => {
+  it('returns a value within sensible bounds for every system', () => {
+    for (const sys of SYSTEMS) {
+      const k = kneeConcurrency(sys);
+      expect(k).not.toBeNull();
+      expect(k).toBeGreaterThan(sys.capacity);
+      expect(k).toBeLessThan(sys.capacity * 3);
+    }
+  });
+});
+
+describe('PerformanceLoadProfileExplorer smoke', () => {
+  it('renders wrap, systems, profiles, dashboard, little, bridge', () => {
+    mount();
+    expect(document.querySelector('[data-testid="plp-wrap"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="plp-systems"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="plp-profiles"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="plp-dashboard"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="plp-little"]')).toBeInTheDocument();
+  });
+
+  it('switching profile re-renders dashboard metrics', () => {
+    mount();
+    const before = document.querySelector('[data-testid="plp-met-concurrency"]').textContent;
+    document.querySelector('[data-testid="plp-profile-stress"]').click();
+    const after = document.querySelector('[data-testid="plp-met-concurrency"]').textContent;
+    expect(after).not.toBe(before);
+  });
+
+  it("Little's Law slider updates the derived L", () => {
+    mount();
+    const before = document.querySelector('[data-testid="plp-ll-derived"]').textContent;
+    const slider = document.querySelector('[data-testid="plp-ll-lambda"]');
+    slider.value = '1000';
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+    const after = document.querySelector('[data-testid="plp-ll-derived"]').textContent;
+    expect(after).not.toBe(before);
+  });
+
+  it('quiz: pick option B (16), submit → correct', () => {
+    mount();
+    document.querySelector('[data-testid="plp-quiz-start"]').click();
+    document.querySelector('input[name="plp-quiz"][value="b"]').click();
+    document.querySelector('[data-testid="plp-quiz-submit"]').click();
+    expect(document.querySelector('[data-testid="plp-quiz-result"]').classList.contains('quiz-correct')).toBe(true);
+  });
+
+  it('lab reflect activates', () => {
+    mount();
+    document.querySelector('[data-testid="plp-lab-start"]').click();
+    expect(document.querySelector('[data-testid="plp-lab-text"]')).toBeInTheDocument();
+  });
+});

--- a/src/utils/urlRouter.js
+++ b/src/utils/urlRouter.js
@@ -26,7 +26,7 @@ export const TAB_SECTIONS = {
   flow:     { tabs: ['flow', 'defectCost', 'vmodel'],                                                 default: 'flow' },
   types:    { tabs: ['pyramid', 'adjuster'],                                                          default: 'pyramid' },
   // J-series acceptance tabs grow as J2-J8 land; J1 ships 'gherkin'.
-  acceptance: { tabs: ['gherkin', 'usecase', 'e2ejourney', 'contract'],                               default: 'gherkin' },
+  acceptance: { tabs: ['gherkin', 'usecase', 'e2ejourney', 'contract', 'perfload'],                   default: 'gherkin' },
 };
 
 // ── ComponentName → { section, tab? } ────────────────────────────────
@@ -71,6 +71,7 @@ export const EXPLORER_TO_LOCATION = {
   UseCaseDerivationExplorer:   { section: 'acceptance', tab: 'usecase' },
   E2EUserJourneyExplorer:      { section: 'acceptance', tab: 'e2ejourney' },
   ContractTestingExplorer:     { section: 'acceptance', tab: 'contract' },
+  PerformanceLoadProfileExplorer: { section: 'acceptance', tab: 'perfload' },
 };
 
 const FILTER_DIMS = ['level', 'technique', 'series', 'difficulty'];


### PR DESCRIPTION
## Summary
Fifth tab in J. Acceptance. Adds non-functional acceptance: four canonical load shapes, three system presets, a live Little's Law toy, and a knee-of-the-curve marker.

## Component
- **4 profiles** — Load / Stress / Spike / Soak — each shown as an inline SVG sparkline. Pick one to drive the dashboard.
- **3 systems** — API gateway (stateless) / DB-bound / CPU-bound. Each has its own capacity, base latency, and breaking-error rate.
- **Pure response model** — `latency(c) = base × (1 + max(0, (c−cap)/cap)² × 4)` — flat below capacity, hyperbolic above. Error rate and throughput follow.
- **Dashboard** — concurrency / throughput / p50-p95-p99 / error rate; "knee of the curve" marker tells students where latency first doubles.
- **Little's Law (L = λ × W)** — drag λ or W slider; derived L updates live. Solver also exposed for tests in all three directions.
- **Bridge** 🔗 → Risk-Based Testing — pair load profile with risk to budget perf testing.
- **Quiz**: classic 200 req/s × 80 ms → L = ? (answer 16). **Lab**: why Soak finds what Stress misses.

## Test plan
- [x] `npm run test:run` — 619/619 (was 600; +19 J5 assertions including pure-math: shapes, response model with non-linear growth, percentile ordering, Little's Law in three directions, knee bounds).
- [x] Manual: `?explorer=PerformanceLoadProfileExplorer` lands here; switched profiles, dragged sliders — dashboard recomputes live.
- [ ] CI green on GitHub Actions.

Closes #204. J6 (Chaos Engineering) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)