### PR TITLE
fix(slicing): move N1 variable picker into the right panel

### DIFF
--- a/src/components/ProgramSlicingExplorer.css
+++ b/src/components/ProgramSlicingExplorer.css
@@ -131,6 +131,14 @@
   max-height: 26rem;
 }
 
+/* Variable picker — sits at the top of the right panel, above the list. */
+.pse-slice-var {
+  margin-bottom: 0.7rem;
+  padding-bottom: 0.7rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+.pse-slice-var .pse-var-bar { margin-top: 0; }
+
 /* Statements-in-slice list */
 .pse-slice-count { color: #64748b; font-weight: 600; }
 .pse-slice-empty {

--- a/src/components/ProgramSlicingExplorer.js
+++ b/src/components/ProgramSlicingExplorer.js
@@ -171,7 +171,8 @@ function renderGraphPanel(sliceSet) {
   </div>`;
 }
 
-// The "statements in slice" panel — right column.
+// The right column: the variable picker on top, then the
+// "statements in slice" list.
 function renderSliceList(sliceSet) {
   const ex = currentExample();
   const inSlice = ex.statements.filter((s) => sliceSet.has(s.id));
@@ -189,7 +190,10 @@ function renderSliceList(sliceSet) {
         </li>`).join('')}
     </ul>`;
   }
+  const varPicker = renderVarPicker();
+  const varBlock = varPicker ? `<div class="pse-slice-var">${varPicker}</div>` : '';
   return `<div class="pse-slice-list" data-testid="slicing-slice-list">
+    ${varBlock}
     <h3 class="pse-col-title">${t('slicing.stmtsInSlice')} <span class="pse-slice-count">(${inSlice.length})</span></h3>
     ${body}
   </div>`;
@@ -255,7 +259,6 @@ function render() {
         ${renderSliceList(sliceSet)}
       </div>
 
-      ${renderVarPicker()}
       ${renderDetail(sliceSet)}
 
       <section class="pse-self-test">

--- a/src/tests/ProgramSlicingExplorer.test.jsx
+++ b/src/tests/ProgramSlicingExplorer.test.jsx
@@ -45,6 +45,18 @@ describe('ProgramSlicingExplorer', () => {
     expect(items.length).toBeGreaterThan(0);
   });
 
+  it('renders the variable picker at the top of the right-hand panel', () => {
+    root.querySelector('[data-stmt]').click();
+    const panel = root.querySelector('[data-testid="slicing-slice-list"]');
+    const varBtn = panel.querySelector('[data-testid^="slicing-var-"]');
+    // the variable picker lives inside the right panel...
+    expect(varBtn).toBeTruthy();
+    // ...above the statements-in-slice heading
+    const title = panel.querySelector('.pse-col-title');
+    expect(varBtn.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+  });
+
   it('zooms the PDG graph in and out', () => {
     const val = () => root.querySelector('[data-testid="slicing-zoom-val"]').textContent.trim();
     expect(val()).toBe('100%');


### PR DESCRIPTION
## Summary

Follow-up to #285/#286. The variable picker was a full-width row *below* the graph|slice-list row. Move it into the **top of the right-hand panel**, above the "Statements in slice" list, with a divider — so choosing the criterion's variable sits right next to the slice it produces.

## Test Plan

- [x] `npx vitest run` — 896 passing (new test: variable picker renders inside the right panel, above the slice-list heading).
- [x] Screenshot — Variable picker at top-right, divider, "Statements in slice" below; graph on the left.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)