### PR TITLE
fix(nav): drop sticky on .app-nav so visualization gets the full viewport

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -160,9 +160,6 @@ textarea:focus-visible {
   padding: 10px 20px;
   background: var(--app-surface);
   box-shadow: var(--app-shadow-sm);
-  position: sticky;
-  top: 0;
-  z-index: 100;
 }
 .app-nav__selector {
   display: grid;
@@ -240,7 +237,7 @@ textarea:focus-visible {
 }
 
 .app-main > section {
-  scroll-margin-top: 152px;
+  scroll-margin-top: 24px;
 }
 
 .app-main section h2 {


### PR DESCRIPTION
## Summary
PR #295 switched the nav button row from horizontal-scroll to \`flex-wrap: wrap\` so 8 category labels can break onto their own rows. Combined with the existing \`position: sticky; top: 0\`, the now-much-taller sticky header covered the top of the viewport and left only a tiny strip for the visualization area below.

- Drop the three sticky-related properties on \`.app-nav\` so the nav scrolls away on scroll-down. Visualization gets the full viewport.
- Reduce \`.app-main > section { scroll-margin-top: ... }\` from \`152px\` → \`24px\` (the sticky-offset rationale no longer applies; section deep-links land near the top with small breathing room).
- Mobile breakpoint (\`@media (max-width: 680px)\`) unchanged.

## Test Plan
- [x] 972/972 unit tests pass (CSS-only change)
- [x] manual: scrolling down reveals the visualization at full viewport height; scrolling up brings the nav back; clicking a section button still scrolls to that section cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)