### PR TITLE
fix(router): bridge / nav clicks push history; popstate restores source

### DIFF
--- a/e2e/navigation-state.spec.js
+++ b/e2e/navigation-state.spec.js
@@ -47,6 +47,34 @@ test.describe('Navigation state', () => {
     await expect(page.locator('[data-blackbox-tab="pairwise"]')).toHaveAttribute('aria-selected', 'true');
   });
 
+  test('browser back button returns to the source after a cross-section bridge click', async ({ page }) => {
+    // Start on the BDD/Gherkin tab via deeplink.
+    await page.goto('/index.html?explorer=BDDGherkinExplorer');
+    await page.waitForLoadState('networkidle');
+    await page.getByTestId('bdd-preset-discount').click();
+
+    // Snapshot the source URL exactly as the browser sees it — we don't
+    // care about the shape (`?explorer=` vs `?section=&tab=`), just that
+    // the back button takes us back to this exact string.
+    const sourceUrl = page.url();
+    await expect(page.getByTestId('section-acceptance')).toBeVisible();
+
+    // Cross-section jump to Decision Table.
+    await page.getByTestId('bdd-bridge-decision-table').click();
+    await expect(page.getByTestId('section-blackbox')).toBeVisible();
+    expect(page.url()).toContain('section=blackbox');
+    expect(page.url()).toContain('tab=dt');
+    expect(page.url()).not.toBe(sourceUrl);
+
+    // Browser back: URL is restored, page reloads (we listen for popstate
+    // and call location.reload()), and the source section is visible again.
+    await page.goBack();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('section-acceptance')).toBeVisible();
+    await expect(page.getByTestId('section-blackbox')).toBeHidden();
+    expect(page.url()).toBe(sourceUrl);
+  });
+
   test('cross-section bridge from J1 BDD → Decision Table switches section AND inner tab', async ({ page }) => {
     await page.goto('/index.html?explorer=BDDGherkinExplorer');
 

--- a/src/app.js
+++ b/src/app.js
@@ -137,6 +137,12 @@ export function renderApp(container) {
   // toggle the language.
   let initialDeeplinkHandled = false;
 
+  // Mirror of the most recent `location.search` we've written via
+  // `syncUrl()`. The popstate handler compares against this to decide
+  // whether to reload — hash-only navigation (skip-link Enter etc.)
+  // changes neither lastSearchSnapshot nor `location.search`.
+  let lastSearchSnapshot = globalThis.location?.search ?? '';
+
   function paint() {
     // Read URL state once at the top of paint() — tabbed-section setups
     // below reference it, so this MUST run before any of them.
@@ -721,6 +727,11 @@ export function renderApp(container) {
         } else {
           globalThis.history?.replaceState?.(null, '', url);
         }
+        // Keep the popstate handler's reference in lockstep with the URL
+        // we just wrote — so a true back-navigation across our pushed
+        // entries flips this comparison, but a hash-only navigation
+        // (skip-link) leaves it equal.
+        lastSearchSnapshot = qs;
       } catch {
         // Ignore — push/replaceState may be unavailable in some test envs.
       }
@@ -965,15 +976,17 @@ export function renderApp(container) {
   paint();
   onLocaleChange(() => paint());
 
-  // When the browser navigates back/forward across a `pushState` entry,
-  // re-load the page so the app re-applies state from the new URL. A full
-  // reload is the cheapest way to keep section + tab + pack + filter
-  // state in lockstep with the URL without duplicating all the boot
-  // logic; the only thing lost is per-Explorer interaction state at the
-  // destination, which is acceptable when the user is undoing a bridge
-  // click anyway.
+  // Browser back/forward across one of our pushState entries: reload so
+  // the app re-applies state from the new URL. Compare `location.search`
+  // against the last value `syncUrl()` wrote — hash-only navigation
+  // (skip-link `<a href="#app-main">` etc.) doesn't change search, so we
+  // ignore it.
   globalThis.addEventListener?.('popstate', () => {
-    globalThis.location?.reload?.();
+    const current = globalThis.location?.search ?? '';
+    if (current !== lastSearchSnapshot) {
+      lastSearchSnapshot = current;
+      globalThis.location?.reload?.();
+    }
   });
 
   // Show ResultViewer if URL contains ?result= (Phase A share link)

--- a/src/app.js
+++ b/src/app.js
@@ -702,7 +702,11 @@ export function renderApp(container) {
     });
     overviewPacksHost.appendChild(packBar.element);
 
-    function syncUrl() {
+    // mode='push' creates a new history entry (so the browser back button
+    // returns the user to the previous URL); 'replace' overwrites the
+    // current entry without polluting the back stack. Section/nav changes
+    // push; filter/tab/pack chip changes replace.
+    function syncUrl(mode = 'replace') {
       try {
         const state = {
           section: activeSection,
@@ -712,9 +716,13 @@ export function renderApp(container) {
         };
         const qs = serializeLocation(state);
         const url = `${globalThis.location.pathname}${qs}${globalThis.location.hash}`;
-        globalThis.history?.replaceState?.(null, '', url);
+        if (mode === 'push') {
+          globalThis.history?.pushState?.(null, '', url);
+        } else {
+          globalThis.history?.replaceState?.(null, '', url);
+        }
       } catch {
-        // Ignore — `replaceState` may be unavailable in some test envs.
+        // Ignore — push/replaceState may be unavailable in some test envs.
       }
     }
 
@@ -876,12 +884,16 @@ export function renderApp(container) {
         openCloudDrawer();
         return;
       }
+      // Section change is a navigation: push a history entry so the
+      // browser back button returns the user to the previous section.
+      // Same-section re-clicks fall through to replace (no history spam).
+      const sectionChanged = activeSection !== sectionId;
       activeSection = sectionId;
       persistActiveSection(activeSection);
       renderNav();
       updateSectionVisibility();
       updateCloudTriggerState();
-      syncUrl();
+      syncUrl(sectionChanged ? 'push' : 'replace');
       if (shouldScroll) {
         requestAnimationFrame(() => {
           scrollToActiveSection();
@@ -952,6 +964,17 @@ export function renderApp(container) {
 
   paint();
   onLocaleChange(() => paint());
+
+  // When the browser navigates back/forward across a `pushState` entry,
+  // re-load the page so the app re-applies state from the new URL. A full
+  // reload is the cheapest way to keep section + tab + pack + filter
+  // state in lockstep with the URL without duplicating all the boot
+  // logic; the only thing lost is per-Explorer interaction state at the
+  // destination, which is acceptable when the user is undoing a bridge
+  // click anyway.
+  globalThis.addEventListener?.('popstate', () => {
+    globalThis.location?.reload?.();
+  });
 
   // Show ResultViewer if URL contains ?result= (Phase A share link)
   const viewer = createResultViewer();


### PR DESCRIPTION
## Bug (manual test §D)
After **any cross-section bridge click**, the browser **back button** did not return the user to the source section. Same for plain nav-bar / overview-card clicks.

## Root cause
Every URL write went through `replaceState`, including section navigations. Source URLs never made it into the back stack — so `history.back()` had nothing to return to.

## Fix
- `syncUrl(mode)` now accepts `'push' | 'replace'`. Default stays `'replace'` so filter / tab / pack chip changes don't pollute the back stack (would be obnoxious — every chip toggle is a fine-grained edit, not a navigation).
- `setActiveSection` detects whether `activeSection` actually changes and passes `'push'` only on real section transitions. This routes through every section-changing path:
  - Nav bar buttons → `setActiveSection(id, true)`
  - Overview card clicks → `setActiveSection(id, true)`
  - Cross-section bridges → simulate a nav-button click via the §D-217 fix, so the same push happens
- New `popstate` listener at the bottom of `renderApp()` calls `location.reload()`. Simplest reliable way to keep section + tab + pack + filter state in lockstep with the URL across back/forward without duplicating the boot pipeline. Trade-off: per-Explorer interaction state at the destination is discarded — acceptable since the user is explicitly undoing a navigation.

## Regression test
New in `e2e/navigation-state.spec.js`:
1. Open `?explorer=BDDGherkinExplorer`, snapshot `location.href`.
2. Click the bridge to Decision Table — assert section flips to `section-blackbox` + `tab=dt`.
3. `page.goBack()` — assert URL string equals the snapshot exactly, `section-acceptance` is visible, `section-blackbox` is hidden.

## Test plan
- [x] `npm run test:run` — 656/656 (unchanged).
- [x] `npx playwright test e2e/navigation-state.spec.js` — 6 passed, 1 skipped (conditional Logic→GroupTheory bridge).
- [x] Manual: walked the BDD→DT bridge in Chrome; back button now lands on the BDD/Gherkin tab.
- [ ] CI green on GitHub Actions.

Found via the manual-test plan; the matching D-§ row in `MANUAL_TEST_PLAN.md` is the after-each-jump back-button check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)