### PR TITLE
Polish in-app slide viewer UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -229,6 +229,22 @@ textarea:focus-visible {
   gap: 10px;
 }
 
+.section-heading-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 28px;
+  border-bottom: 3px solid var(--app-primary);
+}
+
+.section-heading-row h2 {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-bottom: 0;
+  border-bottom: 0;
+}
+
 /* Overview */
 .overview-section__header {
   max-width: 720px;
@@ -504,6 +520,12 @@ textarea:focus-visible {
   .app-main {
     padding: 32px 24px;
     gap: 48px;
+  }
+
+  .section-heading-row {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 4px;
   }
 
   .app-main > section {

--- a/src/app.js
+++ b/src/app.js
@@ -281,13 +281,17 @@ export function renderApp(container) {
       const node = sections[sectionId];
       const heading = node?.querySelector('h2');
       if (!heading) continue;
+      const headingRow = document.createElement('div');
+      headingRow.className = 'section-heading-row';
+      heading.parentNode.insertBefore(headingRow, heading);
+      headingRow.appendChild(heading);
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'section-slides-btn';
       btn.dataset.testid = `slides-btn-${sectionId}`;
       btn.textContent = t('slides.open');
       btn.addEventListener('click', () => openSlideViewer(sectionId));
-      heading.insertAdjacentElement('afterend', btn);
+      headingRow.appendChild(btn);
     }
 
     const components = {

--- a/src/components/SlideViewer.css
+++ b/src/components/SlideViewer.css
@@ -5,32 +5,74 @@
 }
 .slideviewer-overlay[hidden] { display: none; }
 .slideviewer-panel {
-  background: #fff; border-radius: 12px; width: min(960px, 100%);
+  background: #f8fafc; border-radius: 10px; width: min(1100px, 100%);
   max-height: 92vh; display: flex; flex-direction: column; overflow: hidden;
+  box-shadow: 0 22px 60px rgba(2, 6, 23, 0.28);
 }
 .slideviewer-bar {
   display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
-  padding: 0.6rem 0.85rem; border-bottom: 1px solid #e2e8f0; background: #f8fafc;
+  padding: 0.6rem 0.85rem; border-bottom: 1px solid #e2e8f0; background: #fff;
 }
-.slideviewer-decks { display: flex; gap: 0.3rem; flex-wrap: wrap; }
+.slideviewer-title {
+  color: #1f2a44;
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+.slideviewer-decks {
+  display: flex; gap: 0;
+  flex-wrap: wrap; overflow: hidden;
+  border: 1px solid #cbd5e1; border-radius: 8px;
+}
 .slideviewer-deck-btn {
-  padding: 0.2rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 999px;
+  padding: 0.34rem 0.7rem; border: 0; border-right: 1px solid #cbd5e1;
   background: #fff; color: #475569; font-size: 0.78rem; cursor: pointer;
 }
-.slideviewer-deck-btn--active { background: #1d4ed8; border-color: #1d4ed8; color: #fff; font-weight: 700; }
-.slideviewer-close { margin-left: auto; border: none; background: transparent; font-size: 1.1rem; cursor: pointer; color: #475569; }
-.slideviewer-slide {
-  flex: 1; overflow-y: auto; padding: 1.4rem 1.6rem; color: #1f2a44; line-height: 1.6;
+.slideviewer-deck-btn:last-child { border-right: 0; }
+.slideviewer-deck-btn--active { background: #1d4ed8; color: #fff; font-weight: 700; }
+.slideviewer-close {
+  margin-left: auto; width: 34px; height: 34px;
+  border: 1px solid #cbd5e1; border-radius: 8px;
+  background: #fff; font-size: 1rem; cursor: pointer; color: #475569;
 }
-.slideviewer-slide h1 { font-size: 1.5rem; margin: 0 0 0.6rem; }
-.slideviewer-slide h2 { font-size: 1.2rem; margin: 0 0 0.5rem; }
-.slideviewer-slide h3, .slideviewer-slide h4 { font-size: 1rem; margin: 0.6rem 0 0.4rem; }
-.slideviewer-slide img { max-width: 100%; height: auto; border-radius: 6px; }
+.slideviewer-stage {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(14px, 2.2vw, 28px);
+  background: #e2e8f0;
+}
+.slideviewer-slide {
+  width: min(100%, calc((92vh - 120px) * 16 / 9));
+  aspect-ratio: 16 / 9;
+  overflow-y: auto;
+  padding: clamp(1rem, 2.1vw, 2rem);
+  color: #1f2a44;
+  line-height: 1.65;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  box-shadow: 0 12px 34px rgba(15, 23, 42, 0.14);
+}
+.slideviewer-slide h1 { font-size: 1.8rem; margin: 0 0 0.75rem; }
+.slideviewer-slide h2 { font-size: 1.35rem; margin: 0 0 0.65rem; }
+.slideviewer-slide h3, .slideviewer-slide h4 { font-size: 1rem; margin: 0.75rem 0 0.45rem; }
+.slideviewer-slide p,
+.slideviewer-slide ul,
+.slideviewer-slide ol,
+.slideviewer-slide table,
+.slideviewer-slide blockquote,
+.slideviewer-slide pre { margin-top: 0.62rem; }
+.slideviewer-slide img {
+  display: block; max-width: 100%; height: auto; margin: 0.75rem auto 0;
+  border: 1px solid #dbe3ec; border-radius: 6px; background: #f8fafc;
+}
 .slideviewer-slide pre.slide-code {
   background: #1e1e1e; color: #d4d4d4; border-radius: 6px; padding: 0.7rem;
   overflow-x: auto; font-size: 0.82rem;
 }
-.slideviewer-slide table.slide-table { border-collapse: collapse; font-size: 0.85rem; }
+.slideviewer-slide table.slide-table { border-collapse: collapse; font-size: 0.85rem; width: 100%; }
+.slideviewer-slide table.slide-table th { background: #f1f5f9; }
 .slideviewer-slide table.slide-table th, .slideviewer-slide table.slide-table td {
   border: 1px solid #e2e8f0; padding: 0.3rem 0.55rem; text-align: left;
 }
@@ -40,12 +82,19 @@
 }
 .slideviewer-notes {
   border-top: 1px dashed #cbd5e1; background: #fffbeb; color: #78350f;
+  max-height: 18vh; overflow-y: auto;
   padding: 0.6rem 1rem; font-size: 0.83rem; white-space: pre-wrap;
 }
 .slideviewer-notes[hidden] { display: none; }
 .slideviewer-foot {
-  display: flex; align-items: center; gap: 0.6rem;
-  padding: 0.6rem 0.85rem; border-top: 1px solid #e2e8f0; background: #f8fafc;
+  display: flex; align-items: center; justify-content: space-between; gap: 0.8rem;
+  padding: 0.6rem 0.85rem; border-top: 1px solid #e2e8f0; background: #fff;
+}
+.slideviewer-foot__nav,
+.slideviewer-foot__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
 }
 .slideviewer-nav-btn {
   padding: 0.3rem 0.85rem; border: 1px solid #1d4ed8; border-radius: 6px;
@@ -54,6 +103,74 @@
 .slideviewer-nav-btn:disabled { opacity: 0.4; cursor: default; }
 .slideviewer-counter { font-size: 0.82rem; color: #475569; }
 .slideviewer-notes-toggle {
-  margin-left: auto; padding: 0.3rem 0.7rem; border: 1px solid #cbd5e1;
+  padding: 0.3rem 0.7rem; border: 1px solid #cbd5e1;
   border-radius: 6px; background: #fff; color: #475569; font-size: 0.8rem; cursor: pointer;
+}
+
+@media (max-width: 680px) {
+  .slideviewer-overlay {
+    align-items: stretch;
+    padding: 0;
+  }
+
+  .slideviewer-panel {
+    width: 100%;
+    max-height: none;
+    height: 100vh;
+    border-radius: 0;
+  }
+
+  .slideviewer-bar {
+    gap: 0.45rem;
+    padding: 0.55rem;
+  }
+
+  .slideviewer-decks {
+    flex: 1 1 100%;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    order: 2;
+  }
+
+  .slideviewer-deck-btn {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .slideviewer-stage {
+    align-items: start;
+    padding: 12px;
+  }
+
+  .slideviewer-slide {
+    width: 100%;
+    aspect-ratio: auto;
+    min-height: 100%;
+    padding: 1rem;
+  }
+
+  .slideviewer-slide h1 { font-size: 1.4rem; }
+  .slideviewer-slide h2 { font-size: 1.14rem; }
+
+  .slideviewer-slide table.slide-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .slideviewer-foot {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .slideviewer-foot__nav,
+  .slideviewer-foot__meta {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .slideviewer-nav-btn {
+    flex: 1 1 0;
+  }
 }

--- a/src/components/SlideViewer.js
+++ b/src/components/SlideViewer.js
@@ -6,6 +6,11 @@ import { parseDeck } from '../utils/slideMarkdown.js';
 let overlay = null;
 let returnFocusTo = null;
 const view = { decks: [], deckIndex: 0, slideIndex: 0, slides: [], notesOn: false };
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  'a[href]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
 
 function decksForSection(sectionId) {
   return SLIDE_DECKS.filter((d) => d.section === sectionId);
@@ -24,53 +29,95 @@ function loadDeck(index) {
 function onKey(e) {
   if (!overlay || overlay.hidden) return;
   if (e.key === 'Escape') closeSlideViewer();
-  else if (e.key === 'ArrowRight') go(1);
-  else if (e.key === 'ArrowLeft') go(-1);
+  else if (e.key === 'ArrowRight') { e.preventDefault(); go(1, 'slideviewer-next'); }
+  else if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1, 'slideviewer-prev'); }
+  else if (e.key === 'Home') { e.preventDefault(); goTo(0, 'slideviewer-prev'); }
+  else if (e.key === 'End') { e.preventDefault(); goTo(view.slides.length - 1, 'slideviewer-next'); }
+  else if (e.key === 'Tab') trapFocus(e);
 }
 
-function go(delta) {
+function focusInViewer(testId = 'slideviewer-close') {
+  const preferred = overlay?.querySelector(`[data-testid="${testId}"]`);
+  const target = preferred && !preferred.disabled
+    ? preferred
+    : overlay?.querySelector(FOCUSABLE_SELECTOR) || overlay?.querySelector('.slideviewer-panel');
+  target?.focus?.();
+}
+
+function trapFocus(e) {
+  const focusable = [...overlay.querySelectorAll(FOCUSABLE_SELECTOR)]
+    .filter((node) => !node.disabled && !node.closest('[hidden]'));
+  if (!focusable.length) {
+    e.preventDefault();
+    overlay.querySelector('.slideviewer-panel')?.focus();
+    return;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+
+function goTo(index, focusTestId) {
+  if (index < 0 || index >= view.slides.length || index === view.slideIndex) return;
+  view.slideIndex = index;
+  paint(focusTestId);
+}
+
+function go(delta, focusTestId) {
   const next = view.slideIndex + delta;
-  if (next < 0 || next >= view.slides.length) return;
-  view.slideIndex = next;
-  paint();
+  goTo(next, focusTestId);
 }
 
-function paint() {
+function paint(focusTestId) {
   const slide = view.slides[view.slideIndex] || { html: `<p>${t('slides.empty')}</p>`, notes: '' };
   const multi = view.decks.length > 1;
   overlay.innerHTML = `
-    <div class="slideviewer-panel" role="dialog" aria-modal="true">
+    <div class="slideviewer-panel" role="dialog" aria-modal="true" aria-label="${t('slides.dialog')}" tabindex="-1">
       <div class="slideviewer-bar">
-        ${multi ? `<div class="slideviewer-decks">${view.decks.map((d, i) => `
+        ${multi ? `<div class="slideviewer-decks" role="tablist" aria-label="${t('slides.deckSelector')}">${view.decks.map((d, i) => `
           <button type="button" class="slideviewer-deck-btn ${i === view.deckIndex ? 'slideviewer-deck-btn--active' : ''}"
-            data-deck="${i}" data-testid="slideviewer-deck-${i}">${deckTitle(d)}</button>`).join('')}</div>` : ''}
+            data-deck="${i}" data-testid="slideviewer-deck-${i}" role="tab"
+            aria-selected="${i === view.deckIndex ? 'true' : 'false'}">${deckTitle(d)}</button>`).join('')}</div>` : '<span class="slideviewer-title">' + deckTitle(view.decks[view.deckIndex]) + '</span>'}
         <button type="button" class="slideviewer-close" data-testid="slideviewer-close"
           aria-label="${t('slides.close')}">✕</button>
       </div>
-      <div class="slideviewer-slide" data-testid="slideviewer-slide">${slide.html}</div>
+      <div class="slideviewer-stage">
+        <div class="slideviewer-slide" data-testid="slideviewer-slide">${slide.html}</div>
+      </div>
       <div class="slideviewer-notes" data-testid="slideviewer-notes" ${view.notesOn ? '' : 'hidden'}>${slide.notes || ''}</div>
       <div class="slideviewer-foot">
-        <button type="button" class="slideviewer-nav-btn" data-testid="slideviewer-prev"
+        <div class="slideviewer-foot__nav">
+        <button type="button" class="slideviewer-nav-btn" data-testid="slideviewer-prev" aria-label="${t('slides.prev')}"
           ${view.slideIndex === 0 ? 'disabled' : ''}>${t('slides.prev')}</button>
-        <button type="button" class="slideviewer-nav-btn" data-testid="slideviewer-next"
+        <button type="button" class="slideviewer-nav-btn" data-testid="slideviewer-next" aria-label="${t('slides.next')}"
           ${view.slideIndex >= view.slides.length - 1 ? 'disabled' : ''}>${t('slides.next')}</button>
+        </div>
+        <div class="slideviewer-foot__meta">
         <span class="slideviewer-counter" data-testid="slideviewer-counter">${t('slides.counter', {
           n: view.slideIndex + 1, total: view.slides.length,
         })}</span>
         <button type="button" class="slideviewer-notes-toggle" data-testid="slideviewer-notes-toggle">${
           view.notesOn ? t('slides.notes.hide') : t('slides.notes.show')}</button>
+        </div>
       </div>
     </div>`;
   overlay.querySelector('[data-testid="slideviewer-close"]').addEventListener('click', closeSlideViewer);
-  overlay.querySelector('[data-testid="slideviewer-prev"]').addEventListener('click', () => go(-1));
-  overlay.querySelector('[data-testid="slideviewer-next"]').addEventListener('click', () => go(1));
+  overlay.querySelector('[data-testid="slideviewer-prev"]').addEventListener('click', () => go(-1, 'slideviewer-prev'));
+  overlay.querySelector('[data-testid="slideviewer-next"]').addEventListener('click', () => go(1, 'slideviewer-next'));
   overlay.querySelector('[data-testid="slideviewer-notes-toggle"]').addEventListener('click', () => {
     view.notesOn = !view.notesOn;
-    paint();
+    paint('slideviewer-notes-toggle');
   });
   overlay.querySelectorAll('[data-deck]').forEach((btn) => {
-    btn.addEventListener('click', () => { loadDeck(Number(btn.dataset.deck)); paint(); });
+    btn.addEventListener('click', () => { loadDeck(Number(btn.dataset.deck)); paint(btn.dataset.testid); });
   });
+  if (focusTestId) focusInViewer(focusTestId);
 }
 
 export function openSlideViewer(sectionId) {
@@ -90,12 +137,14 @@ export function openSlideViewer(sectionId) {
   view.notesOn = false;
   loadDeck(0);
   paint();
+  focusInViewer('slideviewer-close');
 }
 
 export function closeSlideViewer() {
   if (!overlay) return;
   overlay.remove();
   overlay = null;
+  document.removeEventListener('keydown', onKey);
   if (returnFocusTo && returnFocusTo.focus) returnFocusTo.focus();
   returnFocusTo = null;
 }

--- a/src/i18n/dict.js
+++ b/src/i18n/dict.js
@@ -820,6 +820,8 @@ export const messages = {
     'agileTab.regression': 'Regression & Test Debt',
     // Slide viewer
     'slides.open': '📊 Course slides',
+    'slides.dialog': 'Course slide viewer',
+    'slides.deckSelector': 'Slide decks',
     'slides.prev': 'Previous',
     'slides.next': 'Next',
     'slides.close': 'Close',
@@ -3321,6 +3323,8 @@ export const messages = {
     'agileTab.regression': '回歸與測試債',
     // 簡報檢視器
     'slides.open': '📊 課程簡報',
+    'slides.dialog': '課程簡報檢視器',
+    'slides.deckSelector': '簡報集',
     'slides.prev': '上一張',
     'slides.next': '下一張',
     'slides.close': '關閉',

--- a/src/styles.css
+++ b/src/styles.css
@@ -64,8 +64,24 @@
 @import url('./components/quiz.css');
 
 .section-slides-btn {
-  margin: 0.2rem 0 0.6rem; padding: 0.25rem 0.7rem;
-  border: 1px solid #1d4ed8; border-radius: 999px;
-  background: #fff; color: #1d4ed8; font-size: 0.78rem; cursor: pointer;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  padding: 0.42rem 0.78rem;
+  border: 1px solid var(--app-primary-strong);
+  border-radius: var(--app-radius-md);
+  background: var(--app-surface);
+  color: var(--app-primary-strong);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-.section-slides-btn:hover { background: #1d4ed8; color: #fff; }
+.section-slides-btn:hover { background: var(--app-primary-strong); color: #fff; }
+
+@media (max-width: 680px) {
+  .section-slides-btn {
+    align-self: flex-end;
+    margin: 0 0 10px;
+  }
+}

--- a/src/tests/SlideViewer.test.jsx
+++ b/src/tests/SlideViewer.test.jsx
@@ -12,6 +12,8 @@ describe('SlideViewer', () => {
     const overlay = document.querySelector('[data-testid="slideviewer"]');
     expect(overlay).toBeInTheDocument();
     expect(overlay.hasAttribute('hidden')).toBe(false);
+    expect(document.querySelector('.slideviewer-panel')).toHaveAttribute('role', 'dialog');
+    expect(document.activeElement).toBe(document.querySelector('[data-testid="slideviewer-close"]'));
     expect(document.querySelector('[data-testid="slideviewer-slide"]').innerHTML.trim()).not.toBe('');
   });
 
@@ -42,5 +44,28 @@ describe('SlideViewer', () => {
     openSlideViewer('graph');
     document.querySelector('[data-testid="slideviewer-close"]').click();
     expect(document.querySelector('[data-testid="slideviewer"]')).toBeNull();
+  });
+
+  it('supports Home and End keyboard navigation', () => {
+    openSlideViewer('graph');
+    const counter = () => document.querySelector('[data-testid="slideviewer-counter"]').textContent;
+    window.document.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(counter()).toContain('/ ');
+    expect(document.querySelector('[data-testid="slideviewer-next"]')).toBeDisabled();
+    window.document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(counter()).toMatch(/1\s*\//);
+    expect(document.querySelector('[data-testid="slideviewer-prev"]')).toBeDisabled();
+  });
+
+  it('keeps tab focus inside the viewer', () => {
+    openSlideViewer('graph');
+    const firstDeck = document.querySelector('[data-testid="slideviewer-deck-0"]');
+    const notesToggle = document.querySelector('[data-testid="slideviewer-notes-toggle"]');
+    notesToggle.focus();
+    window.document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(document.activeElement).toBe(firstDeck);
+    firstDeck.focus();
+    window.document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    expect(document.activeElement).toBe(notesToggle);
   });
 });


### PR DESCRIPTION
## Summary
- move course-slide buttons into section heading rows
- restyle the viewer as a presentation stage with clearer deck selector, image/table treatment, and mobile footer layout
- add dialog labels, initial focus, focus trapping, and Home/End keyboard navigation

Closes #259

## Verification
- npm run test -- --run
- npm run build
- Playwright smoke at 1440px, 390px, and 320px for `?section=flow` slide viewer

Note: `npm run build` still reports the existing Vite warning that `./src/bootstrap.js` is not `type=module`; this PR does not change that build path.