### PR TITLE
Improve TDD cycle mobile readability

### DIFF
--- a/src/components/TddCycleExplorer.css
+++ b/src/components/TddCycleExplorer.css
@@ -362,6 +362,19 @@
 .quiz-correct { background: #f0fdf4; border: 1px solid #bbf7d0; color: #166534; }
 .quiz-wrong   { background: #fef2f2; border: 1px solid #fca5a5; color: #991b1b; }
 
+@media (max-width: 560px) {
+  .tdc-panels-row {
+    flex-direction: column;
+  }
+
+  .tdc-test-list,
+  .tdc-code-panel,
+  .tdc-suite {
+    flex-basis: auto;
+    width: 100%;
+  }
+}
+
 .tdc-quiz-close {
   margin-top: 0.4rem;
   padding: 0.25rem 0.7rem;


### PR DESCRIPTION
## Summary
- Stack TDD Cycle's Test List, Production Code, and Test Suite panels on narrow screens
- Prevent the mobile Test List from compressing test names into a tiny two-column layout

## Verification
- npm run test:run
- npm run build
- npx playwright test e2e/mobile-explorer.spec.js
- npm run test:run -- src/tests/TddCycleExplorer.test.jsx src/tests/TddRulesExplorer.test.jsx
- Playwright smoke at 390px and 360px: .tdc-test-name clientWidth equals scrollWidth; no horizontal body overflow