### PR TITLE
fix(bridges): cross-section bridges must click the section nav button

### DIFF
--- a/e2e/navigation-state.spec.js
+++ b/e2e/navigation-state.spec.js
@@ -47,6 +47,39 @@ test.describe('Navigation state', () => {
     await expect(page.locator('[data-blackbox-tab="pairwise"]')).toHaveAttribute('aria-selected', 'true');
   });
 
+  test('cross-section bridge from J1 BDD → Decision Table switches section AND inner tab', async ({ page }) => {
+    await page.goto('/index.html?explorer=BDDGherkinExplorer');
+
+    // Pick the discount preset so the Examples table + bridge button are present.
+    await page.getByTestId('bdd-preset-discount').click();
+    await expect(page.getByTestId('bdd-bridge-decision-table')).toBeVisible();
+
+    // Click the bridge.
+    await page.getByTestId('bdd-bridge-decision-table').click();
+
+    // Expectation: section-blackbox is now the active section, AND the DT tab
+    // is selected. The pre-fix bug was that activeSection stayed on
+    // 'acceptance' and the user kept seeing the BDD/Gherkin tab.
+    await expect(page.getByTestId('section-blackbox')).toBeVisible();
+    await expect(page.getByTestId('section-acceptance')).toBeHidden();
+    await expect(page.locator('[data-blackbox-tab="dt"]')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('cross-section bridge from Logic Coverage → Group Theory switches active section', async ({ page }) => {
+    await page.goto('/index.html?section=logic');
+    await page.waitForLoadState('networkidle');
+
+    // Bridge button is rendered conditionally inside Logic — make sure it exists.
+    const bridge = page.getByTestId('logic-bridge-groupth');
+    await bridge.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {});
+    if (!(await bridge.isVisible().catch(() => false))) {
+      test.skip(true, 'logic-bridge-groupth not rendered for the default predicate / criterion');
+    }
+    await bridge.click();
+    await expect(page.getByTestId('section-groupth')).toBeVisible();
+    await expect(page.getByTestId('section-logic')).toBeHidden();
+  });
+
   test('does not save the Cloud utility drawer as the active learning section', async ({ page }) => {
     await page.goto('/index.html');
 

--- a/src/components/BDDGherkinExplorer.js
+++ b/src/components/BDDGherkinExplorer.js
@@ -348,9 +348,10 @@ function bindEvents() {
     });
   });
   root.querySelector('[data-testid="bdd-bridge-decision-table"]')?.addEventListener('click', () => {
-    // Defer to app.js's nav: switch to the blackbox section's dt tab.
+    // Switch the section via the nav button (setActiveSection + scroll),
+    // then click the inner Decision-Table tab.
+    document.querySelector('[data-section="blackbox"]')?.click();
     document.querySelector('[data-blackbox-tab="dt"]')?.click();
-    document.querySelector('[data-testid="section-blackbox"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   });
   root.querySelector('[data-testid="bdd-quiz-start"]')?.addEventListener('click', () => {
     state.quiz = { active: true, phase: 'question', answer: '' };

--- a/src/components/E2EUserJourneyExplorer.js
+++ b/src/components/E2EUserJourneyExplorer.js
@@ -262,8 +262,8 @@ function bindEvents() {
     render();
   });
   root.querySelector('[data-testid="e2e-bridge-tqx"]')?.addEventListener('click', () => {
+    document.querySelector('[data-section="advanced"]')?.click();
     document.querySelector('[data-advanced-tab="testquality"]')?.click();
-    document.querySelector('[data-testid="section-advanced"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   });
   root.querySelector('[data-testid="e2e-bridge-rbt"]')?.addEventListener('click', () => {
     document.querySelector('[data-section="rbt"]')?.click();

--- a/src/components/GroupTheoryExplorer.js
+++ b/src/components/GroupTheoryExplorer.js
@@ -533,9 +533,11 @@ export function createGroupTheoryExplorer() {
     }
 
     root.querySelector('[data-testid="gth-bridge-mt"]')?.addEventListener('click', () => {
-      // MT is a tab inside section-blackbox, not a standalone section
+      // MT is a tab inside section-blackbox. Switch the section first via
+      // the nav button (which calls setActiveSection + scrolls), then click
+      // the inner tab so MT becomes the active panel.
+      document.querySelector('[data-section="blackbox"]')?.click();
       document.querySelector('[data-blackbox-tab="mt"]')?.click();
-      document.querySelector('[data-testid="section-blackbox"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
 
     // Covering array controls

--- a/src/components/LogicCoverageExplorer.js
+++ b/src/components/LogicCoverageExplorer.js
@@ -1052,7 +1052,10 @@ export function createLogicCoverageExplorer() {
     }
 
     root.querySelector('[data-testid="logic-bridge-groupth"]')?.addEventListener('click', () => {
-      document.querySelector('[data-testid="section-groupth"]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // Switch sections via the nav button so activeSection is updated
+      // (just calling scrollIntoView on a `display:none` section is a no-op).
+      // setActiveSection(true) handles smooth-scroll + focus on its own.
+      document.querySelector('[data-section="groupth"]')?.click();
     });
 
     // Search range inputs.


### PR DESCRIPTION
## Bugs (from manual test plan §D)

D1 / D2 / D4, plus the pre-existing Logic Coverage → Group Theory bridge, all looked exactly like this:

```js
document.querySelector('[data-blackbox-tab="dt"]')?.click();          // wrong — section is still 'acceptance', tab is hidden
document.querySelector('[data-testid="section-blackbox"]')?.scrollIntoView(...);  // no-op — target has display:none
```

So if the user was in any section **other than** the destination, the bridge was effectively dead: it flipped a hidden tab state and asked the browser to scroll to an invisible element. The user kept seeing the source section.

## Pattern (correct)

Cross-section bridges must click the **section nav button** first; `setActiveSection(target, true)` switches the section and scrolls + focuses on its own. Only after that should the inner tab be clicked.

```js
document.querySelector('[data-section="blackbox"]')?.click();   // setActiveSection('blackbox', true)
document.querySelector('[data-blackbox-tab="dt"]')?.click();    // now the visible section's DT tab
```

## Affected bridges
- `LogicCoverageExplorer` → groupth (no tabs).
- `GroupTheoryExplorer` → blackbox / mt.
- `BDDGherkinExplorer` → blackbox / dt.
- `E2EUserJourneyExplorer` → advanced / testquality.

Other J-series bridges (J2/J3/J4/J5 → rbt/inttest, J7 → flow/vmodel, J8 → advanced, same-section J6/J7/J8 → another acceptance tab) were already correct. Audit done; no other broken cases.

## Regression tests
Added to `e2e/navigation-state.spec.js`:

1. **BDD → Decision Table** — asserts `section-blackbox` visible **and** `section-acceptance` hidden **and** dt tab `aria-selected=true`.
2. **Logic → Group Theory** — asserts `section-groupth` visible **and** `section-logic` hidden (auto-skipped if the conditional bridge button isn't rendered for the default predicate).

## Test plan
- [x] `npm run test:run` — 656/656 (unchanged).
- [x] `npx playwright test e2e/navigation-state.spec.js` — 5 passed, 1 skipped.
- [x] Manual: opened BDD/Gherkin, picked discount preset, clicked the bridge → landed on Decision Table tab.
- [ ] CI green on GitHub Actions.

Found via the manual-test plan added in PR #213 — §D caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)