### PR TITLE
Lighten section shell styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -69,8 +69,7 @@ textarea:focus-visible {
 }
 
 .app-main > section:focus-visible {
-  box-shadow: var(--app-focus-ring);
-  border-radius: var(--app-radius-md);
+  box-shadow: none;
 }
 
 /* Header */
@@ -233,9 +232,9 @@ textarea:focus-visible {
   font-size: 1.45rem;
   font-weight: 700;
   color: var(--app-text-strong);
-  margin-bottom: 28px;
-  padding-bottom: 12px;
-  border-bottom: 3px solid var(--app-primary);
+  margin-bottom: 24px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--app-border);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -246,14 +245,16 @@ textarea:focus-visible {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 28px;
-  border-bottom: 3px solid var(--app-primary);
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--app-border);
 }
 
-.section-heading-row h2 {
+.app-main .section-heading-row h2 {
   flex: 1 1 auto;
   min-width: 0;
   margin-bottom: 0;
+  padding-bottom: 0;
   border-bottom: 0;
 }
 
@@ -343,15 +344,15 @@ textarea:focus-visible {
 .syntax-tab-row {
   display: flex;
   gap: 4px;
-  margin-bottom: 24px;
-  border-bottom: 2px solid var(--app-border-muted);
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--app-border-muted);
   flex-wrap: wrap;
 }
 .syntax-tab-btn {
   background: transparent;
   border: none;
-  border-bottom: 3px solid transparent;
-  margin-bottom: -2px;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
   padding: 10px 18px;
   font-size: 0.95rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Replace the full-section focus ring with no visual shell outline after programmatic section navigation
- Soften section heading dividers from thick primary-blue rules to neutral one-pixel separators
- Tighten tab row separators and fix heading-row specificity so slide-enabled sections do not show duplicate lines

## Verification
- npm run test:run
- npm run build
- npx playwright test e2e/navigation-state.spec.js e2e/accessibility-navigation.spec.js e2e/mobile-explorer.spec.js
- Playwright screenshots: desktop/mobile TDD and Black-Box section shells