### PR TITLE
docs(slides): note screenshot programme complete in deck index

### DIFF
--- a/docs/slides/index.en.md
+++ b/docs/slides/index.en.md
@@ -9,7 +9,7 @@ The stvisual course is **57 lectures**. Each deck contains:
 
 All decks are Marp Markdown — convert to PPTX with a single command. Decks are also viewable inside the app: every section header carries a "📊 Slides" button. Screenshots are produced by [scripts/capture-slide-screenshots.mjs](../../scripts/capture-slide-screenshots.mjs).
 
-> #1–#13 ship with the original course; #14–#57 were authored by the slide-completion programme (Waves A–G), covering all 54 explorers. Screenshot reinforcement is being rolled out in batches.
+> #1–#13 ship with the original course; #14–#57 were authored by the slide-completion programme (Waves A–G), covering all 54 explorers. Every deck carries tool screenshots in its own interface language — English decks show the English UI, Chinese decks the Chinese UI.
 
 ---
 

--- a/docs/slides/index.zh-TW.md
+++ b/docs/slides/index.zh-TW.md
@@ -9,7 +9,7 @@ stvisual 課程共 **57 講**，每講皆有：
 
 所有簡報為 Marp Markdown，可一鍵轉 PPTX。簡報亦可直接在 app 內檢視：每個 section 標題下都有「📊 課程簡報」按鈕。截圖由 [scripts/capture-slide-screenshots.mjs](../../scripts/capture-slide-screenshots.mjs) 統一產生。
 
-> #1–#13 由原始課程建立；#14–#57 為 slide-completion 計畫（Waves A–G）補齊，涵蓋全部 54 個 explorer。截圖補強仍在分批進行中。
+> #1–#13 由原始課程建立；#14–#57 為 slide-completion 計畫（Waves A–G）補齊，涵蓋全部 54 個 explorer。每一講都附有對應介面語言的工具截圖 —— 英文講次顯示英文介面，中文講次顯示中文介面。
 
 ---
 


### PR DESCRIPTION
## Summary

Waves A–G (PRs #272–#280) are all merged — every lecture deck #1–#57 now carries tool screenshots in its own interface language. Update the one-line status note in both `index.en.md` and `index.zh-TW.md`, which previously said screenshot reinforcement was still in progress.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)