### PR TITLE
fix(ui): stop agile-quadrants y-axis labels overlapping

### DIFF
--- a/src/components/AgileQuadrantsExplorer.css
+++ b/src/components/AgileQuadrantsExplorer.css
@@ -6,7 +6,9 @@
 .agq-grid-wrap {
   display: grid;
   grid-template-columns: 1.6rem 1fr;
-  grid-template-rows: 1.6rem 1fr 1.6rem;
+  /* One row per quadrant row, so each y-axis label sits beside its own
+     row instead of both labels colliding in a single tall cell. */
+  grid-template-rows: 1.6rem 1fr 1fr 1.6rem;
   gap: 0.3rem;
   align-items: center;
 }
@@ -15,12 +17,12 @@
   letter-spacing: 0.02em; text-align: center;
 }
 .agq-axis-y { writing-mode: vertical-rl; transform: rotate(180deg); grid-column: 1; }
-.agq-axis-y--top { grid-row: 2; align-self: start; }
-.agq-axis-y--bottom { grid-row: 2; align-self: end; }
+.agq-axis-y--top { grid-row: 2; align-self: center; }
+.agq-axis-y--bottom { grid-row: 3; align-self: center; }
 .agq-axis-x--left  { grid-column: 2; grid-row: 1; text-align: left; padding-left: 0.5rem; }
-.agq-axis-x--right { grid-column: 2; grid-row: 3; text-align: right; padding-right: 0.5rem; }
+.agq-axis-x--right { grid-column: 2; grid-row: 4; text-align: right; padding-right: 0.5rem; }
 .agq-grid {
-  grid-column: 2; grid-row: 2;
+  grid-column: 2; grid-row: 2 / 4;
   display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;
 }
 .agq-quad {


### PR DESCRIPTION
## Summary

In the Agile Testing Quadrants Explorer, the two y-axis labels (*business-facing* / *technology-facing*) were both placed in the same tall grid cell (`grid-row: 2`) with `align-self: start` and `end`. Rendered as vertical text they are long enough to meet and overlap in the middle of the axis.

Fix: give `.agq-grid-wrap` one row per quadrant row (`1.6rem 1fr 1fr 1.6rem`), span the 2×2 `.agq-grid` across both middle rows, and centre each y-axis label in its own row. Each label now sits cleanly beside the quadrant row it describes.

Found while capturing slide screenshots of the agile explorers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)