### PR TITLE
feat(slides): Task 3 — viewer i18n keys and styles

### DIFF
--- a/src/components/SlideViewer.css
+++ b/src/components/SlideViewer.css
@@ -1,0 +1,59 @@
+.slideviewer-overlay {
+  position: fixed; inset: 0; z-index: 1000;
+  background: rgba(15, 23, 42, 0.72);
+  display: flex; align-items: center; justify-content: center; padding: 1.5rem;
+}
+.slideviewer-overlay[hidden] { display: none; }
+.slideviewer-panel {
+  background: #fff; border-radius: 12px; width: min(960px, 100%);
+  max-height: 92vh; display: flex; flex-direction: column; overflow: hidden;
+}
+.slideviewer-bar {
+  display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+  padding: 0.6rem 0.85rem; border-bottom: 1px solid #e2e8f0; background: #f8fafc;
+}
+.slideviewer-decks { display: flex; gap: 0.3rem; flex-wrap: wrap; }
+.slideviewer-deck-btn {
+  padding: 0.2rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 999px;
+  background: #fff; color: #475569; font-size: 0.78rem; cursor: pointer;
+}
+.slideviewer-deck-btn--active { background: #1d4ed8; border-color: #1d4ed8; color: #fff; font-weight: 700; }
+.slideviewer-close { margin-left: auto; border: none; background: transparent; font-size: 1.1rem; cursor: pointer; color: #475569; }
+.slideviewer-slide {
+  flex: 1; overflow-y: auto; padding: 1.4rem 1.6rem; color: #1f2a44; line-height: 1.6;
+}
+.slideviewer-slide h1 { font-size: 1.5rem; margin: 0 0 0.6rem; }
+.slideviewer-slide h2 { font-size: 1.2rem; margin: 0 0 0.5rem; }
+.slideviewer-slide h3, .slideviewer-slide h4 { font-size: 1rem; margin: 0.6rem 0 0.4rem; }
+.slideviewer-slide img { max-width: 100%; height: auto; border-radius: 6px; }
+.slideviewer-slide pre.slide-code {
+  background: #1e1e1e; color: #d4d4d4; border-radius: 6px; padding: 0.7rem;
+  overflow-x: auto; font-size: 0.82rem;
+}
+.slideviewer-slide table.slide-table { border-collapse: collapse; font-size: 0.85rem; }
+.slideviewer-slide table.slide-table th, .slideviewer-slide table.slide-table td {
+  border: 1px solid #e2e8f0; padding: 0.3rem 0.55rem; text-align: left;
+}
+.slideviewer-slide blockquote {
+  margin: 0.5rem 0; padding: 0.4rem 0.8rem; border-left: 3px solid #1d4ed8;
+  background: #eff6ff; color: #1e3a8a;
+}
+.slideviewer-notes {
+  border-top: 1px dashed #cbd5e1; background: #fffbeb; color: #78350f;
+  padding: 0.6rem 1rem; font-size: 0.83rem; white-space: pre-wrap;
+}
+.slideviewer-notes[hidden] { display: none; }
+.slideviewer-foot {
+  display: flex; align-items: center; gap: 0.6rem;
+  padding: 0.6rem 0.85rem; border-top: 1px solid #e2e8f0; background: #f8fafc;
+}
+.slideviewer-nav-btn {
+  padding: 0.3rem 0.85rem; border: 1px solid #1d4ed8; border-radius: 6px;
+  background: #fff; color: #1d4ed8; font-size: 0.82rem; cursor: pointer;
+}
+.slideviewer-nav-btn:disabled { opacity: 0.4; cursor: default; }
+.slideviewer-counter { font-size: 0.82rem; color: #475569; }
+.slideviewer-notes-toggle {
+  margin-left: auto; padding: 0.3rem 0.7rem; border: 1px solid #cbd5e1;
+  border-radius: 6px; background: #fff; color: #475569; font-size: 0.8rem; cursor: pointer;
+}

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -818,6 +818,15 @@ export const messages = {
 
     // Regression & Test-Debt Explorer (M6)
     'agileTab.regression': 'Regression & Test Debt',
+    // Slide viewer
+    'slides.open': '📊 Course slides',
+    'slides.prev': 'Previous',
+    'slides.next': 'Next',
+    'slides.close': 'Close',
+    'slides.notes.show': '🗒 Notes',
+    'slides.notes.hide': '🗒 Hide notes',
+    'slides.counter': 'Slide {n} / {total}',
+    'slides.empty': 'No slides available.',
     'rdebt.title': 'Regression & Test-Debt Explorer',
     'rdebt.desc': 'An agile regression suite grows every sprint. Left unmanaged, obsolete and flaky tests pile up — maintenance cost climbs while the value the suite delivers flattens out. Where the lines cross is test debt. Pruning, quarantine and risk-based selection push that crossover back, or remove it.',
     'rdebt.strategies': 'Maintenance strategies:',
@@ -3310,6 +3319,15 @@ export const messages = {
 
     // 回歸測試與測試債探索器（M6）
     'agileTab.regression': '回歸與測試債',
+    // 簡報檢視器
+    'slides.open': '📊 課程簡報',
+    'slides.prev': '上一張',
+    'slides.next': '下一張',
+    'slides.close': '關閉',
+    'slides.notes.show': '🗒 講者備註',
+    'slides.notes.hide': '🗒 隱藏備註',
+    'slides.counter': '第 {n} / {total} 張',
+    'slides.empty': '尚無簡報。',
     'rdebt.title': '回歸測試與測試債探索器',
     'rdebt.desc': '敏捷的回歸套件每個 sprint 都在長大。若不照料，過時與 flaky 測試會堆積——維護成本攀升，而套件帶來的價值卻趨於平緩。兩條線交叉之處就是測試債。修剪、隔離與風險導向挑選能把交叉點往後推，或讓它消失。',
     'rdebt.strategies': '維護策略：',

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,4 +60,5 @@
 @import url('./components/ExampleMappingExplorer.css');
 @import url('./components/ContinuousTestingPipelineExplorer.css');
 @import url('./components/RegressionDebtExplorer.css');
+@import url('./components/SlideViewer.css');
 @import url('./components/quiz.css');


### PR DESCRIPTION
Task 3 of the [in-app slide docs plan](docs/superpowers/plans/2026-05-16-in-app-slide-docs.md).

- EN + ZH `slides.*` i18n keys — open button, prev/next, close, notes show/hide, slide counter, empty state
- `src/components/SlideViewer.css` — overlay, panel, deck selector, slide area (headings/code/tables/blockquote/images), notes panel, footer nav
- `@import` wired into `styles.css`

i18n parity test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)