### PR TITLE
fix(slides): copy public/ assets into the GitHub Pages build

### DIFF
--- a/scripts/prepare-pages.mjs
+++ b/scripts/prepare-pages.mjs
@@ -22,6 +22,9 @@ await cp(path.join(projectRoot, 'src', 'data'), path.join(outputDir, 'src', 'dat
 await cp(path.join(projectRoot, 'src', 'config'), path.join(outputDir, 'src', 'config'), { recursive: true });
 await cp(path.join(projectRoot, 'src', 'utils'), path.join(outputDir, 'src', 'utils'), { recursive: true });
 await cp(path.join(projectRoot, 'src', 'i18n'), path.join(outputDir, 'src', 'i18n'), { recursive: true });
+// public/ assets (e.g. slide-assets/) are served from the site root —
+// mirrors Vite's publicDir behaviour for the GitHub Pages build.
+await cp(path.join(projectRoot, 'public'), outputDir, { recursive: true });
 await writeFile(path.join(outputDir, '.nojekyll'), '');
 
 console.log(`Prepared GitHub Pages site at ${outputDir}`);


### PR DESCRIPTION
**Bug:** slide images don't display.

The slide screenshots live in `public/slide-assets/`. `npm run dev` and `vite build` copy `public/` automatically, but the GitHub Pages build (`scripts/prepare-pages.mjs`) copied only `index.html` + `src/**` — never `public/` — so every `./slide-assets/*.png` 404'd on the deployed site.

**Fix:** `prepare-pages.mjs` now copies `public/` into the site root, mirroring Vite's `publicDir` behaviour. Verified: `site/slide-assets/` contains all 43 screenshots after the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)