### PR TITLE
Soften secondary navigation controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -181,7 +181,7 @@ textarea:focus-visible {
   border: 1px solid var(--app-border);
   border-radius: 999px;
   background: transparent;
-  color: var(--app-primary-strong);
+  color: var(--app-text-muted);
   cursor: pointer;
   font-size: 0.82rem;
   font-family: inherit;
@@ -192,6 +192,7 @@ textarea:focus-visible {
 .nav-btn:hover {
   background: rgba(52, 152, 219, 0.1);
   border-color: var(--app-primary);
+  color: var(--app-primary-strong);
 }
 .nav-btn.active {
   background: var(--app-primary-strong);

--- a/src/styles.css
+++ b/src/styles.css
@@ -73,17 +73,21 @@
   flex: 0 0 auto;
   margin-top: 2px;
   padding: 0.42rem 0.78rem;
-  border: 1px solid var(--app-primary-strong);
+  border: 1px solid var(--app-border);
   border-radius: var(--app-radius-md);
   background: var(--app-surface);
-  color: var(--app-primary-strong);
+  color: var(--app-text-muted);
   font: inherit;
   font-size: 0.82rem;
   font-weight: 800;
   cursor: pointer;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-.section-slides-btn:hover { background: var(--app-primary-strong); color: #fff; }
+.section-slides-btn:hover {
+  border-color: var(--app-primary);
+  background: rgba(52, 152, 219, 0.1);
+  color: var(--app-primary-strong);
+}
 
 @media (max-width: 680px) {
   .section-slides-btn {


### PR DESCRIPTION
## Summary
- Make inactive desktop nav chips use neutral text, reserving blue for hover and active state
- Lower the visual weight of Course slides buttons so they read as secondary actions

## Verification
- npm run test:run
- npm run build
- npx playwright test e2e/navigation-state.spec.js e2e/accessibility-navigation.spec.js
- Playwright screenshots: desktop Overview and TDD control states