### PR TITLE
docs(slides): refresh deck index to 57 lectures

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -53,11 +53,13 @@
 | ↳ FlakyDiagnosisExplorer (J8) | 6 類 flakiness × 8 sample logs，內建錯誤分佈長條圖 | ✓ |
 | 全站 i18n | ZH-TW / EN 切換 | — |
 
-### 投影片（13 講，雙語，含 speaker notes）
+### 投影片（57 講，雙語，含 speaker notes）
 
-01 課程概觀、02 測試流程、03 Graph Coverage、04 Data Flow、05 Logic Coverage、
-06 Program Mutation、07 Grammar & String、08 Spec Mutation、09 Fuzz Testing、
-10 Symbolic Execution、11 Concolic Execution、12 Test Generation、13 Logic Binding
+完整課程簡報，每個 explorer 一講。#1–#13 為原始課程；#14–#57 由
+slide-completion 計畫（Waves A–G）補齊，涵蓋全部 54 個 explorer。Marp Markdown，
+可一鍵轉 PPTX，亦可在 app 內每個 section 的「📊 課程簡報」按鈕開啟全螢幕檢視。
+目錄見 [docs/slides/index.zh-TW.md](docs/slides/index.zh-TW.md) /
+[index.en.md](docs/slides/index.en.md)。截圖補強分批進行中。
 
 ### 測試
 
@@ -1016,8 +1018,14 @@ L2 = `{ level:['system'], technique:['model-based','state-transition'], series:[
 
 ---
 
-## M. Agile Testing Explorer（路線圖）
+## M. Agile Testing Explorer（全部完成 2026-05-16）
 
+> **狀態：M1–M6 已全數實作並合併。** `section.agile` 區塊上線，六個分頁分別為
+> M1 Agile Testing Quadrants（PR #240）、M2 Sprint Cadence（PR #242）、
+> M3 Definition of Ready/Done（PR #244）、M5 Three Amigos / Example Mapping（PR #246）、
+> M4 Continuous Testing Pipeline（PR #248）、M6 Regression & Test Debt（PR #250）。
+> 對應簡報為 #52–#57。以下為原始規劃內容，保留供對照。
+>
 > **教學缺口**：現有 Explorer 多以「單一測試技術」為單位（覆蓋準則、突變、符號執行……），但敏捷測試（Agile Testing）的核心不是某一種技術，而是**把測試織進整個交付節奏裡**——全隊參與、shift-left、快速回饋。學生常見的誤解是「敏捷 = 不寫測試文件 = 隨便測」。本節用兩層視角矯正：**概念地圖**（Agile Testing Quadrants）說明「敏捷下哪些測試該做、誰做、何時做」；**流程視角**（Sprint Cadence）說明「測試如何貫穿一個 sprint」。
 >
 > 與既有 Explorer 的關係：M 節是上層整合視角。M1 象限圖的多數技術 chip 直接 **bridge** 到既有 Explorer（BDD→J1、Exploratory、Performance Load→J5、覆蓋準則……），M 節本身只新增敏捷特有、現有 Explorer 未涵蓋的主題（節奏、品質閘、故事精煉、持續測試管線、回歸債）。

--- a/docs/slides/index.en.md
+++ b/docs/slides/index.en.md
@@ -1,90 +1,129 @@
 # Software Testing Visualization — Slide-Deck Index
 
-The stvisual course is **12 lectures**. Each deck contains:
+The stvisual course is **57 lectures**. Each deck contains:
 - **Concept**: definitions + subsumption / algorithm overview
 - **Worked example**: hand calculation + textbook citation
-- **Tool demo**: testids, click-by-click steps, screenshots
+- **Tool demo**: matching explorer, click-by-click steps (screenshots)
 - **Summary + exercises**
 - **Further reading**: matching spec section + source files
 
-All decks are Marp Markdown — convert to PPTX with a single command. Screenshots are produced by [scripts/capture-slide-screenshots.mjs](../../scripts/capture-slide-screenshots.mjs).
+All decks are Marp Markdown — convert to PPTX with a single command. Decks are also viewable inside the app: every section header carries a "📊 Slides" button. Screenshots are produced by [scripts/capture-slide-screenshots.mjs](../../scripts/capture-slide-screenshots.mjs).
+
+> #1–#13 ship with the original course; #14–#57 were authored by the slide-completion programme (Waves A–G), covering all 54 explorers. Screenshot reinforcement is being rolled out in batches.
 
 ---
 
 ## Course catalogue
 
-| # | Topic | ZH | EN | Screenshots |
-| --- | --- | --- | --- | --- |
-| 1 | Course intro & testing method classification | [01-course-intro.zh-TW.md](01-course-intro.zh-TW.md) | [01-course-intro.en.md](01-course-intro.en.md) | methods-overview, methods-whitebox |
-| 2 | Testing flow & testing pyramid | [02-testing-flow-pyramid.zh-TW.md](02-testing-flow-pyramid.zh-TW.md) | [02-testing-flow-pyramid.en.md](02-testing-flow-pyramid.en.md) | flow-overview, pyramid-overview |
-| 3 | Graph Coverage (structural) | [03-graph-coverage.zh-TW.md](03-graph-coverage.zh-TW.md) | [03-graph-coverage.en.md](03-graph-coverage.en.md) | graph-coverage-node, edge, prime-path, metrics, triangle, editor |
-| 4 | Data Flow Coverage | [04-data-flow-coverage.zh-TW.md](04-data-flow-coverage.zh-TW.md) | [04-data-flow-coverage.en.md](04-data-flow-coverage.en.md) | dfg-empty, triangle, all-defs, all-uses, all-du-paths |
-| 5 | Logic Coverage (14 criteria) | [05-logic-coverage.zh-TW.md](05-logic-coverage.zh-TW.md) | [05-logic-coverage.en.md](05-logic-coverage.en.md) | logic-overview, truth-table, cacc, ic-kmap, cutpnfp |
-| 6 | Program Mutation (15 operators) | [06-program-mutation.zh-TW.md](06-program-mutation.zh-TW.md) | [06-program-mutation.en.md](06-program-mutation.en.md) | mutation-overview, mutant-list, per-test, shape-hierarchy |
-| 7 | Grammar + String Mutation | [07-grammar-and-string-mutation.zh-TW.md](07-grammar-and-string-mutation.zh-TW.md) | [07-grammar-and-string-mutation.en.md](07-grammar-and-string-mutation.en.md) | grammar-overview, derivations, mutants, string-mutants |
-| 8 | Specification Mutation + SMV + Safety Monitor FSM | [08-spec-mutation.zh-TW.md](08-spec-mutation.zh-TW.md) | [08-spec-mutation.en.md](08-spec-mutation.en.md) | spec-overview, mutants, fsm, smv-source |
-| 9 | Fuzz Testing | [09-fuzz-testing.zh-TW.md](09-fuzz-testing.zh-TW.md) | [09-fuzz-testing.en.md](09-fuzz-testing.en.md) | fuzz-overview, fuzz-cfg |
-| 10 | Symbolic Execution | [10-symbolic-execution.zh-TW.md](10-symbolic-execution.zh-TW.md) | [10-symbolic-execution.en.md](10-symbolic-execution.en.md) | symbex-overview, paths, cfg |
-| 11 | Concolic Execution | [11-concolic-execution.zh-TW.md](11-concolic-execution.zh-TW.md) | [11-concolic-execution.en.md](11-concolic-execution.en.md) | concolic-overview, iters, cfg |
-| 12 | Test Generation from Coverage | [12-test-generation.zh-TW.md](12-test-generation.zh-TW.md) | [12-test-generation.en.md](12-test-generation.en.md) | testgen-overview, requirements, tests, cfg |
-| 13 | Logic Coverage Binding | [13-logic-binding.zh-TW.md](13-logic-binding.zh-TW.md) | [13-logic-binding.en.md](13-logic-binding.en.md) | binding-panel, binding-results |
+### Foundations
 
----
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 1 | Course intro & testing method classification | [01-course-intro.zh-TW.md](01-course-intro.zh-TW.md) | [01-course-intro.en.md](01-course-intro.en.md) |
+| 2 | Testing flow & testing pyramid | [02-testing-flow-pyramid.zh-TW.md](02-testing-flow-pyramid.zh-TW.md) | [02-testing-flow-pyramid.en.md](02-testing-flow-pyramid.en.md) |
+| 14 | The deferred cost of defects | [14-defect-cost.zh-TW.md](14-defect-cost.zh-TW.md) | [14-defect-cost.en.md](14-defect-cost.en.md) |
+| 15 | The V-model | [15-v-model.zh-TW.md](15-v-model.zh-TW.md) | [15-v-model.en.md](15-v-model.en.md) |
+| 16 | Testing levels & types | [16-testing-types.zh-TW.md](16-testing-types.zh-TW.md) | [16-testing-types.en.md](16-testing-types.en.md) |
+| 17 | The test automation pyramid | [17-test-pyramid.zh-TW.md](17-test-pyramid.zh-TW.md) | [17-test-pyramid.en.md](17-test-pyramid.en.md) |
 
-## Learning dependencies
+### Coverage Criteria
 
-```
-   #1 Intro
-       │
-       ▼
-   #2 Testing flow
-       │
-       ├──► #3 Graph Coverage ──► #4 Data Flow Coverage
-       │
-       ├──► #5 Logic Coverage  ◄── shares parsePredicate ──► #8 Spec Mutation
-       │
-       ├──► #6 Program Mutation ──► #7 Grammar Mutation ──► #8 Spec Mutation
-       │
-       └──► #9 Fuzz Testing ──► #10 Symbolic Execution ──► #11 Concolic Execution
-                                                                      │
-                                                                      ▼
-                                          #12 Test Generation from Coverage (#3+#4+#10 bridge)
-                                                                      │
-                                                                      ▼
-                                          #13 Logic Coverage Binding (#5 extension: clause → concrete witness)
-```
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 3 | Graph Coverage (structural) | [03-graph-coverage.zh-TW.md](03-graph-coverage.zh-TW.md) | [03-graph-coverage.en.md](03-graph-coverage.en.md) |
+| 4 | Data Flow Coverage | [04-data-flow-coverage.zh-TW.md](04-data-flow-coverage.zh-TW.md) | [04-data-flow-coverage.en.md](04-data-flow-coverage.en.md) |
+| 5 | Logic Coverage (14 criteria) | [05-logic-coverage.zh-TW.md](05-logic-coverage.zh-TW.md) | [05-logic-coverage.en.md](05-logic-coverage.en.md) |
+| 18 | Code coverage criteria | [18-code-coverage.zh-TW.md](18-code-coverage.zh-TW.md) | [18-code-coverage.en.md](18-code-coverage.en.md) |
+| 28 | Group theory & test symmetry | [28-group-theory.zh-TW.md](28-group-theory.zh-TW.md) | [28-group-theory.en.md](28-group-theory.en.md) |
 
-Four threads:
-- #3–#4 graphs & data flow → **#12 auto test generation** (bridges #3/#4 requirements with #10 witnesses)
-- #5 and #8 share the predicate parser
-- #6–#8 chain — the mutation subject walks from **program** to **spec**
-- #9–#11 chain — the search strategy walks from **random** to **symbolic** to **concolic**
+### Mutation & Specification
 
----
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 6 | Program Mutation (15 operators) | [06-program-mutation.zh-TW.md](06-program-mutation.zh-TW.md) | [06-program-mutation.en.md](06-program-mutation.en.md) |
+| 7 | Grammar + String Mutation | [07-grammar-and-string-mutation.zh-TW.md](07-grammar-and-string-mutation.zh-TW.md) | [07-grammar-and-string-mutation.en.md](07-grammar-and-string-mutation.en.md) |
+| 8 | Specification Mutation + SMV + Safety Monitor FSM | [08-spec-mutation.zh-TW.md](08-spec-mutation.zh-TW.md) | [08-spec-mutation.en.md](08-spec-mutation.en.md) |
 
-## Slide → spec section map
+### Execution & Test Generation
 
-| Deck # | Spec section | Primary tool |
-| --- | --- | --- |
-| 1 | §1, §2 | TestingMethodTree |
-| 2 | §2.B | TestingFlow + TestingTypesTable |
-| 3 | §3 | GraphCoverageExplorer (CFG) |
-| 4 | §15 | GraphCoverageExplorer (DFG) + dataFlow.js |
-| 5 | §4–5 | LogicCoverageExplorer + karnaughMap.js |
-| 6 | §11.2 / §17.3 | SyntaxCoverageExplorer + mutation.js |
-| 7 | §12 / §13 | GrammarCoverageExplorer + grammar.js |
-| 8 | §14 / §16 | SpecMutationExplorer + specMutation.js + specFsm.js |
-| 9 | §15 | FuzzTestingExplorer + fuzzTesting.js + pathToCfg.js |
-| 10 | §16 | SymbolicExecutionExplorer + symbolicExecution.js |
-| 11 | §17 | ConcolicExecutionExplorer + concolicExecution.js |
-| 12 | §12 | TestGenerationExplorer + testGeneration.js |
-| 13 | §4–5 (ext.) | LogicCoverageExplorer (Binding) + logicBinding.js |
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 9 | Fuzz Testing | [09-fuzz-testing.zh-TW.md](09-fuzz-testing.zh-TW.md) | [09-fuzz-testing.en.md](09-fuzz-testing.en.md) |
+| 10 | Symbolic Execution | [10-symbolic-execution.zh-TW.md](10-symbolic-execution.zh-TW.md) | [10-symbolic-execution.en.md](10-symbolic-execution.en.md) |
+| 11 | Concolic Execution | [11-concolic-execution.zh-TW.md](11-concolic-execution.zh-TW.md) | [11-concolic-execution.en.md](11-concolic-execution.en.md) |
+| 12 | Test Generation from Coverage | [12-test-generation.zh-TW.md](12-test-generation.zh-TW.md) | [12-test-generation.en.md](12-test-generation.en.md) |
+| 13 | Logic Coverage Binding | [13-logic-binding.zh-TW.md](13-logic-binding.zh-TW.md) | [13-logic-binding.en.md](13-logic-binding.en.md) |
+| 29 | Property-based testing | [29-property-based.zh-TW.md](29-property-based.zh-TW.md) | [29-property-based.en.md](29-property-based.en.md) |
+| 30 | Integration testing | [30-integration-testing.zh-TW.md](30-integration-testing.zh-TW.md) | [30-integration-testing.en.md](30-integration-testing.en.md) |
 
-Full spec: [docs/Specification.zh-TW.md](../Specification.zh-TW.md).
+### Black-Box Test Design
+
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 19 | Boundary value analysis | [19-boundary-value.zh-TW.md](19-boundary-value.zh-TW.md) | [19-boundary-value.en.md](19-boundary-value.en.md) |
+| 20 | Equivalence partitioning | [20-equivalence-partitioning.zh-TW.md](20-equivalence-partitioning.zh-TW.md) | [20-equivalence-partitioning.en.md](20-equivalence-partitioning.en.md) |
+| 21 | Decision table testing | [21-decision-table.zh-TW.md](21-decision-table.zh-TW.md) | [21-decision-table.en.md](21-decision-table.en.md) |
+| 22 | State transition testing | [22-state-transition.zh-TW.md](22-state-transition.zh-TW.md) | [22-state-transition.en.md](22-state-transition.en.md) |
+| 23 | Pairwise testing | [23-pairwise.zh-TW.md](23-pairwise.zh-TW.md) | [23-pairwise.en.md](23-pairwise.en.md) |
+| 24 | Cause-effect graphing | [24-cause-effect.zh-TW.md](24-cause-effect.zh-TW.md) | [24-cause-effect.en.md](24-cause-effect.en.md) |
+| 25 | Metamorphic testing | [25-metamorphic.zh-TW.md](25-metamorphic.zh-TW.md) | [25-metamorphic.en.md](25-metamorphic.en.md) |
+| 26 | Exploratory testing | [26-exploratory.zh-TW.md](26-exploratory.zh-TW.md) | [26-exploratory.en.md](26-exploratory.en.md) |
+| 27 | Test doubles | [27-test-doubles.zh-TW.md](27-test-doubles.zh-TW.md) | [27-test-doubles.en.md](27-test-doubles.en.md) |
+| 31 | Risk-based testing | [31-risk-based.zh-TW.md](31-risk-based.zh-TW.md) | [31-risk-based.en.md](31-risk-based.en.md) |
+
+### Advanced / AI-Assisted
+
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 32 | The equivalent mutant problem | [32-equivalent-mutants.zh-TW.md](32-equivalent-mutants.zh-TW.md) | [32-equivalent-mutants.en.md](32-equivalent-mutants.en.md) |
+| 33 | Mutation score | [33-mutation-score.zh-TW.md](33-mutation-score.zh-TW.md) | [33-mutation-score.en.md](33-mutation-score.en.md) |
+| 34 | LLM test-generation pipeline | [34-llm-test-pipeline.zh-TW.md](34-llm-test-pipeline.zh-TW.md) | [34-llm-test-pipeline.en.md](34-llm-test-pipeline.en.md) |
+| 35 | Test quality gates | [35-test-quality-gates.zh-TW.md](35-test-quality-gates.zh-TW.md) | [35-test-quality-gates.en.md](35-test-quality-gates.en.md) |
+| 36 | Fault-directed test generation | [36-fault-directed-testing.zh-TW.md](36-fault-directed-testing.zh-TW.md) | [36-fault-directed-testing.en.md](36-fault-directed-testing.en.md) |
+| 37 | SAILOR — guided symbolic execution | [37-sailor-vulnerability.zh-TW.md](37-sailor-vulnerability.zh-TW.md) | [37-sailor-vulnerability.en.md](37-sailor-vulnerability.en.md) |
+
+### Acceptance & E2E
+
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 38 | BDD & Gherkin | [38-bdd-gherkin.zh-TW.md](38-bdd-gherkin.zh-TW.md) | [38-bdd-gherkin.en.md](38-bdd-gherkin.en.md) |
+| 39 | Use-case test derivation | [39-use-case-derivation.zh-TW.md](39-use-case-derivation.zh-TW.md) | [39-use-case-derivation.en.md](39-use-case-derivation.en.md) |
+| 40 | E2E user journey | [40-e2e-user-journey.zh-TW.md](40-e2e-user-journey.zh-TW.md) | [40-e2e-user-journey.en.md](40-e2e-user-journey.en.md) |
+| 41 | Contract testing | [41-contract-testing.zh-TW.md](41-contract-testing.zh-TW.md) | [41-contract-testing.en.md](41-contract-testing.en.md) |
+| 42 | Performance & load testing | [42-performance-load.zh-TW.md](42-performance-load.zh-TW.md) | [42-performance-load.en.md](42-performance-load.en.md) |
+| 43 | Chaos engineering | [43-chaos-engineering.zh-TW.md](43-chaos-engineering.zh-TW.md) | [43-chaos-engineering.en.md](43-chaos-engineering.en.md) |
+| 44 | The ATDD cycle | [44-atdd-cycle.zh-TW.md](44-atdd-cycle.zh-TW.md) | [44-atdd-cycle.en.md](44-atdd-cycle.en.md) |
+| 45 | Flaky test diagnosis | [45-flaky-diagnosis.zh-TW.md](45-flaky-diagnosis.zh-TW.md) | [45-flaky-diagnosis.en.md](45-flaky-diagnosis.en.md) |
+
+### Model-Based Testing
+
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 46 | MBT workflow | [46-mbt-workflow.zh-TW.md](46-mbt-workflow.zh-TW.md) | [46-mbt-workflow.en.md](46-mbt-workflow.en.md) |
+| 47 | FSM test generation | [47-fsm-test-generation.zh-TW.md](47-fsm-test-generation.zh-TW.md) | [47-fsm-test-generation.en.md](47-fsm-test-generation.en.md) |
+| 48 | The W-method | [48-w-method.zh-TW.md](48-w-method.zh-TW.md) | [48-w-method.en.md](48-w-method.en.md) |
+| 49 | EFSM & guarded transitions | [49-efsm-guarded-transition.zh-TW.md](49-efsm-guarded-transition.zh-TW.md) | [49-efsm-guarded-transition.en.md](49-efsm-guarded-transition.en.md) |
+| 50 | Usage-model statistical testing | [50-usage-model-statistical.zh-TW.md](50-usage-model-statistical.zh-TW.md) | [50-usage-model-statistical.en.md](50-usage-model-statistical.en.md) |
+| 51 | Model mutation | [51-model-mutation.zh-TW.md](51-model-mutation.zh-TW.md) | [51-model-mutation.en.md](51-model-mutation.en.md) |
+
+### Agile Testing
+
+| # | Topic | ZH | EN |
+| --- | --- | --- | --- |
+| 52 | Agile testing quadrants | [52-agile-quadrants.zh-TW.md](52-agile-quadrants.zh-TW.md) | [52-agile-quadrants.en.md](52-agile-quadrants.en.md) |
+| 53 | Sprint testing cadence | [53-sprint-cadence.zh-TW.md](53-sprint-cadence.zh-TW.md) | [53-sprint-cadence.en.md](53-sprint-cadence.en.md) |
+| 54 | Definition of Ready / Done | [54-definition-gates.zh-TW.md](54-definition-gates.zh-TW.md) | [54-definition-gates.en.md](54-definition-gates.en.md) |
+| 55 | Three Amigos & example mapping | [55-example-mapping.zh-TW.md](55-example-mapping.zh-TW.md) | [55-example-mapping.en.md](55-example-mapping.en.md) |
+| 56 | Continuous testing pipeline | [56-continuous-testing.zh-TW.md](56-continuous-testing.zh-TW.md) | [56-continuous-testing.en.md](56-continuous-testing.en.md) |
+| 57 | Regression & test debt | [57-regression-debt.zh-TW.md](57-regression-debt.zh-TW.md) | [57-regression-debt.en.md](57-regression-debt.en.md) |
 
 ---
 
 ## How to use
+
+### View inside the app
+
+Every section header carries a "📊 Slides" button that opens the full-screen slide viewer (prev/next, ←/→ keys, speaker-notes toggle, Esc to close). The language follows the current locale — zh-TW / en.
 
 ### Convert one deck to PPTX
 
@@ -108,50 +147,18 @@ done
 node scripts/capture-slide-screenshots.mjs
 ```
 
-The script:
-1. Detects whether `http://127.0.0.1:4173` is already up; if not, launches `python3 -m http.server`.
-2. Pins locale to `zh`, viewport `1440×900 @2x`.
-3. Walks each explorer in order, capturing the relevant testid and saving into [docs/assets/slides/](../assets/slides/).
-4. Shuts down the self-started server when done.
+The script detects `http://127.0.0.1:4173`, pins the locale to `zh`, walks each explorer in order, and captures the relevant testid into [docs/assets/slides/](../assets/slides/).
 
-### Live preview (Marp watch)
+### Rebuild the in-app slide data
 
 ```bash
-npx -y @marp-team/marp-cli --watch docs/slides/03-graph-coverage.en.md --html
+npm run build:slide-decks
 ```
 
-Open `docs/slides/03-graph-coverage.en.html` — saving the source re-renders.
+Bakes `docs/slides/*.md` into `src/data/slideDecks.generated.js` for the in-app viewer.
 
 ---
 
-## Screenshot inventory (46 files)
+## Full specification
 
-Located in [docs/assets/slides/](../assets/slides/):
-
-```
-methods-overview.png            methods-whitebox.png
-flow-overview.png               pyramid-overview.png
-graph-coverage-{node,edge,prime-path,metrics,triangle,editor}.png
-dfg-{empty,triangle,all-defs,all-uses,all-du-paths}.png
-logic-{overview,truth-table,cacc,ic-kmap,cutpnfp}.png
-mutation-{overview,mutant-list,per-test,shape-hierarchy}.png
-grammar-{overview,derivations,mutants,string-mutants}.png
-spec-{overview,mutants,fsm,smv-source}.png
-fuzz-{overview,cfg}.png
-symbex-{overview,paths,cfg}.png
-concolic-{overview,iters,cfg}.png
-testgen-{overview,requirements,tests,cfg}.png
-binding-{panel,results}.png
-```
-
----
-
-## Possible extensions
-
-- **#12.2 Logic Coverage Binding** — manually map clause variables to program expressions, auto-solve concrete inputs.
-- **Speaker notes** — add `<!-- speaker -->` Marp speaker notes below each slide (deliberately omitted today so instructors can adapt freely).
-- **SMT solver integration** — replace #10 / #11’s brute-force witness solver with z3-solver-js for large integers and string constraints.
-
----
-
-Styling and layout: vanilla Marp default theme with pagination; for a corporate look, add `theme: <yourtheme>` to each deck’s front-matter.
+[docs/Specification.zh-TW.md](../Specification.zh-TW.md).

--- a/docs/slides/index.zh-TW.md
+++ b/docs/slides/index.zh-TW.md
@@ -1,90 +1,129 @@
 # 軟體測試視覺化 — 課程簡報目錄
 
-stvisual 課程共 **12 講**，每講皆有：
+stvisual 課程共 **57 講**，每講皆有：
 - **觀念**：定義 + subsumption / 演算法總覽
 - **範例**：手算示範 + 教科書引用
-- **工具演示**：對應的 testid、互動步驟、截圖
+- **工具演示**：對應的 explorer、互動步驟（截圖）
 - **小結 + 課堂練習**
 - **延伸閱讀**：對應規格章節與原始碼
 
-所有簡報為 Marp Markdown，可一鍵轉 PPTX；截圖由 [scripts/capture-slide-screenshots.mjs](../../scripts/capture-slide-screenshots.mjs) 統一產生。
+所有簡報為 Marp Markdown，可一鍵轉 PPTX。簡報亦可直接在 app 內檢視：每個 section 標題下都有「📊 課程簡報」按鈕。截圖由 [scripts/capture-slide-screenshots.mjs](../../scripts/capture-slide-screenshots.mjs) 統一產生。
+
+> #1–#13 由原始課程建立；#14–#57 為 slide-completion 計畫（Waves A–G）補齊，涵蓋全部 54 個 explorer。截圖補強仍在分批進行中。
 
 ---
 
 ## 課程目錄
 
-| # | 主題 | ZH | EN | 截圖 |
-| --- | --- | --- | --- | --- |
-| 1 | 課程概觀 & 測試方法分類 | [01-course-intro.zh-TW.md](01-course-intro.zh-TW.md) | [01-course-intro.en.md](01-course-intro.en.md) | methods-overview、methods-whitebox |
-| 2 | 測試流程 & 測試金字塔 | [02-testing-flow-pyramid.zh-TW.md](02-testing-flow-pyramid.zh-TW.md) | [02-testing-flow-pyramid.en.md](02-testing-flow-pyramid.en.md) | flow-overview、pyramid-overview |
-| 3 | Graph Coverage（結構性） | [03-graph-coverage.zh-TW.md](03-graph-coverage.zh-TW.md) | [03-graph-coverage.en.md](03-graph-coverage.en.md) | graph-coverage-node、edge、prime-path、metrics、triangle、editor |
-| 4 | Data Flow Coverage | [04-data-flow-coverage.zh-TW.md](04-data-flow-coverage.zh-TW.md) | [04-data-flow-coverage.en.md](04-data-flow-coverage.en.md) | dfg-empty、triangle、all-defs、all-uses、all-du-paths |
-| 5 | Logic Coverage（14 準則）| [05-logic-coverage.zh-TW.md](05-logic-coverage.zh-TW.md) | [05-logic-coverage.en.md](05-logic-coverage.en.md) | logic-overview、truth-table、cacc、ic-kmap、cutpnfp |
-| 6 | Program Mutation（15 operators） | [06-program-mutation.zh-TW.md](06-program-mutation.zh-TW.md) | [06-program-mutation.en.md](06-program-mutation.en.md) | mutation-overview、mutant-list、per-test、shape-hierarchy |
-| 7 | Grammar + String Mutation | [07-grammar-and-string-mutation.zh-TW.md](07-grammar-and-string-mutation.zh-TW.md) | [07-grammar-and-string-mutation.en.md](07-grammar-and-string-mutation.en.md) | grammar-overview、derivations、mutants、string-mutants |
-| 8 | Specification Mutation + SMV + Safety Monitor FSM | [08-spec-mutation.zh-TW.md](08-spec-mutation.zh-TW.md) | [08-spec-mutation.en.md](08-spec-mutation.en.md) | spec-overview、mutants、fsm、smv-source |
-| 9 | Fuzz Testing | [09-fuzz-testing.zh-TW.md](09-fuzz-testing.zh-TW.md) | [09-fuzz-testing.en.md](09-fuzz-testing.en.md) | fuzz-overview、fuzz-cfg |
-| 10 | Symbolic Execution | [10-symbolic-execution.zh-TW.md](10-symbolic-execution.zh-TW.md) | [10-symbolic-execution.en.md](10-symbolic-execution.en.md) | symbex-overview、paths、cfg |
-| 11 | Concolic Execution | [11-concolic-execution.zh-TW.md](11-concolic-execution.zh-TW.md) | [11-concolic-execution.en.md](11-concolic-execution.en.md) | concolic-overview、iters、cfg |
-| 12 | Test Generation from Coverage | [12-test-generation.zh-TW.md](12-test-generation.zh-TW.md) | [12-test-generation.en.md](12-test-generation.en.md) | testgen-overview、requirements、tests、cfg |
-| 13 | Logic Coverage Binding | [13-logic-binding.zh-TW.md](13-logic-binding.zh-TW.md) | [13-logic-binding.en.md](13-logic-binding.en.md) | binding-panel、binding-results |
+### 基礎（Foundations）
 
----
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 1 | 課程概觀 & 測試方法分類 | [01-course-intro.zh-TW.md](01-course-intro.zh-TW.md) | [01-course-intro.en.md](01-course-intro.en.md) |
+| 2 | 測試流程 & 測試金字塔 | [02-testing-flow-pyramid.zh-TW.md](02-testing-flow-pyramid.zh-TW.md) | [02-testing-flow-pyramid.en.md](02-testing-flow-pyramid.en.md) |
+| 14 | 缺陷的延遲成本 | [14-defect-cost.zh-TW.md](14-defect-cost.zh-TW.md) | [14-defect-cost.en.md](14-defect-cost.en.md) |
+| 15 | V 模型 | [15-v-model.zh-TW.md](15-v-model.zh-TW.md) | [15-v-model.en.md](15-v-model.en.md) |
+| 16 | 測試層級與類型 | [16-testing-types.zh-TW.md](16-testing-types.zh-TW.md) | [16-testing-types.en.md](16-testing-types.en.md) |
+| 17 | 測試自動化金字塔 | [17-test-pyramid.zh-TW.md](17-test-pyramid.zh-TW.md) | [17-test-pyramid.en.md](17-test-pyramid.en.md) |
 
-## 學習依賴關係
+### 覆蓋準則（Coverage Criteria）
 
-```
-   #1 課程概觀
-       │
-       ▼
-   #2 測試流程
-       │
-       ├──► #3 Graph Coverage ──► #4 Data Flow Coverage
-       │
-       ├──► #5 Logic Coverage  ◄── 共用 parsePredicate ──► #8 Spec Mutation
-       │
-       ├──► #6 Program Mutation ──► #7 Grammar Mutation ──► #8 Spec Mutation
-       │
-       └──► #9 Fuzz Testing ──► #10 Symbolic Execution ──► #11 Concolic Execution
-                                                                      │
-                                                                      ▼
-                                          #12 Test Generation from Coverage (#3+#4+#10 橋接)
-                                                                      │
-                                                                      ▼
-                                          #13 Logic Coverage Binding (#5 延伸：clause → concrete witness)
-```
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 3 | Graph Coverage（結構性） | [03-graph-coverage.zh-TW.md](03-graph-coverage.zh-TW.md) | [03-graph-coverage.en.md](03-graph-coverage.en.md) |
+| 4 | Data Flow Coverage | [04-data-flow-coverage.zh-TW.md](04-data-flow-coverage.zh-TW.md) | [04-data-flow-coverage.en.md](04-data-flow-coverage.en.md) |
+| 5 | Logic Coverage（14 準則） | [05-logic-coverage.zh-TW.md](05-logic-coverage.zh-TW.md) | [05-logic-coverage.en.md](05-logic-coverage.en.md) |
+| 18 | 程式碼覆蓋準則 | [18-code-coverage.zh-TW.md](18-code-coverage.zh-TW.md) | [18-code-coverage.en.md](18-code-coverage.en.md) |
+| 28 | 群論與測試對稱性 | [28-group-theory.zh-TW.md](28-group-theory.zh-TW.md) | [28-group-theory.en.md](28-group-theory.en.md) |
 
-四條子線（圖、邏輯、突變、執行式測試）：
-- #3–#4 圖與資料流 → **#12 自動測試產生**（橋接 #3/#4 需求與 #10 witness）
-- #5、#8 共用 predicate parser
-- #6–#8 一脈：突變對象從**程式**走到**規格**
-- #9–#11 一脈：搜尋從**隨機**走到**符號**再走到**concolic**
+### 突變與規格（Mutation & Specification）
 
----
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 6 | Program Mutation（15 operators） | [06-program-mutation.zh-TW.md](06-program-mutation.zh-TW.md) | [06-program-mutation.en.md](06-program-mutation.en.md) |
+| 7 | Grammar + String Mutation | [07-grammar-and-string-mutation.zh-TW.md](07-grammar-and-string-mutation.zh-TW.md) | [07-grammar-and-string-mutation.en.md](07-grammar-and-string-mutation.en.md) |
+| 8 | Specification Mutation + SMV + Safety Monitor FSM | [08-spec-mutation.zh-TW.md](08-spec-mutation.zh-TW.md) | [08-spec-mutation.en.md](08-spec-mutation.en.md) |
 
-## 投影片與規格章節對照
+### 執行式測試與測試生成（Execution & Test Generation）
 
-| 簡報 # | 對應規格章節 | 主要工具 |
-| --- | --- | --- |
-| 1 | §1, §2 | TestingMethodTree |
-| 2 | §2.B | TestingFlow + TestingTypesTable |
-| 3 | §3 | GraphCoverageExplorer（CFG） |
-| 4 | §15 | GraphCoverageExplorer（DFG）+ dataFlow.js |
-| 5 | §4–5 | LogicCoverageExplorer + karnaughMap.js |
-| 6 | §11.2 / §17.3 | SyntaxCoverageExplorer + mutation.js |
-| 7 | §12 / §13 | GrammarCoverageExplorer + grammar.js |
-| 8 | §14 / §16 | SpecMutationExplorer + specMutation.js + specFsm.js |
-| 9 | §15 | FuzzTestingExplorer + fuzzTesting.js + pathToCfg.js |
-| 10 | §16 | SymbolicExecutionExplorer + symbolicExecution.js |
-| 11 | §17 | ConcolicExecutionExplorer + concolicExecution.js |
-| 12 | §12 | TestGenerationExplorer + testGeneration.js |
-| 13 | §4–5 (延伸) | LogicCoverageExplorer（Binding）+ logicBinding.js |
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 9 | Fuzz Testing | [09-fuzz-testing.zh-TW.md](09-fuzz-testing.zh-TW.md) | [09-fuzz-testing.en.md](09-fuzz-testing.en.md) |
+| 10 | Symbolic Execution | [10-symbolic-execution.zh-TW.md](10-symbolic-execution.zh-TW.md) | [10-symbolic-execution.en.md](10-symbolic-execution.en.md) |
+| 11 | Concolic Execution | [11-concolic-execution.zh-TW.md](11-concolic-execution.zh-TW.md) | [11-concolic-execution.en.md](11-concolic-execution.en.md) |
+| 12 | Test Generation from Coverage | [12-test-generation.zh-TW.md](12-test-generation.zh-TW.md) | [12-test-generation.en.md](12-test-generation.en.md) |
+| 13 | Logic Coverage Binding | [13-logic-binding.zh-TW.md](13-logic-binding.zh-TW.md) | [13-logic-binding.en.md](13-logic-binding.en.md) |
+| 29 | 性質導向測試 | [29-property-based.zh-TW.md](29-property-based.zh-TW.md) | [29-property-based.en.md](29-property-based.en.md) |
+| 30 | 整合測試 | [30-integration-testing.zh-TW.md](30-integration-testing.zh-TW.md) | [30-integration-testing.en.md](30-integration-testing.en.md) |
 
-完整規格：[docs/Specification.zh-TW.md](../Specification.zh-TW.md)。
+### 黑箱測試設計（Black-Box Test Design）
+
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 19 | 邊界值分析 | [19-boundary-value.zh-TW.md](19-boundary-value.zh-TW.md) | [19-boundary-value.en.md](19-boundary-value.en.md) |
+| 20 | 等價類分割 | [20-equivalence-partitioning.zh-TW.md](20-equivalence-partitioning.zh-TW.md) | [20-equivalence-partitioning.en.md](20-equivalence-partitioning.en.md) |
+| 21 | 決策表測試 | [21-decision-table.zh-TW.md](21-decision-table.zh-TW.md) | [21-decision-table.en.md](21-decision-table.en.md) |
+| 22 | 狀態遷移測試 | [22-state-transition.zh-TW.md](22-state-transition.zh-TW.md) | [22-state-transition.en.md](22-state-transition.en.md) |
+| 23 | 成對測試 | [23-pairwise.zh-TW.md](23-pairwise.zh-TW.md) | [23-pairwise.en.md](23-pairwise.en.md) |
+| 24 | 因果圖 | [24-cause-effect.zh-TW.md](24-cause-effect.zh-TW.md) | [24-cause-effect.en.md](24-cause-effect.en.md) |
+| 25 | 蛻變測試 | [25-metamorphic.zh-TW.md](25-metamorphic.zh-TW.md) | [25-metamorphic.en.md](25-metamorphic.en.md) |
+| 26 | 探索式測試 | [26-exploratory.zh-TW.md](26-exploratory.zh-TW.md) | [26-exploratory.en.md](26-exploratory.en.md) |
+| 27 | 測試替身 | [27-test-doubles.zh-TW.md](27-test-doubles.zh-TW.md) | [27-test-doubles.en.md](27-test-doubles.en.md) |
+| 31 | 風險導向測試 | [31-risk-based.zh-TW.md](31-risk-based.zh-TW.md) | [31-risk-based.en.md](31-risk-based.en.md) |
+
+### AI 輔助 / 進階測試（Advanced）
+
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 32 | 等價突變體問題 | [32-equivalent-mutants.zh-TW.md](32-equivalent-mutants.zh-TW.md) | [32-equivalent-mutants.en.md](32-equivalent-mutants.en.md) |
+| 33 | 突變分數 | [33-mutation-score.zh-TW.md](33-mutation-score.zh-TW.md) | [33-mutation-score.en.md](33-mutation-score.en.md) |
+| 34 | LLM 測試生成管線 | [34-llm-test-pipeline.zh-TW.md](34-llm-test-pipeline.zh-TW.md) | [34-llm-test-pipeline.en.md](34-llm-test-pipeline.en.md) |
+| 35 | 測試品質閘門 | [35-test-quality-gates.zh-TW.md](35-test-quality-gates.zh-TW.md) | [35-test-quality-gates.en.md](35-test-quality-gates.en.md) |
+| 36 | 缺陷導向測試生成 | [36-fault-directed-testing.zh-TW.md](36-fault-directed-testing.zh-TW.md) | [36-fault-directed-testing.en.md](36-fault-directed-testing.en.md) |
+| 37 | SAILOR — 引導式符號執行 | [37-sailor-vulnerability.zh-TW.md](37-sailor-vulnerability.zh-TW.md) | [37-sailor-vulnerability.en.md](37-sailor-vulnerability.en.md) |
+
+### 驗收與 E2E（Acceptance & E2E）
+
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 38 | BDD 與 Gherkin | [38-bdd-gherkin.zh-TW.md](38-bdd-gherkin.zh-TW.md) | [38-bdd-gherkin.en.md](38-bdd-gherkin.en.md) |
+| 39 | 用例測試衍生 | [39-use-case-derivation.zh-TW.md](39-use-case-derivation.zh-TW.md) | [39-use-case-derivation.en.md](39-use-case-derivation.en.md) |
+| 40 | E2E 使用者旅程 | [40-e2e-user-journey.zh-TW.md](40-e2e-user-journey.zh-TW.md) | [40-e2e-user-journey.en.md](40-e2e-user-journey.en.md) |
+| 41 | 契約測試 | [41-contract-testing.zh-TW.md](41-contract-testing.zh-TW.md) | [41-contract-testing.en.md](41-contract-testing.en.md) |
+| 42 | 效能與負載測試 | [42-performance-load.zh-TW.md](42-performance-load.zh-TW.md) | [42-performance-load.en.md](42-performance-load.en.md) |
+| 43 | 混沌工程 | [43-chaos-engineering.zh-TW.md](43-chaos-engineering.zh-TW.md) | [43-chaos-engineering.en.md](43-chaos-engineering.en.md) |
+| 44 | ATDD 循環 | [44-atdd-cycle.zh-TW.md](44-atdd-cycle.zh-TW.md) | [44-atdd-cycle.en.md](44-atdd-cycle.en.md) |
+| 45 | Flaky 測試診斷 | [45-flaky-diagnosis.zh-TW.md](45-flaky-diagnosis.zh-TW.md) | [45-flaky-diagnosis.en.md](45-flaky-diagnosis.en.md) |
+
+### 模型驅動測試（Model-Based Testing）
+
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 46 | MBT 工作流程 | [46-mbt-workflow.zh-TW.md](46-mbt-workflow.zh-TW.md) | [46-mbt-workflow.en.md](46-mbt-workflow.en.md) |
+| 47 | FSM 測試生成 | [47-fsm-test-generation.zh-TW.md](47-fsm-test-generation.zh-TW.md) | [47-fsm-test-generation.en.md](47-fsm-test-generation.en.md) |
+| 48 | W 方法 | [48-w-method.zh-TW.md](48-w-method.zh-TW.md) | [48-w-method.en.md](48-w-method.en.md) |
+| 49 | EFSM 與守衛轉移 | [49-efsm-guarded-transition.zh-TW.md](49-efsm-guarded-transition.zh-TW.md) | [49-efsm-guarded-transition.en.md](49-efsm-guarded-transition.en.md) |
+| 50 | 使用模型統計測試 | [50-usage-model-statistical.zh-TW.md](50-usage-model-statistical.zh-TW.md) | [50-usage-model-statistical.en.md](50-usage-model-statistical.en.md) |
+| 51 | 模型突變 | [51-model-mutation.zh-TW.md](51-model-mutation.zh-TW.md) | [51-model-mutation.en.md](51-model-mutation.en.md) |
+
+### 敏捷測試（Agile Testing）
+
+| # | 主題 | ZH | EN |
+| --- | --- | --- | --- |
+| 52 | 敏捷測試象限 | [52-agile-quadrants.zh-TW.md](52-agile-quadrants.zh-TW.md) | [52-agile-quadrants.en.md](52-agile-quadrants.en.md) |
+| 53 | 衝刺測試節奏 | [53-sprint-cadence.zh-TW.md](53-sprint-cadence.zh-TW.md) | [53-sprint-cadence.en.md](53-sprint-cadence.en.md) |
+| 54 | 就緒／完成準則 | [54-definition-gates.zh-TW.md](54-definition-gates.zh-TW.md) | [54-definition-gates.en.md](54-definition-gates.en.md) |
+| 55 | 三方會談與範例映射 | [55-example-mapping.zh-TW.md](55-example-mapping.zh-TW.md) | [55-example-mapping.en.md](55-example-mapping.en.md) |
+| 56 | 持續測試管線 | [56-continuous-testing.zh-TW.md](56-continuous-testing.zh-TW.md) | [56-continuous-testing.en.md](56-continuous-testing.en.md) |
+| 57 | 回歸與測試債 | [57-regression-debt.zh-TW.md](57-regression-debt.zh-TW.md) | [57-regression-debt.en.md](57-regression-debt.en.md) |
 
 ---
 
 ## 操作指南
+
+### 在 app 內檢視
+
+每個 section 的標題下有「📊 課程簡報」按鈕，開啟全螢幕簡報檢視器（上一張／下一張、←/→ 鍵、講者備註切換、Esc 關閉）。語言依當前 locale 自動選 zh-TW / en。
 
 ### 轉 PPTX（單份）
 
@@ -102,55 +141,24 @@ done
 
 > 排除 `index.*.md` 是因為它不是 Marp 簡報。
 
-### 重新擷取所有截圖
+### 重新擷取截圖
 
 ```bash
 node scripts/capture-slide-screenshots.mjs
 ```
 
-腳本會：
-1. 偵測 `http://127.0.0.1:4173` 是否在跑；沒跑就自己啟 `python3 -m http.server`。
-2. 把 locale pin 成 `zh`、`viewport 1440×900 @2x`。
-3. 依序走訪所有 explorer 區塊，把對應 testid 截下來存到 [docs/assets/slides/](../assets/slides/)。
-4. 全部完成後關閉自啟的 server。
+腳本會偵測 `http://127.0.0.1:4173`、把 locale pin 成 `zh`、依序走訪 explorer 區塊並把對應 testid 截到 [docs/assets/slides/](../assets/slides/)。
 
-### Marp Watch 模式（開發中用）
+### 重新產生 app 內簡報資料
 
 ```bash
-npx -y @marp-team/marp-cli --watch docs/slides/03-graph-coverage.zh-TW.md --html
+npm run build:slide-decks
 ```
 
-開啟 `docs/slides/03-graph-coverage.zh-TW.html`，存檔即重渲染。
+把 `docs/slides/*.md` 烤進 `src/data/slideDecks.generated.js`，供 app 內檢視器使用。
 
 ---
 
-## 截圖清單（46 張）
+## 完整規格
 
-存放於 [docs/assets/slides/](../assets/slides/)：
-
-```
-methods-overview.png            methods-whitebox.png
-flow-overview.png               pyramid-overview.png
-graph-coverage-{node,edge,prime-path,metrics,triangle,editor}.png
-dfg-{empty,triangle,all-defs,all-uses,all-du-paths}.png
-logic-{overview,truth-table,cacc,ic-kmap,cutpnfp}.png
-mutation-{overview,mutant-list,per-test,shape-hierarchy}.png
-grammar-{overview,derivations,mutants,string-mutants}.png
-spec-{overview,mutants,fsm,smv-source}.png
-fuzz-{overview,cfg}.png
-symbex-{overview,paths,cfg}.png
-concolic-{overview,iters,cfg}.png
-testgen-{overview,requirements,tests,cfg}.png
-binding-{panel,results}.png
-```
-
----
-
-## 後續可能擴充
-
-- **Speaker notes**：每張投影片下方加 `<!-- speaker -->` Marp speaker notes（目前刻意省略，方便講師自行擴展）。
-- **SMT solver 整合**：把 #10 / #11 的 brute-force witness solver 換成 z3-solver-js，支援大整數與字串 constraint。
-
----
-
-簡報配色與 layout：純 Marp default theme + paginate；如需企業內部風格，請在每份的 front-matter 加 `theme: <yourtheme>`。
+[docs/Specification.zh-TW.md](../Specification.zh-TW.md)。


### PR DESCRIPTION
## Summary

`docs/slides/index.{en,zh-TW}.md` had gone stale — both still described the course as 13 lectures and listed only decks #1–#13, even though the slide-completion programme (Waves A–G, PRs #264–#270) authored decks #14–#57.

- Rewrite both index files to catalogue all **57 lectures**, grouped into 9 topic sections (Foundations, Coverage Criteria, Mutation & Specification, Execution & Test Generation, Black-Box Test Design, Advanced / AI-Assisted, Acceptance & E2E, Model-Based Testing, Agile Testing).
- Document the in-app slide viewer ("📊 Slides" button per section) and refresh the operations guide (PPTX conversion, screenshot capture, `npm run build:slide-decks`).
- `Plan.md`: bump the slide count 13 → 57, and mark Section M (Agile Testing, M1–M6) complete with its merged PR numbers.

Docs only — no code or generated-data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)