### PR TITLE
fix(router): scroll deeplinked section into view at boot

### DIFF
--- a/e2e/navigation-state.spec.js
+++ b/e2e/navigation-state.spec.js
@@ -32,6 +32,21 @@ test.describe('Navigation state', () => {
     await expect(page.getByRole('tab', { name: /Grammar Coverage|Grammar/ })).toHaveAttribute('aria-selected', 'true');
   });
 
+  test('?explorer=… deeplink scrolls the destination section into view on boot', async ({ page }) => {
+    await page.goto('/index.html?explorer=PairwiseExplorer');
+    // Wait for the rAF inside paint() to execute the scroll.
+    await page.waitForFunction(() => window.scrollY > 0, { timeout: 2000 }).catch(() => {});
+
+    // Section is visible AND its top is within the viewport.
+    const section = page.getByTestId('section-blackbox');
+    await expect(section).toBeVisible();
+    const topInViewport = await section.evaluate((el) => el.getBoundingClientRect().top < window.innerHeight - 50);
+    expect(topInViewport).toBe(true);
+
+    // Pairwise tab is the active one.
+    await expect(page.locator('[data-blackbox-tab="pairwise"]')).toHaveAttribute('aria-selected', 'true');
+  });
+
   test('does not save the Cloud utility drawer as the active learning section', async ({ page }) => {
     await page.goto('/index.html');
 

--- a/src/app.js
+++ b/src/app.js
@@ -132,6 +132,11 @@ function persistActiveSection(sectionId) {
 }
 
 export function renderApp(container) {
+  // Tracks whether the initial deeplink scroll has run; reset across
+  // locale-change re-paints so we don't scroll the user again after they
+  // toggle the language.
+  let initialDeeplinkHandled = false;
+
   function paint() {
     // Read URL state once at the top of paint() — tabbed-section setups
     // below reference it, so this MUST run before any of them.
@@ -928,6 +933,21 @@ export function renderApp(container) {
     renderNav();
     updateSectionVisibility();
     updateCloudDrawerState();
+
+    // On first boot, if the URL pointed at a specific section/explorer,
+    // scroll it into view so the user actually sees the destination
+    // instead of the (now-hidden) overview / header area at the top.
+    // We only do this once per session — locale switches keep the user
+    // wherever they currently are.
+    if (!initialDeeplinkHandled) {
+      initialDeeplinkHandled = true;
+      if (activeSection !== 'all' && urlState.section) {
+        requestAnimationFrame(() => {
+          scrollToActiveSection();
+          focusActiveSection();
+        });
+      }
+    }
   }
 
   paint();


### PR DESCRIPTION
## Bug
Surfaced in manual test **A1** of `MANUAL_TEST_PLAN.md`:

> Open `?explorer=PairwiseExplorer` — expected to **land directly on `section-blackbox` → tab `pairwise`; section scrolled into view**.

What actually happened: the routing was correct (Overview hidden, blackbox visible, pairwise tab `aria-selected=true`), but the page was still at `scrollY=0`, so the user saw the app header / nav / Overview filter bar and had to scroll down to find Pairwise.

Headless Playwright confirms the issue: `getBoundingClientRect().top` for `section-blackbox` was below the fold pre-fix.

## Fix
- `renderApp()` keeps an `initialDeeplinkHandled` flag in closure scope.
- `paint()` consumes it on the **first call only**; subsequent calls (locale-change re-paints) don't re-scroll — the user may have moved by then.
- Scroll runs via `requestAnimationFrame` so it executes after the destination section is in the DOM post-`paint()`.
- Both `scrollToActiveSection()` (smooth) and `focusActiveSection()` fire — same code path as the in-page nav clicks with `shouldScroll=true`.

## Regression test
New case in `e2e/navigation-state.spec.js` opens `?explorer=PairwiseExplorer` and asserts:
- section-blackbox is visible
- its `getBoundingClientRect().top` is inside the viewport
- pairwise tab `aria-selected=true`

## Test plan
- [x] Local headless: post-fix `window.scrollY === 239`, section top in viewport.
- [x] All 4 `navigation-state.spec.js` tests pass.
- [x] Unit suite: 656/656 (unchanged).
- [ ] CI green on GitHub Actions.

Found via the manual-test plan added in PR #213 — A1 caught it on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)