### PR TITLE
fix(tsconfig): resolve "no inputs found" error by narrowing include

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,8 @@
+// Ambient types shared across the project.
+//
+// Today this file exists so `tsc` has at least one input to satisfy
+// `tsconfig.json`'s include glob; tomorrow it's the natural home for
+// shared declarations (window/event-map augmentations, third-party
+// shims, common DOM helpers) as the codebase gradually adopts TS.
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist", "build"]
 }


### PR DESCRIPTION
## Bug
Editor / IDE showed a TS18003 diagnostic in `tsconfig.json`:

> No inputs were found in config file. Specified 'include' paths were `["src"]` and 'exclude' paths were `["node_modules","dist","build"]`.

The repo has zero `.ts`/`.tsx` files today — README intentionally keeps `.js` as-is and only asks **new** modules to be written in TS. But `"include": ["src"]` told tsc to scan the whole `src/` tree, found nothing it cared about, and emitted the error.

## Fix
- Narrow `tsconfig.json`'s `include` to `["src/**/*.ts", "src/**/*.tsx"]`.
- Add `src/types.d.ts` — an ambient-types stub. Today it just satisfies the include glob so `tsc` has at least one input; tomorrow it's the natural home for shared declarations (window / event-map augmentations, third-party shims, common DOM helpers) as the codebase gradually adopts TS.

## Verified
- [x] `npx tsc --noEmit` exits 0 with no diagnostics.
- [x] Unit suite: 656/656 green (no JS behaviour touched).
- [ ] CI green on GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)