### PR TITLE
fix(stvisual): private slide-markdown passes through inline <svg>

### DIFF
--- a/src/standalone.js
+++ b/src/standalone.js
@@ -41278,7 +41278,7 @@ The lattice panel draws the subsumption order \u2014 ACoC \u2192 TWC \u2192 PWC 
     return t2.length > 4 && t2.startsWith("$$") && t2.endsWith("$$");
   }
   function isBlockStart(line) {
-    return /^(#{1,6}\s|>|\s*([-*+]|\d+\.)\s|```)/.test(line) || line.includes("|") || line.trim() === "$$" || isSingleLineDisplayMath(line);
+    return /^(#{1,6}\s|>|\s*([-*+]|\d+\.)\s|```)/.test(line) || line.includes("|") || line.trim() === "$$" || isSingleLineDisplayMath(line) || line.trimStart().startsWith("<svg");
   }
   function renderMarkdown(md) {
     const lines = md.split("\n");
@@ -41299,6 +41299,20 @@ The lattice panel draws the subsumption order \u2014 ACoC \u2192 TWC \u2192 PWC 
         }
         i++;
         out.push(`<pre class="slide-code"><code>${escapeHtml26(code.join("\n"))}</code></pre>`);
+        continue;
+      }
+      if (line.trimStart().startsWith("<svg")) {
+        const buf = [];
+        let depth = 0;
+        while (i < lines.length) {
+          const cur = lines[i];
+          buf.push(cur);
+          depth += (cur.match(/<svg[\s/>]/g) || []).length;
+          depth -= (cur.match(/<\/svg>/g) || []).length;
+          i++;
+          if (depth <= 0) break;
+        }
+        out.push(buf.join("\n"));
         continue;
       }
       if (line.trim() === "$$") {

--- a/src/tests/slideMarkdown.test.js
+++ b/src/tests/slideMarkdown.test.js
@@ -75,6 +75,27 @@ describe('renderMarkdown', () => {
   it('leaves prose prices ($50 to $99) unmathed', () => {
     expect(renderMarkdown('$50 to $99 range')).toBe('<p>$50 to $99 range</p>');
   });
+  it('passes through inline <svg> verbatim (not HTML-escaped)', () => {
+    const md = '<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></svg>';
+    const html = renderMarkdown(md);
+    expect(html).toContain('<svg viewBox="0 0 10 10">');
+    expect(html).toContain('<circle cx="5" cy="5" r="4"/>');
+    expect(html).toContain('</svg>');
+    expect(html).not.toContain('&lt;svg');
+  });
+  it('keeps a multi-line <svg> block intact and resumes parsing after', () => {
+    const md = '<svg width="100" height="100">\n  <rect x="0" y="0" width="100" height="100"/>\n  <text x="10" y="20">hi</text>\n</svg>\n\nNext paragraph.';
+    const html = renderMarkdown(md);
+    expect(html).toContain('<rect x="0" y="0" width="100" height="100"/>');
+    expect(html).toContain('<text x="10" y="20">hi</text>');
+    expect(html).toContain('<p>Next paragraph.</p>');
+  });
+  it('balances nested <svg> (viewport) via depth count', () => {
+    const md = '<svg><svg x="10"><circle r="1"/></svg></svg>\n\nAfter.';
+    const html = renderMarkdown(md);
+    expect(html).toContain('<svg><svg x="10"><circle r="1"/></svg></svg>');
+    expect(html).toContain('<p>After.</p>');
+  });
 });
 
 describe('parseDeck', () => {

--- a/src/utils/slideMarkdown.js
+++ b/src/utils/slideMarkdown.js
@@ -133,7 +133,8 @@ function isSingleLineDisplayMath(line) {
 function isBlockStart(line) {
   return /^(#{1,6}\s|>|\s*([-*+]|\d+\.)\s|```)/.test(line)
     || line.includes('|') || line.trim() === '$$'
-    || isSingleLineDisplayMath(line);
+    || isSingleLineDisplayMath(line)
+    || line.trimStart().startsWith('<svg');
 }
 
 export function renderMarkdown(md) {
@@ -150,6 +151,27 @@ export function renderMarkdown(md) {
       while (i < lines.length && !lines[i].trim().startsWith('```')) { code.push(lines[i]); i++; }
       i++;
       out.push(`<pre class="slide-code"><code>${escapeHtml(code.join('\n'))}</code></pre>`);
+      continue;
+    }
+
+    // Inline-rendered <svg> block — pass through verbatim. Authors paste
+    // pre-rendered SVG (e.g. from mmdc) directly into the deck markdown;
+    // the public slide pipeline ships inline SVG the same way, so the
+    // viewer already styles it. Nested <svg> is rare but valid (nested
+    // viewport), so count opens against closes rather than stopping at
+    // the first </svg>.
+    if (line.trimStart().startsWith('<svg')) {
+      const buf = [];
+      let depth = 0;
+      while (i < lines.length) {
+        const cur = lines[i];
+        buf.push(cur);
+        depth += (cur.match(/<svg[\s/>]/g) || []).length;
+        depth -= (cur.match(/<\/svg>/g) || []).length;
+        i++;
+        if (depth <= 0) break;
+      }
+      out.push(buf.join('\n'));
       continue;
     }
 


### PR DESCRIPTION
## Summary

Backport of [dsvisual ef9f82d](https://github.com/skhuang/dsvisual/commit/ef9f82d) / [rdvisual #7](https://github.com/skhuang/rdvisual/pull/7). Private deck `.md` files fetched from Drive at runtime go through `src/utils/slideMarkdown.js`, which was HTML-escaping inline `<svg>` blocks — turning author-pasted pre-rendered diagrams into literal `&lt;svg&gt;` text.

Public slides ship inline SVG the same way (mmdc → injected into static HTML), so the slide viewer already styles inline SVG; only the runtime parser was missing the pass-through path.

## Changes

- `src/utils/slideMarkdown.js`
  - New block handler: line starting with `<svg` consumes until matching `</svg>`, emitting verbatim
  - Nested viewport `<svg>` handled by depth count (rare but legal)
  - `isBlockStart` recognises `<svg` so it isn't pulled into a paragraph
- `src/tests/slideMarkdown.test.js` — 3 new vitest cases:
  1. Single-line `<svg>...</svg>` passes through unescaped
  2. Multi-line `<svg>` block intact, subsequent paragraph still parsed
  3. Nested `<svg>` balanced by depth count

## Test Plan

- [x] `npx vitest run` — **1125/1125 passing** locally (21/21 in `slideMarkdown.test.js`)
- [ ] After merge, verify a private deck containing inline `<svg>` renders correctly via the cloud drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)