### PR TITLE
feat(advanced): two-level nav — paper selector → that paper's tabs

### DIFF
--- a/e2e/navigation-state.spec.js
+++ b/e2e/navigation-state.spec.js
@@ -75,6 +75,41 @@ test.describe('Navigation state', () => {
     expect(page.url()).toBe(sourceUrl);
   });
 
+  test('Advanced Testing two-level nav: paper selector switches sub-tabs', async ({ page }) => {
+    // Deeplink to an ACH-paper Explorer.
+    await page.goto('/index.html?explorer=TestQualityExplorer');
+    await page.waitForLoadState('networkidle');
+
+    // ACH paper chip is active; its 5 sub-tabs are the visible ones.
+    await expect(page.locator('[data-advanced-paper="ach"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('[data-advanced-tab="testquality"]')).toHaveAttribute('aria-selected', 'true');
+    expect(await page.locator('[data-advanced-tab]:not([hidden])').count()).toBe(5);
+
+    // Switch to the SAILOR paper — its single tab becomes the visible set.
+    await page.locator('[data-advanced-paper="sailor"]').click();
+    await expect(page.locator('[data-advanced-tab="sailor"]')).toHaveAttribute('aria-selected', 'true');
+    expect(await page.locator('[data-advanced-tab]:not([hidden])').count()).toBe(1);
+    await expect(page.getByTestId('sailor-wrap')).toBeVisible();
+  });
+
+  test('cross-section bridge into a hidden Advanced tab still works (paper switch)', async ({ page }) => {
+    // Land on the SAILOR paper so the TestQuality tab is rendered-but-hidden.
+    await page.goto('/index.html?explorer=SAILORPipelineExplorer');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-advanced-paper="sailor"]')).toHaveAttribute('aria-selected', 'true');
+
+    // Bridge from J3 E2E → TestQuality (an ACH-paper tab).
+    await page.locator('[data-section="acceptance"]').click();
+    await page.locator('[data-acceptance-tab="e2ejourney"]').click();
+    await page.getByTestId('e2e-bridge-tqx').click();
+
+    // The bridge must flip both the paper chip AND the sub-tab.
+    await expect(page.getByTestId('section-advanced')).toBeVisible();
+    await expect(page.locator('[data-advanced-paper="ach"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('[data-advanced-tab="testquality"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByTestId('tqx-wrap')).toBeVisible();
+  });
+
   test('cross-section bridge from J1 BDD → Decision Table switches section AND inner tab', async ({ page }) => {
     await page.goto('/index.html?explorer=BDDGherkinExplorer');
 

--- a/src/App.css
+++ b/src/App.css
@@ -347,6 +347,37 @@ textarea:focus-visible {
   gap: 32px;
 }
 
+/* Advanced Testing — paper selector (level 1, above the sub-tab row) */
+.adv-paper-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.adv-paper-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--app-text-subtle);
+  background: var(--app-surface-muted);
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+.adv-paper-btn:hover {
+  color: var(--app-primary);
+  border-color: var(--app-primary);
+}
+.adv-paper-btn.active {
+  color: #fff;
+  background: var(--app-primary);
+  border-color: var(--app-primary);
+}
+
 .explorer-mobile-nav {
   display: none;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -303,16 +303,41 @@ export function renderApp(container) {
     container.querySelector('[data-slot="rbt"]').appendChild(components.rbt);
     container.querySelector('[data-slot="groupth"]').appendChild(components.groupth);
 
-    // --- Advanced Testing: tabbed (I1 Equivalent Mutants; I2–I5 added in subsequent PRs) ---
-    const advancedTabs = [
-      { id: 'equivmutant',   key: 'advTab.equivmutant',   component: components.equivmutant },
-      { id: 'mutationscore', key: 'advTab.mutationscore', component: components.mutationscore },
-      { id: 'llmpipeline',   key: 'advTab.llmpipeline',   component: components.llmpipeline },
-      { id: 'testquality',   key: 'advTab.testquality',   component: components.testquality },
-      { id: 'faultdirected', key: 'advTab.faultdirected', component: components.faultdirected },
-      { id: 'sailor',        key: 'advTab.sailor',        component: components.sailor },
+    // --- Advanced Testing: two-level nav — paper selector → that paper's tabs ---
+    // Each research paper groups its Explorers; the leaf tab id stays the URL
+    // identifier (?explorer / ?tab), so K4 routing is untouched. The paper
+    // level is a pure UI grouping derived from whichever leaf tab is active.
+    const advancedPapers = [
+      {
+        id: 'ach',
+        labelKey: 'advPaper.ach',
+        tabs: [
+          { id: 'equivmutant',   key: 'advTab.equivmutant',   component: components.equivmutant },
+          { id: 'mutationscore', key: 'advTab.mutationscore', component: components.mutationscore },
+          { id: 'llmpipeline',   key: 'advTab.llmpipeline',   component: components.llmpipeline },
+          { id: 'testquality',   key: 'advTab.testquality',   component: components.testquality },
+          { id: 'faultdirected', key: 'advTab.faultdirected', component: components.faultdirected },
+        ],
+      },
+      {
+        id: 'sailor',
+        labelKey: 'advPaper.sailor',
+        tabs: [
+          { id: 'sailor', key: 'advTab.sailor', component: components.sailor },
+        ],
+      },
     ];
+    // Flattened — drives panel creation and resolveInitialTab.
+    const advancedTabs = advancedPapers.flatMap((p) => p.tabs);
+    const paperOfAdvancedTab = (tabId) =>
+      advancedPapers.find((p) => p.tabs.some((tb) => tb.id === tabId)) || advancedPapers[0];
+
     const advancedSlot = container.querySelector('[data-slot="advanced"]');
+    const advancedPaperBar = document.createElement('nav');
+    advancedPaperBar.className = 'adv-paper-row';
+    advancedPaperBar.dataset.testid = 'advanced-paper-row';
+    advancedPaperBar.setAttribute('role', 'tablist');
+    advancedSlot.appendChild(advancedPaperBar);
     const advancedTabBar = document.createElement('nav');
     advancedTabBar.className = 'syntax-tab-row';
     advancedTabBar.dataset.testid = 'advanced-tab-row';
@@ -337,19 +362,53 @@ export function renderApp(container) {
       urlTab: urlState.tab,
       saved: savedAdvancedTab,
     });
-    function renderAdvancedTabs() {
-      advancedTabBar.innerHTML = advancedTabs.map((tab) => `
+    let activeAdvancedPaper = paperOfAdvancedTab(activeAdvancedTab).id;
+
+    function renderAdvancedPaperBar() {
+      advancedPaperBar.innerHTML = advancedPapers.map((paper) => `
         <button type="button"
-          class="syntax-tab-btn${activeAdvancedTab === tab.id ? ' active' : ''}"
-          data-advanced-tab="${tab.id}"
+          class="adv-paper-btn${activeAdvancedPaper === paper.id ? ' active' : ''}"
+          data-advanced-paper="${paper.id}"
           role="tab"
-          aria-selected="${activeAdvancedTab === tab.id ? 'true' : 'false'}"
-        >${t(tab.key)}</button>
+          aria-selected="${activeAdvancedPaper === paper.id ? 'true' : 'false'}"
+        >${t(paper.labelKey)}</button>
       `).join('');
+      advancedPaperBar.querySelectorAll('[data-advanced-paper]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const paper = advancedPapers.find((p) => p.id === btn.dataset.advancedPaper);
+          if (!paper) return;
+          activeAdvancedPaper = paper.id;
+          activeAdvancedTab = paper.tabs[0].id;  // jump to the paper's first Explorer
+          try { globalThis.localStorage?.setItem(ADVANCED_TAB_KEY, activeAdvancedTab); } catch {}
+          renderAdvancedPaperBar();
+          renderAdvancedTabs();
+          updateAdvancedPanels();
+          if (activeSection === 'advanced') syncUrl();
+        });
+      });
+    }
+    function renderAdvancedTabs() {
+      // Render every leaf tab, but `hidden` the ones outside the active
+      // paper. They stay in the DOM so a cross-section bridge that does
+      // `[data-advanced-tab="testquality"].click()` works regardless of
+      // which paper is currently showing — the click handler re-derives
+      // the paper and re-renders both bars.
+      advancedTabBar.innerHTML = advancedPapers.flatMap((paper) =>
+        paper.tabs.map((tab) => `
+          <button type="button"
+            class="syntax-tab-btn${activeAdvancedTab === tab.id ? ' active' : ''}"
+            data-advanced-tab="${tab.id}"
+            role="tab"
+            aria-selected="${activeAdvancedTab === tab.id ? 'true' : 'false'}"
+            ${paper.id === activeAdvancedPaper ? '' : 'hidden'}
+          >${t(tab.key)}</button>
+        `)).join('');
       advancedTabBar.querySelectorAll('[data-advanced-tab]').forEach((btn) => {
         btn.addEventListener('click', () => {
           activeAdvancedTab = btn.dataset.advancedTab;
+          activeAdvancedPaper = paperOfAdvancedTab(activeAdvancedTab).id;
           try { globalThis.localStorage?.setItem(ADVANCED_TAB_KEY, activeAdvancedTab); } catch {}
+          renderAdvancedPaperBar();
           renderAdvancedTabs();
           updateAdvancedPanels();
           if (activeSection === 'advanced') syncUrl();
@@ -361,6 +420,7 @@ export function renderApp(container) {
         panel.style.display = panel.dataset.advancedPanel === activeAdvancedTab ? '' : 'none';
       });
     }
+    renderAdvancedPaperBar();
     renderAdvancedTabs();
     updateAdvancedPanels();
 

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -303,6 +303,8 @@ export const messages = {
     'advTab.testquality': 'Test Quality Review',
     'advTab.faultdirected': 'Fault-Directed Testing',
     'advTab.sailor': 'SAILOR Pipeline',
+    'advPaper.ach': '📄 Meta ACH · FSE 2025',
+    'advPaper.sailor': '📄 SAILOR · arXiv 2026',
 
     // Acceptance & E2E (J-series)
     'section.acceptance': 'Acceptance & E2E',
@@ -2267,6 +2269,8 @@ export const messages = {
     'advTab.testquality': '測試品質審查',
     'advTab.faultdirected': '缺陷導向測試',
     'advTab.sailor': 'SAILOR 流程',
+    'advPaper.ach': '📄 Meta ACH · FSE 2025',
+    'advPaper.sailor': '📄 SAILOR · arXiv 2026',
 
     // 驗收 / E2E (J 系列)
     'section.acceptance': '驗收 / E2E',


### PR DESCRIPTION
## Summary
PR-2 of the SAILOR work. Advanced Testing was a flat 6-tab row mixing two unrelated papers (Meta ACH = I1–I5, SAILOR = I6). Now it's **two levels**: a paper selector on top, that paper's Explorer tabs below.

## Design — leaf tab stays the identity
- `advancedPapers` groups tabs under their source paper (`ach` → 5 tabs, `sailor` → 1 tab).
- `advancedTabs` = the flattened list — still drives panel creation and `resolveInitialTab`. **The leaf tab id remains the URL identifier**, so K4 routing, `EXPLORER_TO_LOCATION`, `?explorer=`, and `?tab=` are all untouched.
- `activeAdvancedPaper` is *derived* from `activeAdvancedTab` — the leaf tab is the single source of truth.

## Cross-section bridges keep working
The sub-tab bar renders **all** leaf tabs but `hidden`s the ones outside the active paper. They stay in the DOM, so a bridge doing `[data-advanced-tab="testquality"].click()` works even when a different paper is showing — the click handler re-derives the paper and re-renders both bars. **Zero changes in any bridge component.**

## Files
- `src/app.js` — the two-level nav (paper bar + sub-tab bar + panels).
- `src/App.css` — `.adv-paper-row` / `.adv-paper-btn`, pill-style selector distinct from the underline sub-tabs.
- `src/i18n/dict.js` — `advPaper.ach` / `advPaper.sailor` (EN + ZH).
- `e2e/navigation-state.spec.js` — 2 new tests: paper selector swaps the visible sub-tab set; a bridge into a *hidden* Advanced tab flips both the paper chip and the sub-tab.

## Test plan
- [x] `npm run test:run` — 680/680 (unchanged; URL identity preserved).
- [x] `npx playwright test e2e/navigation-state.spec.js` — 8 passed, 1 skipped.
- [x] Browser: deeplink to an ACH explorer shows 5 sub-tabs; SAILOR chip shows 1; `?explorer=` deeplinks still land correctly; E2E→TestQuality bridge works from the SAILOR paper.
- [ ] CI green on GitHub Actions.

Completes the SAILOR two-PR plan (#222 added I6; this restructures the section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)