### PR TITLE
feat(share): add Share button to all 13 I-series + J-series Explorers

### DIFF
--- a/src/components/ATDDCycleExplorer.js
+++ b/src/components/ATDDCycleExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 export const STAGES = ['discuss', 'distill', 'develop', 'demo'];
 
@@ -139,8 +140,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'c';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'atdd', explorerLabel: t('atdd.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('atdd.quiz.prompt'),
+        a: state.quiz.answer ? t('atdd.quiz.' + state.quiz.answer) : '',
+        expected: t('atdd.quiz.c'),
+        ok: correct,
+      }],
+    });
     return `<div class="atdd-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="atdd-quiz-result">
       <p>${correct ? t('atdd.quiz.correct') : t('atdd.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="atdd-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/BDDGherkinExplorer.js
+++ b/src/components/BDDGherkinExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Three preset feature files; tiny on purpose so students can read end-to-end.
 const PRESETS = [
@@ -279,8 +280,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'b';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'bdd', explorerLabel: t('bdd.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('bdd.quiz.prompt'),
+        a: state.quiz.answer ? t('bdd.quiz.' + state.quiz.answer) : '',
+        expected: t('bdd.quiz.b'),
+        ok: correct,
+      }],
+    });
     return `<div class="bdd-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="bdd-quiz-result">
       <p>${correct ? t('bdd.quiz.correct') : t('bdd.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="bdd-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/ChaosEngineeringExplorer.js
+++ b/src/components/ChaosEngineeringExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Each topology is a tiny dependency graph: nodes (services) and edges
 // (consumer → provider). Fault propagation walks edges from any failing
@@ -247,8 +248,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'c';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'chx', explorerLabel: t('chx.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('chx.quiz.prompt'),
+        a: state.quiz.answer ? t('chx.quiz.' + state.quiz.answer) : '',
+        expected: t('chx.quiz.c'),
+        ok: correct,
+      }],
+    });
     return `<div class="chx-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="chx-quiz-result">
       <p>${correct ? t('chx.quiz.correct') : t('chx.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="chx-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/ContractTestingExplorer.js
+++ b/src/components/ContractTestingExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Each scenario describes a consumer's expectation and the provider's
 // actual response. verifyScenario() runs a small structural diff:
@@ -196,8 +197,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'b';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'ct', explorerLabel: t('ct.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('ct.quiz.prompt'),
+        a: state.quiz.answer ? t('ct.quiz.' + state.quiz.answer) : '',
+        expected: t('ct.quiz.b'),
+        ok: correct,
+      }],
+    });
     return `<div class="ct-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="ct-quiz-result">
       <p>${correct ? t('ct.quiz.correct') : t('ct.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="ct-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/E2EUserJourneyExplorer.js
+++ b/src/components/E2EUserJourneyExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Each step has a per-flakiness-source failure rate (probability of THIS run
 // failing AT this step due to THIS source). Independent per-source draws; the
@@ -191,8 +192,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === QUIZ_LOGS[0].correct;
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'e2e', explorerLabel: t('e2e.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('e2e.quiz.prompt'),
+        a: state.quiz.answer || '',
+        expected: QUIZ_LOGS[0].correct,
+        ok: correct,
+      }],
+    });
     return `<div class="e2e-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="e2e-quiz-result">
       <p>${correct ? t('e2e.quiz.correct') : t('e2e.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="e2e-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/EquivalentMutantExplorer.js
+++ b/src/components/EquivalentMutantExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 const PAPER = {
   title: 'Mutation-Guided LLM-based Test Generation at Meta',
@@ -281,8 +282,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'b';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'emx', explorerLabel: t('emx.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('emx.quiz.prompt'),
+        a: state.quiz.answer ? t('emx.quiz.' + state.quiz.answer) : '',
+        expected: t('emx.quiz.b'),
+        ok: correct,
+      }],
+    });
     return `<div class="emx-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="emx-quiz-result">
       <p>${correct ? t('emx.quiz.correct') : t('emx.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="emx-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/FaultDirectedTestingExplorer.js
+++ b/src/components/FaultDirectedTestingExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Four annotated issues paired with a target function, blind mutants (coverage-driven),
 // and the small set of fault-directed mutants the ACH pipeline would propose from the
@@ -217,8 +218,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'a';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'fdx', explorerLabel: t('fdx.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('fdx.quiz.prompt'),
+        a: state.quiz.answer ? t('fdx.quiz.' + state.quiz.answer) : '',
+        expected: t('fdx.quiz.a'),
+        ok: correct,
+      }],
+    });
     return `<div class="fdx-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="fdx-quiz-result">
       <p>${correct ? t('fdx.quiz.correct') : t('fdx.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="fdx-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/FlakyDiagnosisExplorer.js
+++ b/src/components/FlakyDiagnosisExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Six categories — same taxonomy as J3 plus an explicit "order" bucket.
 export const SOURCES = ['timing', 'order', 'async', 'network', 'animation', 'data'];
@@ -171,8 +172,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'b';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'flx', explorerLabel: t('flx.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('flx.quiz.prompt'),
+        a: state.quiz.answer ? t('flx.quiz.' + state.quiz.answer) : '',
+        expected: t('flx.quiz.b'),
+        ok: correct,
+      }],
+    });
     return `<div class="flx-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="flx-quiz-result">
       <p>${correct ? t('flx.quiz.correct') : t('flx.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="flx-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/LLMPipelineExplorer.js
+++ b/src/components/LLMPipelineExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 const AGENTS = [
   {
@@ -194,8 +195,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'c';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'llmp', explorerLabel: t('llmp.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('llmp.quiz.prompt'),
+        a: state.quiz.answer ? t('llmp.quiz.' + state.quiz.answer) : '',
+        expected: t('llmp.quiz.c'),
+        ok: correct,
+      }],
+    });
     return `<div class="llmp-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="llmp-quiz-result">
       <p>${correct ? t('llmp.quiz.correct') : t('llmp.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="llmp-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/MutationScoreExplorer.js
+++ b/src/components/MutationScoreExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Pre-defined target function
 const TARGET_FN = `function classify(score) {
@@ -270,8 +271,20 @@ function renderQuiz(score) {
   if (state.quiz.phase === 'done') {
     const ans = parseInt(state.quiz.answer, 10);
     const correct = ans === score;
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'msx', explorerLabel: t('msx.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('msx.quiz.prompt', { total: NON_EQUIV_MUTANTS.length }),
+        a: String(state.quiz.answer ?? ''),
+        expected: String(score),
+        ok: correct,
+      }],
+    });
     return `<div class="msx-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="msx-quiz-result">
       <p>${correct ? t('msx.quiz.correct') : t('msx.quiz.wrong', { score })}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="msx-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/PerformanceLoadProfileExplorer.js
+++ b/src/components/PerformanceLoadProfileExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Four load shapes. Each emits target concurrency at every tick (0–100).
 // load: steady; stress: ramp; spike: brief impulse; soak: long flat hold.
@@ -196,8 +197,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'b';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'plp', explorerLabel: t('plp.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('plp.quiz.prompt'),
+        a: state.quiz.answer ? t('plp.quiz.' + state.quiz.answer) : '',
+        expected: t('plp.quiz.b'),
+        ok: correct,
+      }],
+    });
     return `<div class="plp-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="plp-quiz-result">
       <p>${correct ? t('plp.quiz.correct') : t('plp.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="plp-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/TestQualityExplorer.js
+++ b/src/components/TestQualityExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 const DIMENSIONS = [
   { id: 'buildable',  icon: '🔨', weight: 1 },
@@ -226,8 +227,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'b';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'tqx', explorerLabel: t('tqx.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('tqx.quiz.prompt'),
+        a: state.quiz.answer ? t('tqx.quiz.' + state.quiz.answer) : '',
+        expected: t('tqx.quiz.b'),
+        ok: correct,
+      }],
+    });
     return `<div class="tqx-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="tqx-quiz-result">
       <p>${correct ? t('tqx.quiz.correct') : t('tqx.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="tqx-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/components/UseCaseDerivationExplorer.js
+++ b/src/components/UseCaseDerivationExplorer.js
@@ -1,4 +1,5 @@
-import { t } from '../i18n/index.js';
+import { t, getLocale } from '../i18n/index.js';
+import { encodeResult } from '../utils/resultExporter.js';
 
 // Three preset use cases. Each flow id is unique so the rendered list
 // stays addressable by data-testid. `kind` drives colour-coding.
@@ -192,8 +193,20 @@ function renderQuiz() {
   }
   if (state.quiz.phase === 'done') {
     const correct = state.quiz.answer === 'c';
+    const shareEncoded = encodeResult({
+      v: 1, explorer: 'uc', explorerLabel: t('uc.title'),
+      mode: 'quiz', ts: Date.now(), lang: getLocale(),
+      score: correct ? 1 : 0, total: 1,
+      items: [{
+        q: t('uc.quiz.prompt'),
+        a: state.quiz.answer ? t('uc.quiz.' + state.quiz.answer) : '',
+        expected: t('uc.quiz.c'),
+        ok: correct,
+      }],
+    });
     return `<div class="uc-quiz-result ${correct ? 'quiz-correct' : 'quiz-wrong'}" data-testid="uc-quiz-result">
       <p>${correct ? t('uc.quiz.correct') : t('uc.quiz.wrong')}</p>
+      <button type="button" class="quiz-share-btn" data-share-payload="${shareEncoded}" data-testid="uc-quiz-share">📋 ${t('quiz.share.btn')}</button>
     </div>`;
   }
   return `

--- a/src/tests/IJseriesShareButtons.test.jsx
+++ b/src/tests/IJseriesShareButtons.test.jsx
@@ -1,0 +1,76 @@
+// Regression for the §F-B class-results pipeline: every I-series and
+// J-series Explorer's quiz `done` state must render a button carrying
+// `data-share-payload`. The CloudStoragePanel's document-level listener
+// uses that attribute to auto-upload to Firestore when a class code is
+// set, so a missing button is a silent black-hole.
+
+import { describe, expect, it } from 'vitest';
+import { createEquivalentMutantExplorer } from '../components/EquivalentMutantExplorer.js';
+import { createMutationScoreExplorer } from '../components/MutationScoreExplorer.js';
+import { createLLMPipelineExplorer } from '../components/LLMPipelineExplorer.js';
+import { createTestQualityExplorer } from '../components/TestQualityExplorer.js';
+import { createFaultDirectedTestingExplorer } from '../components/FaultDirectedTestingExplorer.js';
+import { createBDDGherkinExplorer } from '../components/BDDGherkinExplorer.js';
+import { createUseCaseDerivationExplorer } from '../components/UseCaseDerivationExplorer.js';
+import { createE2EUserJourneyExplorer } from '../components/E2EUserJourneyExplorer.js';
+import { createContractTestingExplorer } from '../components/ContractTestingExplorer.js';
+import { createPerformanceLoadProfileExplorer } from '../components/PerformanceLoadProfileExplorer.js';
+import { createChaosEngineeringExplorer } from '../components/ChaosEngineeringExplorer.js';
+import { createATDDCycleExplorer } from '../components/ATDDCycleExplorer.js';
+import { createFlakyDiagnosisExplorer } from '../components/FlakyDiagnosisExplorer.js';
+
+// Each row: factory, testid prefix, optional setup before the quiz, the
+// value to pick for the radio (or 'numeric' marker), and the resulting
+// share button testid.
+const ROWS = [
+  // ── I-series ─────────────────────────────────────────────────────
+  { name: 'I1 EquivalentMutant',  create: createEquivalentMutantExplorer,    prefix: 'emx',  pick: 'b' },
+  { name: 'I2 MutationScore',     create: createMutationScoreExplorer,       prefix: 'msx',  pick: 'numeric' },
+  { name: 'I3 LLMPipeline',       create: createLLMPipelineExplorer,         prefix: 'llmp', pick: 'c' },
+  { name: 'I4 TestQuality',       create: createTestQualityExplorer,         prefix: 'tqx',  pick: 'b' },
+  { name: 'I5 FaultDirected',     create: createFaultDirectedTestingExplorer,prefix: 'fdx',  pick: 'a' },
+  // ── J-series ─────────────────────────────────────────────────────
+  { name: 'J1 BDDGherkin',        create: createBDDGherkinExplorer,          prefix: 'bdd',  pick: 'b' },
+  { name: 'J2 UseCase',           create: createUseCaseDerivationExplorer,   prefix: 'uc',   pick: 'c' },
+  { name: 'J3 E2EJourney',        create: createE2EUserJourneyExplorer,      prefix: 'e2e',  pick: 'animation' },
+  { name: 'J4 Contract',          create: createContractTestingExplorer,     prefix: 'ct',   pick: 'b' },
+  { name: 'J5 PerfLoad',          create: createPerformanceLoadProfileExplorer, prefix: 'plp', pick: 'b' },
+  { name: 'J6 Chaos',             create: createChaosEngineeringExplorer,    prefix: 'chx',  pick: 'c' },
+  { name: 'J7 ATDD',              create: createATDDCycleExplorer,           prefix: 'atdd', pick: 'c' },
+  { name: 'J8 FlakyDiagnosis',    create: createFlakyDiagnosisExplorer,      prefix: 'flx',  pick: 'b' },
+];
+
+function mount(create) {
+  document.body.innerHTML = '';
+  const el = create();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('I/J series — every quiz `done` state renders a share button', () => {
+  for (const row of ROWS) {
+    it(`${row.name}: share button present after submitting correct answer`, () => {
+      mount(row.create);
+      document.querySelector(`[data-testid="${row.prefix}-quiz-start"]`).click();
+
+      if (row.pick === 'numeric') {
+        // I2 uses a number input. The correct value depends on the
+        // current mutation-score; for the default state (no tests added)
+        // the score is 0, so submitting "0" is the only deterministic
+        // way to hit the correct branch.
+        const inp = document.querySelector(`[data-testid="${row.prefix}-quiz-input"]`);
+        inp.value = '0';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+      } else {
+        const radio = document.querySelector(`input[name="${row.prefix}-quiz"][value="${row.pick}"]`);
+        radio.click();
+      }
+
+      document.querySelector(`[data-testid="${row.prefix}-quiz-submit"]`).click();
+
+      const share = document.querySelector(`[data-testid="${row.prefix}-quiz-share"]`);
+      expect(share, `${row.name} should expose a share button`).toBeInTheDocument();
+      expect(share.getAttribute('data-share-payload'), `${row.name} share payload non-empty`).toBeTruthy();
+    });
+  }
+});


### PR DESCRIPTION
## Bug (manual test §F2)
Setting a class code and clicking a quiz **Share** button on any I-series or J-series Explorer never uploaded to Firestore — TeacherDashboard stayed empty.

## Root cause
`CloudStoragePanel`'s auto-upload listener fires on a click of any `[data-share-payload]` element. The 19 older Explorers all have a share button; **the 13 newer ones (I1–I5, J1–J8) were missing it entirely**, so there was nothing to trigger the upload.

## Fix
One patch per Explorer, mirroring the 19 older ones:
- Import `getLocale` + `encodeResult`.
- In the quiz `done` branch, build a share payload (`v`, explorer short-id, label, `mode='quiz'`, score, total, items[]).
- Render `<button class="quiz-share-btn" data-share-payload=… data-testid="<prefix>-quiz-share">📋 …</button>` next to the result feedback.

Explorer-specific handling:
- **I2 MutationScore** — numeric input: `a` is the typed number, `expected` is the live computed score.
- **J3 E2EUserJourney** — answer is a flakiness-source string, not a/b/c/d.
- All others — 4-option multiple choice; encoded `a`/`expected` use the i18n option labels.

## Regression test
New `src/tests/IJseriesShareButtons.test.jsx` — mounts each of the 13 Explorers, completes its quiz with the correct answer, asserts the share button exists with a non-empty `data-share-payload`.

## Test plan
- [x] `npm run test:run` — 669/669 (was 656; +13).
- [x] Manual: set class code, did a J1 quiz, clicked Share — result appeared in TeacherDashboard.
- [ ] CI green on GitHub Actions.

After this merges, every one of the 43 Explorers feeds the §F-B class-results pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)