### PR TITLE
feat: course customization — ?lang lock, #anchor, pack order

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -842,11 +842,15 @@ export const EXPLORER_TAGS = {
 
 **端到端流程**：選 pack chip → URL 變 `?pack=ai-assisted` → ⬇ Export Markdown → 下載 `.md`，每個 Explorer 都附 `https://demo/?explorer=<Component>` 可點連結，學生點下去落在正確 section + tab。
 
-### 延後項目
+### 延後項目（已完成 2026-05-17）
 
-- **`?lang=` URL 鎖定**：分享連結強制語言。i18n 已在處理 locale，需求出現再加。
-- **原生 `#anchor` 跳轉**：替代 `?section=`，給 section 加 `id` 屬性即可。
-- **CoursePack 自訂排序**：`order: [...]` 欄位允許 pack 內部 Explorer 排序，目前延用 `EXPLORER_TAGS` 鍵序已夠用。
+| 項目 | 說明 |
+| --- | --- |
+| **`?lang=` URL 鎖定** | 分享連結可帶 `?lang=en\|zh` 強制語言；session-only、不覆蓋訪客偏好；URL 與語言切換同步。 |
+| **原生 `#anchor` 跳轉** | 每個 section 有 `id`；`#section-<id>` 為 `?section=` 的替代進入路徑，query param 優先。 |
+| **CoursePack 自訂排序** | `order: [...]` 欄位排序 pack 內 Explorer；`foundations` pack 已套用教學順序。 |
+
+設計與計畫：`docs/superpowers/specs/2026-05-17-coursepack-url-customization-design.md`、`docs/superpowers/plans/2026-05-17-coursepack-url-customization.md`。
 
 ---
 

--- a/docs/superpowers/plans/2026-05-17-coursepack-url-customization.md
+++ b/docs/superpowers/plans/2026-05-17-coursepack-url-customization.md
@@ -1,0 +1,540 @@
+# Course Customization — URL & Pack Ordering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the three deferred items in Plan.md §K — a `?lang=` URL language lock, `#section-<id>` anchor entry paths, and an optional `order:` field on course packs.
+
+**Architecture:** Three small, independent additions. `?lang=` extends the existing `urlRouter` ↔ `app.js` ↔ `i18n` state loop with a non-persisting locale override. `#anchor` adds section `id` attributes and a hash branch to `parseAppLocation`, with query params winning on conflict. CoursePack ordering adds a pure `applyPackOrder` helper consumed by `getCoursePackExplorers`.
+
+**Tech Stack:** Vanilla JS ES modules, Vitest + jsdom. No new dependencies.
+
+**Branch:** `feat/coursepack-url-customization` (already created; design spec already committed).
+
+**Spec:** `docs/superpowers/specs/2026-05-17-coursepack-url-customization-design.md`
+
+---
+
+## Task 1: `?lang=` URL language lock
+
+**Files:**
+- Modify: `src/i18n/index.js` — `setLocale` gains a `{ persist }` option
+- Modify: `src/utils/urlRouter.js` — parse/serialize a `lang` field
+- Modify: `src/app.js` — apply `?lang=` at boot, track `langInUrl`, sync on locale change
+- Test: `src/tests/i18n.test.js`, `src/tests/urlRouter.test.js`
+
+- [ ] **Step 1: Write the failing i18n test**
+
+Append to `src/tests/i18n.test.js`:
+
+```js
+describe('i18n — setLocale persist option', () => {
+  let initialLocale;
+  beforeEach(() => { initialLocale = getLocale(); });
+  afterEach(() => {
+    setLocale(initialLocale);
+    try { globalThis.localStorage?.setItem('stvisual.locale', initialLocale); } catch {}
+  });
+
+  it('setLocale(other, { persist: false }) changes locale but not localStorage', () => {
+    setLocale('en');
+    globalThis.localStorage.setItem('stvisual.locale', 'en');
+    setLocale('zh', { persist: false });
+    expect(getLocale()).toBe('zh');
+    expect(globalThis.localStorage.getItem('stvisual.locale')).toBe('en');
+  });
+
+  it('setLocale(other) (default) writes localStorage', () => {
+    setLocale('en');
+    setLocale('zh');
+    expect(globalThis.localStorage.getItem('stvisual.locale')).toBe('zh');
+  });
+});
+```
+
+- [ ] **Step 2: Run the i18n test to verify it fails**
+
+Run: `npx vitest run src/tests/i18n.test.js`
+Expected: FAIL — `setLocale(zh, { persist:false })` still writes localStorage, so the first new test fails.
+
+- [ ] **Step 3: Add the `persist` option to `setLocale`**
+
+In `src/i18n/index.js`, replace the whole `setLocale` function:
+
+```js
+export function setLocale(locale, { persist = true } = {}) {
+  if (!SUPPORTED.includes(locale) || locale === current) return;
+  current = locale;
+  if (persist) {
+    try { globalThis.localStorage?.setItem(STORAGE_KEY, locale); } catch {}
+  }
+  listeners.forEach((cb) => {
+    try { cb(locale); } catch (err) { console.error(err); }
+  });
+  applyDocumentLocale();
+}
+```
+
+- [ ] **Step 4: Run the i18n test to verify it passes**
+
+Run: `npx vitest run src/tests/i18n.test.js`
+Expected: PASS — all i18n tests green.
+
+- [ ] **Step 5: Write the failing urlRouter test**
+
+Append to `src/tests/urlRouter.test.js`:
+
+```js
+describe('K — ?lang= URL lock', () => {
+  it('?lang=en is parsed into { lang }', () => {
+    expect(parseAppLocation('?lang=en')).toEqual({ lang: 'en' });
+  });
+  it('an unsupported ?lang= value is ignored', () => {
+    expect(parseAppLocation('?lang=fr')).toEqual({});
+  });
+  it('serializeLocation emits ?lang=', () => {
+    expect(serializeLocation({ lang: 'zh' })).toBe('?lang=zh');
+  });
+  it('lang round-trips alongside a section', () => {
+    const qs = serializeLocation({ lang: 'en', section: 'graph' });
+    expect(parseAppLocation(qs)).toEqual({ lang: 'en', section: 'graph' });
+  });
+});
+```
+
+- [ ] **Step 6: Run the urlRouter test to verify it fails**
+
+Run: `npx vitest run src/tests/urlRouter.test.js`
+Expected: FAIL — `parseAppLocation('?lang=en')` returns `{}`.
+
+- [ ] **Step 7: Parse and serialize `lang` in urlRouter**
+
+In `src/utils/urlRouter.js`, inside `parseAppLocation`, add this block right before `return out;`:
+
+```js
+  const lang = params.get('lang');
+  if (lang === 'en' || lang === 'zh') out.lang = lang;
+```
+
+In `serializeLocation`, add this line immediately after `const params = new URLSearchParams();`:
+
+```js
+  if (state.lang === 'en' || state.lang === 'zh') params.set('lang', state.lang);
+```
+
+- [ ] **Step 8: Run the urlRouter test to verify it passes**
+
+Run: `npx vitest run src/tests/urlRouter.test.js`
+Expected: PASS — all urlRouter tests green.
+
+- [ ] **Step 9: Apply `?lang=` at boot in app.js**
+
+In `src/app.js`, find the line `let initialDeeplinkHandled = false;` (~line 163) and add directly below it:
+
+```js
+  // ?lang= URL lock: a share link can force the display language. Once a
+  // lang is present in the URL (or the user picks one) the URL keeps it.
+  let langInUrl = false;
+```
+
+Then find the call site `paint();` followed by `onLocaleChange(() => paint());` (~line 1224). Insert directly **before** `paint();`:
+
+```js
+  // Apply a URL-supplied language before the first paint, without
+  // overwriting the visitor's own saved preference.
+  const bootState = parseAppLocation(
+    globalThis.location?.search ?? '',
+    globalThis.location?.hash ?? '',
+  );
+  if (bootState.lang) {
+    langInUrl = true;
+    setLocale(bootState.lang, { persist: false });
+  }
+```
+
+- [ ] **Step 10: Include `lang` in syncUrl state**
+
+In `src/app.js`, inside `syncUrl`, find the `const state = { ... }` object (~line 960) and add a `lang` property so it reads:
+
+```js
+        const state = {
+          section: activeSection,
+          tab: getCurrentTabForSection(activeSection),
+          pack: packBar?.getActiveId() ?? null,
+          filter: activeFilter,
+          lang: langInUrl ? getLocale() : undefined,
+        };
+```
+
+- [ ] **Step 11: Mark `langInUrl` when the user picks a language**
+
+In `src/app.js`, find the language `<select>` handler (~line 1164) and change it to:
+
+```js
+    container.querySelector('#app-lang-select').addEventListener('change', (e) => {
+      langInUrl = true;
+      setLocale(e.target.value);
+    });
+```
+
+- [ ] **Step 12: Sync the URL after a locale change**
+
+In `src/app.js`, find the initial-deeplink block at the end of `paint()` — it ends with a closing `}` on the line before `}` that closes `paint`. Immediately after the deeplink `if (!initialDeeplinkHandled) { ... }` block and before `paint`'s closing brace, add:
+
+```js
+    // Keep ?lang= current after a language toggle (paint() re-runs on
+    // every locale change). No-op when the language was never URL-locked.
+    if (langInUrl) syncUrl('replace');
+```
+
+- [ ] **Step 13: Run the full unit suite to verify nothing regressed**
+
+Run: `npx vitest run`
+Expected: PASS — all tests green (count unchanged except the 6 new tests added in this task).
+
+- [ ] **Step 14: Manually verify the `?lang=` behaviour**
+
+Run: `npm run serve` then open `http://127.0.0.1:4173/index.html?lang=zh` in a browser.
+Expected: the app loads in Chinese. Open DevTools → Application → Local Storage: `stvisual.locale` is NOT changed to `zh` by the visit. Flip the language dropdown to English → the URL updates to `?lang=en`.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/i18n/index.js src/utils/urlRouter.js src/app.js src/tests/i18n.test.js src/tests/urlRouter.test.js
+git commit -m "$(cat <<'EOF'
+feat(routing): ?lang= URL language lock
+
+A share link may carry ?lang=en|zh to force the display language. It is
+applied for the session only — the visitor's saved preference is left
+intact — and, once present, the URL keeps ?lang= in sync with the
+language dropdown.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `#section-<id>` anchor entry paths
+
+**Files:**
+- Modify: `src/utils/urlRouter.js` — `parseAppLocation` gains a `hash` argument
+- Modify: `src/app.js` — section `id` attributes, hash-aware parsing, hashchange listener, stale-hash clearing
+- Test: `src/tests/urlRouter.test.js`
+
+- [ ] **Step 1: Write the failing urlRouter hash test**
+
+Append to `src/tests/urlRouter.test.js`:
+
+```js
+describe('K — #section anchor', () => {
+  it('a #section-<id> hash resolves a section when no query section', () => {
+    expect(parseAppLocation('', '#section-graph')).toEqual({ section: 'graph' });
+  });
+  it('a query ?section= wins over a #section hash', () => {
+    expect(parseAppLocation('?section=logic', '#section-graph'))
+      .toEqual({ section: 'logic' });
+  });
+  it('a query ?explorer= wins over a #section hash', () => {
+    const state = parseAppLocation('?explorer=PairwiseExplorer', '#section-graph');
+    expect(state.section).toBe('blackbox');
+  });
+  it('a non-section hash (skip-link) is ignored', () => {
+    expect(parseAppLocation('', '#app-main')).toEqual({});
+  });
+  it('parseAppLocation still works when called with no hash argument', () => {
+    expect(parseAppLocation('?section=graph')).toEqual({ section: 'graph' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the urlRouter test to verify it fails**
+
+Run: `npx vitest run src/tests/urlRouter.test.js`
+Expected: FAIL — `parseAppLocation('', '#section-graph')` returns `{}` (the second argument is ignored).
+
+- [ ] **Step 3: Add the `hash` argument to `parseAppLocation`**
+
+In `src/utils/urlRouter.js`, change the function signature:
+
+```js
+export function parseAppLocation(search, hash) {
+```
+
+Then add this block right before `return out;` (after the `lang` block added in Task 1):
+
+```js
+  // #section-<id> — an alternative entry path. Query params win: the hash
+  // is only consulted when neither ?explorer= nor ?section= set a section.
+  if (!out.section && typeof hash === 'string') {
+    const m = /^#section-([a-z0-9-]+)$/.exec(hash);
+    if (m) out.section = m[1];
+  }
+```
+
+- [ ] **Step 4: Run the urlRouter test to verify it passes**
+
+Run: `npx vitest run src/tests/urlRouter.test.js`
+Expected: PASS — all urlRouter tests green.
+
+- [ ] **Step 5: Give every section element a stable `id`**
+
+In `src/app.js`, find the end of the `const sections = { ... };` object literal (~line 276, the line is `    };`). Add directly below it:
+
+```js
+
+    // A stable `id` per section so a `#section-<id>` hash can deep-link to it.
+    for (const [sectionId, el] of Object.entries(sections)) {
+      if (el) el.id = `section-${sectionId}`;
+    }
+```
+
+- [ ] **Step 6: Pass the hash into the in-paint `parseAppLocation` call**
+
+In `src/app.js`, find the line inside `paint()` (~line 174):
+
+```js
+    const urlState = parseAppLocation(globalThis.location?.search ?? '');
+```
+
+Replace it with:
+
+```js
+    const urlState = parseAppLocation(
+      globalThis.location?.search ?? '',
+      globalThis.location?.hash ?? '',
+    );
+```
+
+- [ ] **Step 7: Drop a stale `#section-*` hash when writing the URL**
+
+In `src/app.js`, inside `syncUrl`, find the line:
+
+```js
+        const url = `${globalThis.location.pathname}${qs}${globalThis.location.hash}`;
+```
+
+Replace it with:
+
+```js
+        // A `#section-*` hash is an entry-only anchor; once the app has
+        // navigated, drop it so the URL carries no contradictory anchor.
+        // Other hashes (skip-links) are preserved verbatim.
+        const rawHash = globalThis.location.hash || '';
+        const hash = /^#section-[a-z0-9-]+$/.test(rawHash) ? '' : rawHash;
+        const url = `${globalThis.location.pathname}${qs}${hash}`;
+```
+
+- [ ] **Step 8: Add a hashchange listener**
+
+In `src/app.js`, find the `popstate` listener (~line 1232, `globalThis.addEventListener?.('popstate', ...)`). Add directly **after** that listener's closing `});`:
+
+```js
+
+  // A deliberate `#section-<id>` hash navigation overrides any stale
+  // ?section= query. Reload from a search-free URL so boot re-applies
+  // state from the hash alone. Non-section hashes (skip-links) are left
+  // to the browser's native behaviour.
+  globalThis.addEventListener?.('hashchange', () => {
+    const hash = globalThis.location?.hash ?? '';
+    if (/^#section-[a-z0-9-]+$/.test(hash)) {
+      globalThis.location?.replace?.(`${globalThis.location.pathname}${hash}`);
+    }
+  });
+```
+
+- [ ] **Step 9: Run the full unit suite to verify nothing regressed**
+
+Run: `npx vitest run`
+Expected: PASS — all tests green (5 new tests from this task).
+
+- [ ] **Step 10: Manually verify the anchor behaviour**
+
+Run: `npm run serve` then:
+1. Open `http://127.0.0.1:4173/index.html#section-graph` — the Graph Coverage section is shown and scrolled into view.
+2. Open `http://127.0.0.1:4173/index.html?section=logic#section-graph` — the Logic Coverage section is shown (query wins).
+3. From a loaded page, click a nav button to another section — the URL becomes `?section=…` with no `#section-*` hash.
+4. The skip-link (Tab then Enter on "skip to main") still jumps to `#app-main` without reloading.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/utils/urlRouter.js src/app.js src/tests/urlRouter.test.js
+git commit -m "$(cat <<'EOF'
+feat(routing): #section-<id> anchor entry paths
+
+Each section gets a stable id, and parseAppLocation accepts a hash so a
+#section-<id> URL deep-links to a section. Query params (?section=,
+?explorer=) win on conflict; a deliberate hash navigation reloads from a
+search-free URL. Skip-link hashes are untouched.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: CoursePack custom ordering
+
+**Files:**
+- Modify: `src/data/courseSeries.js` — export `applyPackOrder`, make `getCoursePackExplorers` order-aware, add `order` to the `foundations` pack
+- Test: `src/tests/courseSeries.test.js`
+
+- [ ] **Step 1: Write the failing courseSeries test**
+
+Append to `src/tests/courseSeries.test.js` (and add `applyPackOrder` to the existing import from `../data/courseSeries.js`):
+
+```js
+describe('K — course pack custom ordering', () => {
+  it('applyPackOrder pins listed ids first and keeps the rest in place', () => {
+    expect(applyPackOrder(['a', 'b', 'c', 'd'], ['c', 'a']))
+      .toEqual(['c', 'a', 'b', 'd']);
+  });
+  it('applyPackOrder skips order ids that are not in the matched set', () => {
+    expect(applyPackOrder(['a', 'b'], ['zzz', 'b'])).toEqual(['b', 'a']);
+  });
+  it('applyPackOrder returns matched unchanged when order is absent or empty', () => {
+    expect(applyPackOrder(['a', 'b'], undefined)).toEqual(['a', 'b']);
+    expect(applyPackOrder(['a', 'b'], [])).toEqual(['a', 'b']);
+  });
+  it('the foundations pack honours its order field', () => {
+    expect(getCoursePackExplorers('foundations')).toEqual([
+      'TestingMethodTree', 'TestingFlow', 'DefectCostExplorer',
+      'VModelExplorer', 'TestingTypesTable', 'PyramidAdjusterExplorer',
+    ]);
+  });
+});
+```
+
+The import line at the top of the file becomes:
+
+```js
+import {
+  COURSE_PACKS,
+  getCoursePack,
+  getCoursePackExplorers,
+  getCoursePackFilter,
+  applyPackOrder,
+} from '../data/courseSeries.js';
+```
+
+- [ ] **Step 2: Run the courseSeries test to verify it fails**
+
+Run: `npx vitest run src/tests/courseSeries.test.js`
+Expected: FAIL — `applyPackOrder` is not exported (`SyntaxError` / `undefined`).
+
+- [ ] **Step 3: Add `applyPackOrder` and make `getCoursePackExplorers` order-aware**
+
+In `src/data/courseSeries.js`, replace the existing `getCoursePackExplorers` function with:
+
+```js
+// Apply a pack's optional `order`: ids in `order` that are also in
+// `matched` come first (in `order` sequence); the rest keep their
+// original sequence. Order ids outside `matched` are skipped.
+export function applyPackOrder(matched, order) {
+  if (!Array.isArray(order) || order.length === 0) return matched;
+  const matchedSet = new Set(matched);
+  const pinned = order.filter((id) => matchedSet.has(id));
+  const pinnedSet = new Set(pinned);
+  return [...pinned, ...matched.filter((id) => !pinnedSet.has(id))];
+}
+
+export function getCoursePackExplorers(id) {
+  const pack = getCoursePack(id);
+  if (!pack) return [];
+  const matched = Object.entries(EXPLORER_TAGS)
+    .filter(([, tags]) => explorerMatchesFilter(tags, pack.filter))
+    .map(([explorerId]) => explorerId);
+  return applyPackOrder(matched, pack.order);
+}
+```
+
+- [ ] **Step 4: Add the `order` field to the `foundations` pack**
+
+In `src/data/courseSeries.js`, find the `foundations` entry in `COURSE_PACKS` and add an `order` field so it reads:
+
+```js
+  {
+    id: 'foundations',
+    titleKey: 'pack.foundations.title',
+    descKey: 'pack.foundations.desc',
+    filter: { series: ['foundations'] },
+    // Pedagogical sequence: method map → flow → cost → V-model → types → pyramid.
+    order: ['TestingMethodTree', 'TestingFlow', 'DefectCostExplorer',
+            'VModelExplorer', 'TestingTypesTable', 'PyramidAdjusterExplorer'],
+  },
+```
+
+- [ ] **Step 5: Run the courseSeries test to verify it passes**
+
+Run: `npx vitest run src/tests/courseSeries.test.js`
+Expected: PASS — all courseSeries tests green, including the existing "every pack resolves to at least one explorer" and the AI-Assisted `toContain` tests.
+
+- [ ] **Step 6: Run the full unit suite to verify nothing regressed**
+
+Run: `npx vitest run`
+Expected: PASS — all tests green. In particular the `coursePackExporter` tests still pass: the Markdown export now lists the `foundations` pack in the new order, but no test asserts the old order.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/data/courseSeries.js src/tests/courseSeries.test.js
+git commit -m "$(cat <<'EOF'
+feat(packs): optional order field for course packs
+
+Course packs may carry order: [...] to pin Explorers into a chosen
+sequence; unlisted matches keep their natural order. The foundations
+pack gets a pedagogical sequence. K5's Markdown export inherits the
+order automatically.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update Plan.md
+
+**Files:**
+- Modify: `Plan.md` — move the three items out of §K "延後項目"
+
+- [ ] **Step 1: Mark the deferred items done**
+
+In `Plan.md`, find the `### 延後項目` block under section K and replace its three bullet list with a completion note:
+
+```markdown
+### 延後項目（已完成 2026-05-17）
+
+| 項目 | 說明 |
+| --- | --- |
+| **`?lang=` URL 鎖定** | 分享連結可帶 `?lang=en\|zh` 強制語言；session-only、不覆蓋訪客偏好；URL 與語言切換同步。 |
+| **原生 `#anchor` 跳轉** | 每個 section 有 `id`；`#section-<id>` 為替代進入路徑，query param 優先。 |
+| **CoursePack 自訂排序** | `order: [...]` 欄位排序 pack 內 Explorer；`foundations` pack 已套用教學順序。 |
+
+設計與計畫：`docs/superpowers/specs/2026-05-17-coursepack-url-customization-design.md`。
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Plan.md
+git commit -m "$(cat <<'EOF'
+docs(plan): mark §K deferred items complete
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Done criteria
+
+- `npx vitest run` is fully green, with 15 new tests (6 in Task 1, 5 in Task 2, 4 in Task 3).
+- `?lang=en|zh` forces the language on load without persisting; the URL keeps `?lang=` in sync with the dropdown once set.
+- `#section-<id>` deep-links to a section; `?section=`/`?explorer=` win on conflict; skip-links still work.
+- A course pack's `order` field reorders its Explorers and flows through to K5's Markdown export.
+- `Plan.md` §K no longer lists these as deferred.
+- One PR off `feat/coursepack-url-customization`; CI green; squash-merged.

--- a/docs/superpowers/plans/2026-05-17-coursepack-url-customization.md
+++ b/docs/superpowers/plans/2026-05-17-coursepack-url-customization.md
@@ -332,13 +332,16 @@ In `src/app.js`, find the `popstate` listener (~line 1232, `globalThis.addEventL
 ```js
 
   // A deliberate `#section-<id>` hash navigation overrides any stale
-  // ?section= query. Reload from a search-free URL so boot re-applies
-  // state from the hash alone. Non-section hashes (skip-links) are left
-  // to the browser's native behaviour.
+  // ?section= query. Reload from a URL that keeps only ?lang= (so a
+  // language lock survives) so boot re-applies state from the hash alone.
+  // Non-section hashes (skip-links) are left to the browser's native
+  // behaviour.
   globalThis.addEventListener?.('hashchange', () => {
     const hash = globalThis.location?.hash ?? '';
     if (/^#section-[a-z0-9-]+$/.test(hash)) {
-      globalThis.location?.replace?.(`${globalThis.location.pathname}${hash}`);
+      const lang = new URLSearchParams(globalThis.location?.search ?? '').get('lang');
+      const qs = (lang === 'en' || lang === 'zh') ? `?lang=${lang}` : '';
+      globalThis.location?.replace?.(`${globalThis.location.pathname}${qs}${hash}`);
     }
   });
 ```

--- a/docs/superpowers/specs/2026-05-17-coursepack-url-customization-design.md
+++ b/docs/superpowers/specs/2026-05-17-coursepack-url-customization-design.md
@@ -1,0 +1,176 @@
+# Course Customization — URL & Pack Ordering Design
+
+**Date:** 2026-05-17
+**Scope:** Plan.md section K "延後項目" — three deferred items enabling customizable
+sub-courses (language, order).
+
+## Goal
+
+Implement the three deferred items from Plan.md §K so a teacher can hand out a
+customized sub-course via a share link:
+
+1. `?lang=` URL lock — a share link forces a display language.
+2. Native `#anchor` jump — a `#section-<id>` hash is an alternative entry path
+   to `?section=`.
+3. CoursePack custom ordering — an optional `order: [...]` field controls the
+   Explorer sequence within a pack.
+
+All three are small, independent additions. They ship as one PR.
+
+## Context
+
+- **`src/utils/urlRouter.js`** — single source of truth for URL ↔ state.
+  `parseAppLocation(search)` parses `?section/?tab/?explorer/?pack/?<filter>`;
+  `serializeLocation(state)` rebuilds the query string. History uses
+  `replaceState`/`pushState`; `syncUrl()` in app.js preserves `location.hash`.
+- **`src/i18n/index.js`** — `current` locale resolved at module load from
+  `localStorage['stvisual.locale']` → browser language → `'en'`.
+  `setLocale(locale)` always persists to localStorage and notifies listeners.
+  `SUPPORTED = ['en', 'zh']`.
+- **`src/data/courseSeries.js`** — `COURSE_PACKS` (7 packs, each
+  `{ id, titleKey, descKey, filter }`). `getCoursePackExplorers(id)` returns
+  matched Explorers in `Object.entries(EXPLORER_TAGS)` key order. K5's Markdown
+  export consumes this order.
+- **`src/app.js`** — sections render as `<section data-testid="section-<id>">`,
+  shown/hidden by `display`; one active at a time. `setActiveSection(id)` drives
+  navigation. The language `<select>` calls `setLocale(value)`.
+
+## Feature 1 — `?lang=` URL lock
+
+**Decisions (confirmed):** session-only override; keep & sync in the URL.
+
+### i18n/index.js
+
+`setLocale` gains an options arg:
+
+```js
+export function setLocale(locale, { persist = true } = {}) {
+  if (!SUPPORTED.includes(locale) || locale === current) return;
+  current = locale;
+  if (persist) {
+    try { globalThis.localStorage?.setItem(STORAGE_KEY, locale); } catch {}
+  }
+  listeners.forEach((cb) => { try { cb(locale); } catch (err) { console.error(err); } });
+  applyDocumentLocale();
+}
+```
+
+`persist: false` applies the locale for the session without overwriting the
+visitor's saved preference. The early-return when `locale === current` means a
+`?lang=` matching the already-resolved locale is a harmless no-op.
+
+### urlRouter.js
+
+- `parseAppLocation` reads `lang`: `const lang = params.get('lang');`
+  if `lang === 'en' || lang === 'zh'`, set `out.lang = lang`.
+- `serializeLocation` emits it: `if (state.lang) params.set('lang', state.lang);`
+  Placed first so the param order reads `?lang=…&section=…`.
+
+### app.js
+
+- On boot, after `parseAppLocation`, if `urlState.lang` is present call
+  `setLocale(urlState.lang, { persist: false })`.
+- A module-scope flag `let langInUrl = Boolean(urlState.lang);`.
+- The language `<select>` handler: after `setLocale(value)` (persisting — an
+  explicit user choice), set `langInUrl = true` and call `syncUrl()`.
+- `syncUrl()` builds `state.lang = langInUrl ? getLocale() : undefined`.
+- Register `onLocaleChange(() => { if (langInUrl) syncUrl(); })` so a locale
+  change keeps `?lang=` current. (The existing locale-change re-render is
+  unaffected.)
+
+Net effect: a fresh visit with no `?lang=` keeps a clean URL. Once `?lang=` is
+present — typed in, or after the user flips the dropdown — every URL the app
+writes carries the current language.
+
+## Feature 2 — `#anchor` jump
+
+**Decision (confirmed):** coexist; `?section=`/`?explorer=` (query) win; `#hash`
+is an additional entry path. K4/K5 generated links are unchanged.
+
+### Section ids
+
+Each `<section>` gains `id="section-<id>"` alongside its existing
+`data-testid="section-<id>"` (e.g. `id="section-graph"`, `id="section-overview"`).
+
+### urlRouter.js
+
+- `parseAppLocation(search, hash)` — new optional second argument.
+- After query parsing, if **no** `?section=`/`?explorer=` resolved a section and
+  `hash` matches `/^#section-([a-z0-9-]+)$/`, set `out.section = <captured id>`
+  and `out.fromHash = true`. The captured id is **not** validated here (the full
+  section-id list lives in app.js); app.js validates against its `sections` map
+  and ignores an unknown id.
+- Non-`section-*` hashes (skip-links such as `#main`) are ignored.
+
+### app.js
+
+- Boot: `parseAppLocation(location.search, location.hash)`.
+- A `hashchange` listener: if `location.hash` matches `#section-<id>` and `<id>`
+  is a known section, call `setActiveSection(id)`; otherwise ignore (skip-links
+  keep working).
+- On UI-driven navigation (`setActiveSection` from a nav control or `?section`),
+  if `location.hash` currently matches `#section-<knownid>`, clear it so the URL
+  carries no contradictory stale anchor. Any other hash is left untouched.
+- `syncUrl()` continues to preserve `location.hash` verbatim.
+
+### Precedence summary
+
+`?explorer=` > `?section=` > `#section-<id>` hash. When a query param resolves a
+section, the hash is ignored on parse.
+
+## Feature 3 — CoursePack custom ordering
+
+`COURSE_PACKS` entries gain an optional `order` field:
+
+```js
+{
+  id: 'foundations',
+  titleKey: 'pack.foundations.title',
+  descKey: 'pack.foundations.desc',
+  filter: { series: ['foundations'] },
+  order: ['TestingMethodTree', 'TestingFlow', 'DefectCostExplorer',
+          'VModelExplorer', 'TestingTypesTable', 'PyramidAdjusterExplorer'],
+}
+```
+
+`getCoursePackExplorers(id)` becomes order-aware:
+
+1. Compute `matched` — Explorers whose tags satisfy the pack filter (unchanged).
+2. If the pack has no `order`, return `matched` in `EXPLORER_TAGS` key order
+   (unchanged behaviour).
+3. Otherwise: emit, first, every id in `order` that is also in `matched`
+   (in `order` sequence); then the remaining `matched` ids in `EXPLORER_TAGS`
+   key order. Ids in `order` that are not in `matched` are skipped.
+
+Partial orders are therefore valid — listing one Explorer pins it to the front,
+the rest keep their natural order. K5's Markdown export, which already calls
+`getCoursePackExplorers`, picks up the new order with no change.
+
+The `foundations` pack gets the worked-example `order` shown above (a
+pedagogical sequence: method tree → flow → defect cost → V-model → testing
+types → pyramid). The other six packs are unchanged.
+
+## Testing
+
+TDD, one slice per feature. New/extended unit tests:
+
+- **`urlRouter` test** — `?lang=en` round-trips through
+  `parseAppLocation`/`serializeLocation`; an invalid `?lang=fr` is dropped;
+  `#section-graph` parses to `section: 'graph'` when no query section;
+  `?section=logic#section-graph` yields `section: 'logic'` (query wins);
+  a non-`section-*` hash is ignored.
+- **`i18n` test** — `setLocale(other, { persist: false })` changes `getLocale()`
+  but does not write `localStorage`; `setLocale(other)` does write it.
+- **`courseSeries` test** — a pack with `order` returns Explorers in that
+  sequence; a partial `order` pins the listed ones and appends the rest;
+  an `order` id outside the filter is skipped.
+
+All existing slide/url/i18n tests must stay green. No generated-data
+regeneration is needed.
+
+## Out of scope
+
+- Rewriting `?section=` away in favour of `#anchor` (the "fully replace" option
+  was declined).
+- A UI for editing pack order — `order` is authored in `courseSeries.js`.
+- Persisting `?lang=` to localStorage.

--- a/src/app.js
+++ b/src/app.js
@@ -162,6 +162,10 @@ export function renderApp(container) {
   // toggle the language.
   let initialDeeplinkHandled = false;
 
+  // ?lang= URL lock: a share link can force the display language. Once a
+  // lang is present in the URL (or the user picks one) the URL keeps it.
+  let langInUrl = false;
+
   // Mirror of the most recent `location.search` we've written via
   // `syncUrl()`. The popstate handler compares against this to decide
   // whether to reload — hash-only navigation (skip-link Enter etc.)
@@ -963,6 +967,7 @@ export function renderApp(container) {
           tab: getCurrentTabForSection(activeSection),
           pack: packBar?.getActiveId() ?? null,
           filter: activeFilter,
+          lang: langInUrl ? getLocale() : undefined,
         };
         const qs = serializeLocation(state);
         const url = `${globalThis.location.pathname}${qs}${globalThis.location.hash}`;
@@ -1162,6 +1167,7 @@ export function renderApp(container) {
     }
 
     container.querySelector('#app-lang-select').addEventListener('change', (e) => {
+      langInUrl = true;
       setLocale(e.target.value);
     });
 
@@ -1219,6 +1225,21 @@ export function renderApp(container) {
         });
       }
     }
+
+    // Keep ?lang= current after a language toggle (paint() re-runs on
+    // every locale change). No-op when the language was never URL-locked.
+    if (langInUrl) syncUrl('replace');
+  }
+
+  // Apply a URL-supplied language before the first paint, without
+  // overwriting the visitor's own saved preference.
+  const bootState = parseAppLocation(
+    globalThis.location?.search ?? '',
+    globalThis.location?.hash ?? '',
+  );
+  if (bootState.lang) {
+    langInUrl = true;
+    setLocale(bootState.lang, { persist: false });
   }
 
   paint();

--- a/src/app.js
+++ b/src/app.js
@@ -175,7 +175,10 @@ export function renderApp(container) {
   function paint() {
     // Read URL state once at the top of paint() — tabbed-section setups
     // below reference it, so this MUST run before any of them.
-    const urlState = parseAppLocation(globalThis.location?.search ?? '');
+    const urlState = parseAppLocation(
+      globalThis.location?.search ?? '',
+      globalThis.location?.hash ?? '',
+    );
     container.innerHTML = `
       <div class="app">
         <a class="skip-link" href="#app-main">${t('app.skipMain')}</a>
@@ -278,6 +281,11 @@ export function renderApp(container) {
       flow: main.querySelector('[data-testid="section-flow"]'),
       types: main.querySelector('[data-testid="section-types"]'),
     };
+
+    // A stable `id` per section so a `#section-<id>` hash can deep-link to it.
+    for (const [sectionId, el] of Object.entries(sections)) {
+      if (el) el.id = `section-${sectionId}`;
+    }
 
     // Attach a "course slides" button to every section that owns decks.
     const sectionsWithDecks = [...new Set(SLIDE_DECKS.map((d) => d.section))];
@@ -970,7 +978,12 @@ export function renderApp(container) {
           lang: langInUrl ? getLocale() : undefined,
         };
         const qs = serializeLocation(state);
-        const url = `${globalThis.location.pathname}${qs}${globalThis.location.hash}`;
+        // A `#section-*` hash is an entry-only anchor; once the app has
+        // navigated, drop it so the URL carries no contradictory anchor.
+        // Other hashes (skip-links) are preserved verbatim.
+        const rawHash = globalThis.location.hash || '';
+        const hash = /^#section-[a-z0-9-]+$/.test(rawHash) ? '' : rawHash;
+        const url = `${globalThis.location.pathname}${qs}${hash}`;
         if (mode === 'push') {
           globalThis.history?.pushState?.(null, '', url);
         } else {
@@ -1255,6 +1268,17 @@ export function renderApp(container) {
     if (current !== lastSearchSnapshot) {
       lastSearchSnapshot = current;
       globalThis.location?.reload?.();
+    }
+  });
+
+  // A deliberate `#section-<id>` hash navigation overrides any stale
+  // ?section= query. Reload from a search-free URL so boot re-applies
+  // state from the hash alone. Non-section hashes (skip-links) are left
+  // to the browser's native behaviour.
+  globalThis.addEventListener?.('hashchange', () => {
+    const hash = globalThis.location?.hash ?? '';
+    if (/^#section-[a-z0-9-]+$/.test(hash)) {
+      globalThis.location?.replace?.(`${globalThis.location.pathname}${hash}`);
     }
   });
 

--- a/src/app.js
+++ b/src/app.js
@@ -1272,13 +1272,16 @@ export function renderApp(container) {
   });
 
   // A deliberate `#section-<id>` hash navigation overrides any stale
-  // ?section= query. Reload from a search-free URL so boot re-applies
-  // state from the hash alone. Non-section hashes (skip-links) are left
-  // to the browser's native behaviour.
+  // ?section= query: reload from a URL carrying only the hash, so boot
+  // re-applies state from the hash alone. The ?lang= lock is carried
+  // across so a language-locked share link survives the hash jump.
+  // Non-section hashes (skip-links) are left to the browser.
   globalThis.addEventListener?.('hashchange', () => {
     const hash = globalThis.location?.hash ?? '';
     if (/^#section-[a-z0-9-]+$/.test(hash)) {
-      globalThis.location?.replace?.(`${globalThis.location.pathname}${hash}`);
+      const lang = new URLSearchParams(globalThis.location?.search ?? '').get('lang');
+      const qs = (lang === 'en' || lang === 'zh') ? `?lang=${lang}` : '';
+      globalThis.location?.replace?.(`${globalThis.location.pathname}${qs}${hash}`);
     }
   });
 

--- a/src/data/courseSeries.js
+++ b/src/data/courseSeries.js
@@ -79,7 +79,8 @@ export function getCoursePack(id) {
 export function applyPackOrder(matched, order) {
   if (!Array.isArray(order) || order.length === 0) return matched;
   const matchedSet = new Set(matched);
-  const pinned = order.filter((id) => matchedSet.has(id));
+  // Dedup `order` first so a repeated id cannot appear twice in the result.
+  const pinned = [...new Set(order)].filter((id) => matchedSet.has(id));
   const pinnedSet = new Set(pinned);
   return [...pinned, ...matched.filter((id) => !pinnedSet.has(id))];
 }

--- a/src/data/courseSeries.js
+++ b/src/data/courseSeries.js
@@ -27,6 +27,9 @@ export const COURSE_PACKS = [
     titleKey: 'pack.foundations.title',
     descKey: 'pack.foundations.desc',
     filter: { series: ['foundations'] },
+    // Pedagogical sequence: method map → flow → cost → V-model → types → pyramid.
+    order: ['TestingMethodTree', 'TestingFlow', 'DefectCostExplorer',
+            'VModelExplorer', 'TestingTypesTable', 'PyramidAdjusterExplorer'],
   },
   {
     id: 'coverage',
@@ -70,12 +73,24 @@ export function getCoursePack(id) {
   return COURSE_PACKS.find((p) => p.id === id) ?? null;
 }
 
+// Apply a pack's optional `order`: ids in `order` that are also in
+// `matched` come first (in `order` sequence); the rest keep their
+// original sequence. Order ids outside `matched` are skipped.
+export function applyPackOrder(matched, order) {
+  if (!Array.isArray(order) || order.length === 0) return matched;
+  const matchedSet = new Set(matched);
+  const pinned = order.filter((id) => matchedSet.has(id));
+  const pinnedSet = new Set(pinned);
+  return [...pinned, ...matched.filter((id) => !pinnedSet.has(id))];
+}
+
 export function getCoursePackExplorers(id) {
   const pack = getCoursePack(id);
   if (!pack) return [];
-  return Object.entries(EXPLORER_TAGS)
+  const matched = Object.entries(EXPLORER_TAGS)
     .filter(([, tags]) => explorerMatchesFilter(tags, pack.filter))
     .map(([explorerId]) => explorerId);
+  return applyPackOrder(matched, pack.order);
 }
 
 // Convenience: which top-level Overview sections a pack covers.

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -26,10 +26,12 @@ export function getSupportedLocales() {
   return [...SUPPORTED];
 }
 
-export function setLocale(locale) {
+export function setLocale(locale, { persist = true } = {}) {
   if (!SUPPORTED.includes(locale) || locale === current) return;
   current = locale;
-  try { globalThis.localStorage?.setItem(STORAGE_KEY, locale); } catch {}
+  if (persist) {
+    try { globalThis.localStorage?.setItem(STORAGE_KEY, locale); } catch {}
+  }
   listeners.forEach((cb) => {
     try { cb(locale); } catch (err) { console.error(err); }
   });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,20 @@
 import '@testing-library/jest-dom';
 import { setLocale } from './i18n/index.js';
 
+// Node v25 ships a built-in `localStorage` that shadows jsdom's implementation
+// but exposes no Storage methods. Replace it with a real in-memory Storage so
+// tests that call globalThis.localStorage.setItem/getItem work correctly.
+if (typeof globalThis.localStorage?.setItem !== 'function') {
+  const store = new Map();
+  globalThis.localStorage = {
+    setItem: (k, v) => store.set(String(k), String(v)),
+    getItem: (k) => store.has(String(k)) ? store.get(String(k)) : null,
+    removeItem: (k) => store.delete(String(k)),
+    clear: () => store.clear(),
+    key: (n) => [...store.keys()][n] ?? null,
+    get length() { return store.size; },
+  };
+}
+
 // Existing component tests assume Chinese strings; pin locale for tests.
 setLocale('zh');

--- a/src/tests/courseSeries.test.js
+++ b/src/tests/courseSeries.test.js
@@ -99,6 +99,10 @@ describe('K — course pack custom ordering', () => {
   it('applyPackOrder returns matched unchanged when order is absent or empty', () => {
     expect(applyPackOrder(['a', 'b'], undefined)).toEqual(['a', 'b']);
     expect(applyPackOrder(['a', 'b'], [])).toEqual(['a', 'b']);
+    expect(applyPackOrder([], ['a', 'b'])).toEqual([]);
+  });
+  it('applyPackOrder does not duplicate an id repeated in order', () => {
+    expect(applyPackOrder(['a', 'b', 'c'], ['b', 'b', 'a'])).toEqual(['b', 'a', 'c']);
   });
   it('the foundations pack honours its order field', () => {
     expect(getCoursePackExplorers('foundations')).toEqual([

--- a/src/tests/courseSeries.test.js
+++ b/src/tests/courseSeries.test.js
@@ -4,6 +4,7 @@ import {
   getCoursePack,
   getCoursePackExplorers,
   getCoursePackFilter,
+  applyPackOrder,
 } from '../data/courseSeries.js';
 import { buildCoursePackMarkdown } from '../utils/coursePackExporter.js';
 import { messages } from '../i18n/dict.js';
@@ -84,6 +85,26 @@ describe('K3 — Markdown exporter', () => {
 
   it('returns empty string for an unknown pack', () => {
     expect(buildCoursePackMarkdown('no-such-pack')).toBe('');
+  });
+});
+
+describe('K — course pack custom ordering', () => {
+  it('applyPackOrder pins listed ids first and keeps the rest in place', () => {
+    expect(applyPackOrder(['a', 'b', 'c', 'd'], ['c', 'a']))
+      .toEqual(['c', 'a', 'b', 'd']);
+  });
+  it('applyPackOrder skips order ids that are not in the matched set', () => {
+    expect(applyPackOrder(['a', 'b'], ['zzz', 'b'])).toEqual(['b', 'a']);
+  });
+  it('applyPackOrder returns matched unchanged when order is absent or empty', () => {
+    expect(applyPackOrder(['a', 'b'], undefined)).toEqual(['a', 'b']);
+    expect(applyPackOrder(['a', 'b'], [])).toEqual(['a', 'b']);
+  });
+  it('the foundations pack honours its order field', () => {
+    expect(getCoursePackExplorers('foundations')).toEqual([
+      'TestingMethodTree', 'TestingFlow', 'DefectCostExplorer',
+      'VModelExplorer', 'TestingTypesTable', 'PyramidAdjusterExplorer',
+    ]);
   });
 });
 

--- a/src/tests/i18n.test.js
+++ b/src/tests/i18n.test.js
@@ -39,3 +39,26 @@ describe('i18n document side-effects', () => {
     expect(document.title).toBe('軟體測試方法視覺化');
   });
 });
+
+describe('i18n — setLocale persist option', () => {
+  let initialLocale;
+  beforeEach(() => { initialLocale = getLocale(); });
+  afterEach(() => {
+    setLocale(initialLocale);
+    try { globalThis.localStorage?.setItem('stvisual.locale', initialLocale); } catch {}
+  });
+
+  it('setLocale(other, { persist: false }) changes locale but not localStorage', () => {
+    setLocale('en');
+    globalThis.localStorage.setItem('stvisual.locale', 'en');
+    setLocale('zh', { persist: false });
+    expect(getLocale()).toBe('zh');
+    expect(globalThis.localStorage.getItem('stvisual.locale')).toBe('en');
+  });
+
+  it('setLocale(other) (default) writes localStorage', () => {
+    setLocale('en');
+    setLocale('zh');
+    expect(globalThis.localStorage.getItem('stvisual.locale')).toBe('zh');
+  });
+});

--- a/src/tests/urlRouter.test.js
+++ b/src/tests/urlRouter.test.js
@@ -219,3 +219,19 @@ describe('K4 — resolveInitialTab', () => {
     expect(sectionHasTabs('all')).toBe(false);
   });
 });
+
+describe('K — ?lang= URL lock', () => {
+  it('?lang=en is parsed into { lang }', () => {
+    expect(parseAppLocation('?lang=en')).toEqual({ lang: 'en' });
+  });
+  it('an unsupported ?lang= value is ignored', () => {
+    expect(parseAppLocation('?lang=fr')).toEqual({});
+  });
+  it('serializeLocation emits ?lang=', () => {
+    expect(serializeLocation({ lang: 'zh' })).toBe('?lang=zh');
+  });
+  it('lang round-trips alongside a section', () => {
+    const qs = serializeLocation({ lang: 'en', section: 'graph' });
+    expect(parseAppLocation(qs)).toEqual({ lang: 'en', section: 'graph' });
+  });
+});

--- a/src/tests/urlRouter.test.js
+++ b/src/tests/urlRouter.test.js
@@ -235,3 +235,23 @@ describe('K — ?lang= URL lock', () => {
     expect(parseAppLocation(qs)).toEqual({ lang: 'en', section: 'graph' });
   });
 });
+
+describe('K — #section anchor', () => {
+  it('a #section-<id> hash resolves a section when no query section', () => {
+    expect(parseAppLocation('', '#section-graph')).toEqual({ section: 'graph' });
+  });
+  it('a query ?section= wins over a #section hash', () => {
+    expect(parseAppLocation('?section=logic', '#section-graph'))
+      .toEqual({ section: 'logic' });
+  });
+  it('a query ?explorer= wins over a #section hash', () => {
+    const state = parseAppLocation('?explorer=PairwiseExplorer', '#section-graph');
+    expect(state.section).toBe('blackbox');
+  });
+  it('a non-section hash (skip-link) is ignored', () => {
+    expect(parseAppLocation('', '#app-main')).toEqual({});
+  });
+  it('parseAppLocation still works when called with no hash argument', () => {
+    expect(parseAppLocation('?section=graph')).toEqual({ section: 'graph' });
+  });
+});

--- a/src/utils/urlRouter.js
+++ b/src/utils/urlRouter.js
@@ -133,6 +133,9 @@ export function parseAppLocation(search) {
   }
   if (anyFilter) out.filter = filter;
 
+  const lang = params.get('lang');
+  if (lang === 'en' || lang === 'zh') out.lang = lang;
+
   return out;
 }
 
@@ -146,6 +149,7 @@ export function parseAppLocation(search) {
 export function serializeLocation(state) {
   if (!state) return '';
   const params = new URLSearchParams();
+  if (state.lang === 'en' || state.lang === 'zh') params.set('lang', state.lang);
 
   if (state.section && state.section !== 'all') {
     params.set('section', state.section);

--- a/src/utils/urlRouter.js
+++ b/src/utils/urlRouter.js
@@ -98,7 +98,7 @@ const FILTER_DIMS = ['level', 'technique', 'series', 'difficulty'];
 
 // ── parse ────────────────────────────────────────────────────────────
 
-export function parseAppLocation(search) {
+export function parseAppLocation(search, hash) {
   const params = new URLSearchParams(search ?? '');
   const out = {};
 
@@ -135,6 +135,13 @@ export function parseAppLocation(search) {
 
   const lang = params.get('lang');
   if (lang === 'en' || lang === 'zh') out.lang = lang;
+
+  // #section-<id> — an alternative entry path. Query params win: the hash
+  // is only consulted when neither ?explorer= nor ?section= set a section.
+  if (!out.section && typeof hash === 'string') {
+    const m = /^#section-([a-z0-9-]+)$/.exec(hash);
+    if (m) out.section = m[1];
+  }
 
   return out;
 }


### PR DESCRIPTION
## Summary

Implements the three deferred items from Plan.md §K, so a teacher can hand out a customized sub-course via a share link.

- **`?lang=` URL lock** — `?lang=en|zh` pins the display language for the visit. Session-only (`setLocale` gains `{ persist:false }`) so it never overwrites the visitor's saved preference; once present, `?lang=` stays in the URL and tracks the language toggle.
- **`#section-<id>` anchor** — every section gains an `id`; a `#section-<id>` hash deep-links to a section on load and on `hashchange`. Query params (`?section=`/`?explorer=`) win on conflict; the hash navigation reload preserves `?lang=`; skip-link hashes are untouched.
- **CoursePack `order:`** — a pack may carry an `order: [...]` list; the pure `applyPackOrder` helper pins those Explorers first (deduping a repeated id). The `foundations` pack gets a pedagogical order; K5's Markdown export inherits it unchanged.

Brainstormed → spec → plan → subagent-driven TDD execution. Each task passed a spec-compliance review and a code-quality review; a cross-feature review confirmed clean integration.

- Spec: `docs/superpowers/specs/2026-05-17-coursepack-url-customization-design.md`
- Plan: `docs/superpowers/plans/2026-05-17-coursepack-url-customization.md`

## Test Plan

- [x] `npx vitest run` — 868 passing (16 new tests: `?lang=` parse/serialize + non-persisting `setLocale`; `#anchor` parse + query-precedence; `applyPackOrder` + ordered `foundations`).
- [x] CI green (unit + browser).
- [ ] Manual: `index.html?lang=zh` loads in Chinese without changing `localStorage`; `index.html#section-graph` opens Graph Coverage; `?section=logic#section-graph` opens Logic (query wins).

## Note

`src/standalone.js` (the `file://` offline fallback bundle) is **not** rebuilt here — it is a build artifact already stale from prior merges and is regenerated by `pages:prepare` on deploy. Rebuilding it in this PR would dump unrelated drift; it deserves its own maintenance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)