### PR TITLE
feat(slides): Task 5 — per-section course-slides button

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,8 @@ import { createDefinitionGatesExplorer } from './components/DefinitionGatesExplo
 import { createExampleMappingExplorer } from './components/ExampleMappingExplorer.js';
 import { createContinuousTestingPipelineExplorer } from './components/ContinuousTestingPipelineExplorer.js';
 import { createRegressionDebtExplorer } from './components/RegressionDebtExplorer.js';
+import { openSlideViewer } from './components/SlideViewer.js';
+import { SLIDE_DECKS } from './data/slideDecks.generated.js';
 import { createTagFilterBar } from './components/TagFilterBar.js';
 import { createCoursePackBar } from './components/CoursePackBar.js';
 import { sectionMatchesFilter } from './data/explorerTags.js';
@@ -272,6 +274,21 @@ export function renderApp(container) {
       flow: main.querySelector('[data-testid="section-flow"]'),
       types: main.querySelector('[data-testid="section-types"]'),
     };
+
+    // Attach a "course slides" button to every section that owns decks.
+    const sectionsWithDecks = [...new Set(SLIDE_DECKS.map((d) => d.section))];
+    for (const sectionId of sectionsWithDecks) {
+      const node = sections[sectionId];
+      const heading = node?.querySelector('h2');
+      if (!heading) continue;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'section-slides-btn';
+      btn.dataset.testid = `slides-btn-${sectionId}`;
+      btn.textContent = t('slides.open');
+      btn.addEventListener('click', () => openSlideViewer(sectionId));
+      heading.insertAdjacentElement('afterend', btn);
+    }
 
     const components = {
       methods: createTestingMethodTree(),

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,3 +62,10 @@
 @import url('./components/RegressionDebtExplorer.css');
 @import url('./components/SlideViewer.css');
 @import url('./components/quiz.css');
+
+.section-slides-btn {
+  margin: 0.2rem 0 0.6rem; padding: 0.25rem 0.7rem;
+  border: 1px solid #1d4ed8; border-radius: 999px;
+  background: #fff; color: #1d4ed8; font-size: 0.78rem; cursor: pointer;
+}
+.section-slides-btn:hover { background: #1d4ed8; color: #fff; }


### PR DESCRIPTION
Task 5 of the [in-app slide docs plan](docs/superpowers/plans/2026-05-16-in-app-slide-docs.md).

Every section that owns Marp decks gets a **"📊 課程簡報 / Course slides"** button under its `<h2>`; clicking it opens the `SlideViewer` overlay for that section's decks in the current locale. Nine sections gain a button: methods, flow, graph, logic, syntax, fuzz, symbex, concolic, testgen.

The slide docs feature is now visible and usable in the app. Full unit suite (844) passes; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)