### PR TITLE
Keep category hover menus selectable

### DIFF
--- a/e2e/navigation-state.spec.js
+++ b/e2e/navigation-state.spec.js
@@ -22,6 +22,21 @@ test.describe('Navigation state', () => {
     await expect(page.getByTestId('nav-btn-fuzz')).toHaveClass(/active/);
   });
 
+  test('category hover menu keeps section options selectable across the trigger gap', async ({ page }) => {
+    await page.goto('/index.html');
+
+    const category = page.getByTestId('nav-category-generation');
+    await category.hover();
+
+    const box = await category.boundingBox();
+    expect(box).not.toBeNull();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height + 4);
+    await page.getByTestId('nav-btn-fuzz').click();
+
+    await expect(page.getByTestId('section-fuzz')).toBeVisible();
+    await expect(page.getByTestId('nav-btn-fuzz')).toHaveClass(/active/);
+  });
+
   test('keeps the saved Syntax-Based Testing tab after reload', async ({ page }) => {
     await page.goto('/index.html');
 

--- a/src/App.css
+++ b/src/App.css
@@ -183,6 +183,16 @@ textarea:focus-visible {
 .nav-category-menu.open {
   z-index: 130;
 }
+.nav-category-menu:hover::after,
+.nav-category-menu:focus-within::after,
+.nav-category-menu.open::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 8px;
+}
 .nav-category-btn {
   padding: 7px 13px;
   border: 1px solid var(--app-border);


### PR DESCRIPTION
## Summary
- add a hover bridge between category nav triggers and their dropdown panels
- cover selecting a section after moving through the trigger gap

## Tests
- npm run build:standalone
- npm test -- --run
- npx playwright test e2e/navigation-state.spec.js --project=chromium