### PR TITLE
Slim desktop section navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -155,9 +155,9 @@ textarea:focus-visible {
 .app-nav {
   display: grid;
   grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
-  align-items: end;
-  gap: 12px;
-  padding: 10px 20px;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 20px;
   background: var(--app-surface);
   box-shadow: var(--app-shadow-sm);
 }
@@ -167,25 +167,14 @@ textarea:focus-visible {
 }
 .app-nav__buttons {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   justify-content: flex-start;
-  gap: 6px;
+  gap: 8px;
   min-width: 0;
-  padding: 2px 2px 8px;
-}
-.nav-category {
-  flex-basis: 100%;
-  font-size: 0.72rem;
-  color: var(--app-text-subtle);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: 800;
-  padding: 6px 0 2px;
-  margin-top: 4px;
-}
-.nav-category:first-of-type {
-  margin-top: 0;
+  overflow-x: auto;
+  padding: 2px 2px 6px;
+  scrollbar-width: thin;
 }
 .nav-btn {
   flex: 0 0 auto;

--- a/src/app.js
+++ b/src/app.js
@@ -1176,19 +1176,16 @@ export function renderApp(container) {
           >
             ${t('section.all')}
           </button>
-          ${SECTION_TAXONOMY.map((cat) => `
-            <div class="nav-category" data-testid="nav-category-${cat.id}" aria-hidden="true">${t(cat.labelKey)}</div>
-            ${cat.sectionIds.map((sectionId) => `
-              <button
-                class="nav-btn${activeSection === sectionId ? ' active' : ''}"
-                data-testid="nav-btn-${sectionId}"
-                data-section="${sectionId}"
-                type="button"
-                aria-current="${activeSection === sectionId ? 'page' : 'false'}"
-              >
-                ${t(`section.${sectionId}`)}
-              </button>
-            `).join('')}
+          ${SECTION_ORDER.map((sectionId) => `
+            <button
+              class="nav-btn${activeSection === sectionId ? ' active' : ''}"
+              data-testid="nav-btn-${sectionId}"
+              data-section="${sectionId}"
+              type="button"
+              aria-current="${activeSection === sectionId ? 'page' : 'false'}"
+            >
+              ${t(`section.${sectionId}`)}
+            </button>
           `).join('')}
         </div>
       `;


### PR DESCRIPTION
## Summary
- Collapse the desktop section nav into a single horizontal quick-switch row
- Keep all existing nav-btn-* test ids and section switching behavior intact
- Leave taxonomy grouping in the Overview card/filter area instead of the top nav

## Verification
- npm run test:run
- npm run build
- npx playwright test e2e/navigation-state.spec.js e2e/accessibility-navigation.spec.js e2e/mobile-explorer.spec.js
- Playwright smoke: desktop/tablet nav height is 92px, mobile remains 88px; nav-btn-fuzz/logic/graph update URL and aria-current