### PR TITLE
fix(slicing): keep N1 graph | slice-list side by side at every width

### DIFF
--- a/src/components/ProgramSlicingExplorer.css
+++ b/src/components/ProgramSlicingExplorer.css
@@ -79,17 +79,18 @@
   color: #1f2a44;
 }
 
-/* Graph (left) | statements-in-slice (right), side by side. */
+/* Graph (left) | statements-in-slice (right) — always side by side, at
+   every width. The columns share min-width:0 so they shrink gracefully
+   in a narrow pane rather than wrapping or stacking. */
 .pse-graph-row {
   display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
   gap: 1rem;
   align-items: stretch;
 }
 .pse-graph { flex: 1 1 55%; min-width: 0; display: flex; flex-direction: column; }
 .pse-slice-list { flex: 1 1 45%; min-width: 0; }
-@media (max-width: 640px) {
-  .pse-graph-row { flex-direction: column; }
-}
 
 .pse-graph-head {
   display: flex;


### PR DESCRIPTION
## Summary

Follow-up to #285. The Program Slicing Explorer's graph and "Statements in slice" panels had a `@media (max-width: 640px)` rule that collapsed them into a single column on narrow viewports — e.g. a narrow IDE preview pane — so the slice-list rendered **below** the graph instead of to its right.

Remove the responsive collapse: the two panels stay side by side (graph left, slice-list right) at **every** width. `min-width: 0` on both columns lets them shrink gracefully in a narrow pane rather than wrapping or stacking.

Verified with a layout probe: side-by-side now holds at 380 / 500 / 700 / 1024 / 1440 px viewports.

## Test Plan

- [x] `npx vitest run` slice tests — 14 passing.
- [x] Layout probe — `slice-list` is right-of and level-with the graph at 380–1440 px.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)