### PR TITLE
Use hover menu for language switching

### DIFF
--- a/e2e/accessibility-navigation.spec.js
+++ b/e2e/accessibility-navigation.spec.js
@@ -25,6 +25,22 @@ test.describe('Accessibility navigation', () => {
     await expect(page.getByTestId('nav-btn-graph')).toHaveAttribute('aria-current', 'false');
   });
 
+  test('language hover menu switches locale after selecting an option', async ({ page }) => {
+    await page.goto('/index.html');
+
+    const trigger = page.getByTestId('app-lang-select');
+    await trigger.hover();
+
+    const box = await trigger.boundingBox();
+    expect(box).not.toBeNull();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height + 3);
+    await page.getByTestId('app-lang-option-en').click();
+
+    await expect(page.getByTestId('app-lang-select')).toContainText('English');
+    await expect.poll(() => page.evaluate(() => window.localStorage.getItem('stvisual.locale'))).toBe('en');
+    await expect.poll(() => new URL(page.url()).searchParams.get('lang')).toBe('en');
+  });
+
   test('keeps keyboard focus inside the cloud drawer and restores it on close', async ({ page }) => {
     await page.goto('/index.html');
 

--- a/src/App.css
+++ b/src/App.css
@@ -99,18 +99,94 @@ textarea:focus-visible {
   align-items: center;
   gap: 8px;
   font-size: 0.85rem;
+  position: relative;
 }
 .app-lang__label {
   opacity: 0.85;
 }
-.app-lang select {
+.app-lang-menu {
+  position: relative;
+}
+.app-lang-menu:hover,
+.app-lang-menu:focus-within,
+.app-lang-menu.open {
+  z-index: 150;
+}
+.app-lang-menu:hover::after,
+.app-lang-menu:focus-within::after,
+.app-lang-menu.open::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 6px;
+}
+.app-lang__trigger {
   background: rgba(255, 255, 255, 0.95);
   color: var(--app-header-ink);
   border: none;
   border-radius: var(--app-radius-sm);
   padding: 4px 8px;
   font-size: 0.85rem;
+  font-family: inherit;
   cursor: pointer;
+}
+.app-lang__trigger::after {
+  content: "";
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 6px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+  vertical-align: middle;
+}
+.app-lang__panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 140;
+  min-width: 128px;
+  display: grid;
+  gap: 4px;
+  padding: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  border-radius: var(--app-radius-md);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: var(--app-shadow-lg);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-3px);
+  transition: opacity 0.14s, transform 0.14s;
+}
+.app-lang-menu:hover .app-lang__panel,
+.app-lang-menu:focus-within .app-lang__panel,
+.app-lang-menu.open .app-lang__panel {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+.app-lang__option {
+  border: none;
+  border-radius: var(--app-radius-sm);
+  background: transparent;
+  color: var(--app-header-ink);
+  cursor: pointer;
+  font: inherit;
+  padding: 6px 8px;
+  text-align: left;
+  white-space: nowrap;
+}
+.app-lang__option:hover,
+.app-lang__option:focus-visible {
+  background: rgba(52, 152, 219, 0.12);
+  outline: none;
+}
+.app-lang__option.active {
+  background: var(--app-primary-strong);
+  color: #fff;
 }
 .app-cloud-link {
   border: 1px solid rgba(255, 255, 255, 0.45);

--- a/src/app.js
+++ b/src/app.js
@@ -158,11 +158,34 @@ export function renderApp(container) {
               ${t('section.cloud')}
             </button>
             <div class="app-lang" role="group" aria-label="${t('app.lang.label')}">
-              <label class="app-lang__label" for="app-lang-select">${t('app.lang.label')}</label>
-              <select id="app-lang-select" data-testid="app-lang-select">
-                <option value="en"${getLocale() === 'en' ? ' selected' : ''}>${t('app.lang.en')}</option>
-                <option value="zh"${getLocale() === 'zh' ? ' selected' : ''}>${t('app.lang.zh')}</option>
-              </select>
+              <span class="app-lang__label" id="app-lang-label">${t('app.lang.label')}</span>
+              <div class="app-lang-menu">
+                <button
+                  type="button"
+                  class="app-lang__trigger"
+                  id="app-lang-select"
+                  data-testid="app-lang-select"
+                  aria-haspopup="menu"
+                  aria-expanded="false"
+                  aria-labelledby="app-lang-label app-lang-select"
+                >
+                  ${t(getLocale() === 'en' ? 'app.lang.en' : 'app.lang.zh')}
+                </button>
+                <div class="app-lang__panel" role="menu" aria-label="${t('app.lang.label')}">
+                  ${['en', 'zh'].map((locale) => `
+                    <button
+                      type="button"
+                      class="app-lang__option${getLocale() === locale ? ' active' : ''}"
+                      data-lang-option="${locale}"
+                      data-testid="app-lang-option-${locale}"
+                      role="menuitemradio"
+                      aria-checked="${getLocale() === locale ? 'true' : 'false'}"
+                    >
+                      ${t(`app.lang.${locale}`)}
+                    </button>
+                  `).join('')}
+                </div>
+              </div>
             </div>
           </div>
         </header>
@@ -1476,9 +1499,34 @@ export function renderApp(container) {
       }
     }
 
-    container.querySelector('#app-lang-select').addEventListener('change', (e) => {
-      langInUrl = true;
-      setLocale(e.target.value);
+    const langMenu = container.querySelector('.app-lang-menu');
+    const langTrigger = container.querySelector('#app-lang-select');
+    const setLangMenuOpen = (isOpen) => {
+      langMenu.classList.toggle('open', isOpen);
+      langTrigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    };
+    langMenu.addEventListener('mouseenter', () => {
+      setLangMenuOpen(true);
+    });
+    langMenu.addEventListener('mouseleave', () => {
+      setLangMenuOpen(false);
+    });
+    langTrigger.addEventListener('click', (event) => {
+      event.stopPropagation();
+      setLangMenuOpen(!langMenu.classList.contains('open'));
+    });
+    container.querySelectorAll('[data-lang-option]').forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.stopPropagation();
+        setLangMenuOpen(false);
+        const nextLocale = button.dataset.langOption;
+        if (nextLocale === getLocale()) return;
+        langInUrl = true;
+        setLocale(nextLocale);
+      });
+    });
+    container.querySelector('.app').addEventListener('click', () => {
+      setLangMenuOpen(false);
     });
 
     cloudTrigger.addEventListener('click', () => {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -43018,11 +43018,34 @@ The lattice panel draws the subsumption order \u2014 ACoC \u2192 TWC \u2192 PWC 
               ${t("section.cloud")}
             </button>
             <div class="app-lang" role="group" aria-label="${t("app.lang.label")}">
-              <label class="app-lang__label" for="app-lang-select">${t("app.lang.label")}</label>
-              <select id="app-lang-select" data-testid="app-lang-select">
-                <option value="en"${getLocale() === "en" ? " selected" : ""}>${t("app.lang.en")}</option>
-                <option value="zh"${getLocale() === "zh" ? " selected" : ""}>${t("app.lang.zh")}</option>
-              </select>
+              <span class="app-lang__label" id="app-lang-label">${t("app.lang.label")}</span>
+              <div class="app-lang-menu">
+                <button
+                  type="button"
+                  class="app-lang__trigger"
+                  id="app-lang-select"
+                  data-testid="app-lang-select"
+                  aria-haspopup="menu"
+                  aria-expanded="false"
+                  aria-labelledby="app-lang-label app-lang-select"
+                >
+                  ${t(getLocale() === "en" ? "app.lang.en" : "app.lang.zh")}
+                </button>
+                <div class="app-lang__panel" role="menu" aria-label="${t("app.lang.label")}">
+                  ${["en", "zh"].map((locale) => `
+                    <button
+                      type="button"
+                      class="app-lang__option${getLocale() === locale ? " active" : ""}"
+                      data-lang-option="${locale}"
+                      data-testid="app-lang-option-${locale}"
+                      role="menuitemradio"
+                      aria-checked="${getLocale() === locale ? "true" : "false"}"
+                    >
+                      ${t(`app.lang.${locale}`)}
+                    </button>
+                  `).join("")}
+                </div>
+              </div>
             </div>
           </div>
         </header>
@@ -44323,9 +44346,34 @@ The lattice panel draws the subsumption order \u2014 ACoC \u2192 TWC \u2192 PWC 
           });
         }
       }
-      container.querySelector("#app-lang-select").addEventListener("change", (e) => {
-        langInUrl = true;
-        setLocale(e.target.value);
+      const langMenu = container.querySelector(".app-lang-menu");
+      const langTrigger = container.querySelector("#app-lang-select");
+      const setLangMenuOpen = (isOpen) => {
+        langMenu.classList.toggle("open", isOpen);
+        langTrigger.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      };
+      langMenu.addEventListener("mouseenter", () => {
+        setLangMenuOpen(true);
+      });
+      langMenu.addEventListener("mouseleave", () => {
+        setLangMenuOpen(false);
+      });
+      langTrigger.addEventListener("click", (event) => {
+        event.stopPropagation();
+        setLangMenuOpen(!langMenu.classList.contains("open"));
+      });
+      container.querySelectorAll("[data-lang-option]").forEach((button) => {
+        button.addEventListener("click", (event) => {
+          event.stopPropagation();
+          setLangMenuOpen(false);
+          const nextLocale = button.dataset.langOption;
+          if (nextLocale === getLocale()) return;
+          langInUrl = true;
+          setLocale(nextLocale);
+        });
+      });
+      container.querySelector(".app").addEventListener("click", () => {
+        setLangMenuOpen(false);
       });
       cloudTrigger.addEventListener("click", () => {
         openCloudDrawer();


### PR DESCRIPTION
## Summary
- replace the header language select with a hover/click language menu
- switch locale immediately when a language option is selected
- add browser coverage for hover selection and URL/localStorage updates

## Tests
- npm run build:standalone
- npx playwright test e2e/accessibility-navigation.spec.js --project=chromium
- npm test -- --run